### PR TITLE
feat: Add deletion of associated tasks when deleting a project

### DIFF
--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -22,7 +22,7 @@ router = APIRouter(
 )
 
 
-@router.delete('/projects/{project_id}', tags=["Projects"])
+@router.delete('/{project_id}', tags=["Projects"])
 def delete_project_by_id(
     project_id: int,
     db: Session = Depends(database.get_db)


### PR DESCRIPTION
## What type of PR is this?
- [X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

### Description

This PR enhances the `delete_project_by_id` endpoint to ensure that when a project is deleted, all associated tasks are also deleted. This prevents orphaned tasks and maintains database integrity.

### Changes Made

- Updated the `delete_project_by_id` function to query and delete tasks associated with the project before deleting the project itself.
- Added docstrings to the function for better documentation and clarity.

## Screenshots
![Screenshot from 2024-06-28 11-29-16](https://github.com/hotosm/Drone-TM/assets/54197382/e338731a-cc08-469a-a047-039f0ca50a72)

### How to Test

1. Create a project and associated tasks in the database.
2. Use the `/projects/{project_id}` DELETE endpoint to delete the project.
3. Verify that the project and all associated tasks are deleted from the database.

