### PR TITLE
Upgrade Postgres v14 --> v16, plus migration for live server

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -87,8 +87,9 @@ jobs:
 
       - name: Deploy to VM
         run: |
-          docker compose --file docker-compose.vm.yml --env-file .env pull
+          bash contrib/pg-upgrade/upgrade-db.sh
+ 
           docker compose --file docker-compose.vm.yml --env-file .env up \
-            --detach --remove-orphans --force-recreate
+            --detach --remove-orphans --force-recreate --pull=always
         env:
           DOCKER_HOST: "ssh://${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}"

--- a/contrib/pg-upgrade/Dockerfile
+++ b/contrib/pg-upgrade/Dockerfile
@@ -1,0 +1,9 @@
+FROM tianon/postgres-upgrade:14-to-16
+
+RUN set -ex \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install \
+    -y --no-install-recommends \
+        "postgresql-14-postgis-3" \
+        "postgresql-16-postgis-3" \
+    && rm -rf /var/lib/apt/lists/*

--- a/contrib/pg-upgrade/README.md
+++ b/contrib/pg-upgrade/README.md
@@ -1,0 +1,16 @@
+# Postgres Version Upgrades
+
+- Based on images from https://github.com/tianon/docker-postgres-upgrade
+- Adds the PostGIS dependency and builds an image for our repo.
+- The image is used for upgrading between containerised Postgres versions.
+
+```bash
+# From the repo root
+bash contrib/pg-upgrade/upgrade-db.sh
+```
+
+This will start the upgrade, wait for completion, then mount
+the data and start the new Postgres 16 container.
+
+> Note it is important to shut down the postgres container first, or
+> a postmaster error will be encountered.

--- a/contrib/pg-upgrade/docker-compose.yml
+++ b/contrib/pg-upgrade/docker-compose.yml
@@ -8,6 +8,7 @@ volumes:
     name: drone-tm-pg-16-data
 
 services:
+  # Check if the upgrade has already be complete --> v16
   db-check-upgrade:
     image: postgis/postgis:16-3.4-alpine
     volumes:
@@ -46,6 +47,7 @@ services:
         cp -r /var/lib/postgresql/old/data/* /var/lib/postgresql/new/data/
         echo 'Copied postgres data to docker volume'
 
+  # Do the actual db upgrade
   db-upgrade-version:
     image: ghcr.io/hotosm/fmtm/pg-upgrade:14-to-16
     build: contrib/pg-upgrade
@@ -62,6 +64,7 @@ services:
       POSTGRES_INITDB_ARGS: -U ${POSTGRES_USER}
     restart: "no"
 
+  # Replace the generated pg_hba.conf access file with the original
   db-config-hba:
     image: postgis/postgis:16-3.4-alpine
     depends_on:
@@ -79,6 +82,7 @@ services:
           /var/lib/postgresql/16/data/
         echo 'Copied pg_hba.conf to new postgres dir'
 
+  # Start the db so we can run maintenance tasks
   db-startup:
     image: postgis/postgis:16-3.4-alpine
     depends_on:
@@ -97,6 +101,7 @@ services:
       timeout: 5s
       retries: 3
 
+  # Run maintenance, db vacuum
   db-upgrade:
     image: postgis/postgis:16-3.4-alpine
     depends_on:

--- a/contrib/pg-upgrade/docker-compose.yml
+++ b/contrib/pg-upgrade/docker-compose.yml
@@ -1,0 +1,117 @@
+# The services run in sequential order, via depends_on
+
+volumes:
+  pg-14-data:
+    name: drone-tm-pg-14-data
+  pg-16-data:
+    external: true
+    name: drone-tm-pg-16-data
+
+services:
+  db-check-upgrade:
+    image: postgis/postgis:16-3.4-alpine
+    volumes:
+      - pg-16-data:/var/lib/postgresql/data
+    restart: "no"
+    entrypoint: /bin/sh -c
+    command:
+      - |
+        # The new database directory is empty, so continue upgrade
+        if [ ! -f "/var/lib/postgresql/data/PG_VERSION" ]; then
+          echo "Database is empty"
+          exit 0
+        fi
+
+        if [ "$(cat /var/lib/postgresql/data/PG_VERSION)" = "16" ]; then
+          # The database is already upgraded, skip
+          echo "Database already upgraded"
+          exit 1
+        else
+          # The database is not upgraded, continue
+          echo "Database not upgraded yet"
+          exit 0
+        fi
+
+  # Only required as we are migrating from filesystem to volume
+  db-to-volume:
+    image: postgis/postgis:16-3.4-alpine
+    volumes:
+      - ${PROJECT_DIR:-.}/DockerData/dtm_db_data:/var/lib/postgresql/old/data
+      - pg-14-data:/var/lib/postgresql/new/data
+    restart: "no"
+    entrypoint: /bin/sh -c
+    command:
+      - |
+        rm -rf /var/lib/postgresql/new/data
+        cp -r /var/lib/postgresql/old/data/* /var/lib/postgresql/new/data/
+        echo 'Copied postgres data to docker volume'
+
+  db-upgrade-version:
+    image: ghcr.io/hotosm/fmtm/pg-upgrade:14-to-16
+    build: contrib/pg-upgrade
+    depends_on:
+      db-to-volume:
+        condition: service_completed_successfully
+    volumes:
+      - pg-14-data:/var/lib/postgresql/14/data
+      # Volume defined in main docker-compose.yml
+      - pg-16-data:/var/lib/postgresql/16/data
+    env_file: .env
+    environment:
+      PGUSER: ${POSTGRES_USER}
+      POSTGRES_INITDB_ARGS: -U ${POSTGRES_USER}
+    restart: "no"
+
+  db-config-hba:
+    image: postgis/postgis:16-3.4-alpine
+    depends_on:
+      db-upgrade-version:
+        condition: service_completed_successfully
+    volumes:
+      - ${PROJECT_DIR:-.}/DockerData/dtm_db_data:/var/lib/postgresql/14/data
+      - pg-16-data:/var/lib/postgresql/16/data
+    restart: "no"
+    entrypoint: /bin/sh -c
+    command:
+      - |
+        cp -f \
+          /var/lib/postgresql/14/data/pg_hba.conf \
+          /var/lib/postgresql/16/data/
+        echo 'Copied pg_hba.conf to new postgres dir'
+
+  db-startup:
+    image: postgis/postgis:16-3.4-alpine
+    depends_on:
+      db-config-hba:
+        condition: service_completed_successfully
+    volumes:
+      - pg-16-data:/var/lib/postgresql/data
+    env_file: .env
+    networks:
+      - dtm-network
+    restart: unless-stopped
+    healthcheck:
+      test: pg_isready -U ${POSTGRES_USER:-dtm} -d ${POSTGRES_DB:-dtm_db}
+      start_period: 5s
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  db-upgrade:
+    image: postgis/postgis:16-3.4-alpine
+    depends_on:
+      db-startup:
+        condition: service_healthy
+    env_file: .env
+    networks:
+      - dtm-network
+    restart: "no"
+    entrypoint: /bin/sh -c
+    command:
+      - |
+        PGPASSWORD=${POSTGRES_PASSWORD} \
+        vacuumdb \
+        --host=db-startup \
+        --username=${POSTGRES_USER} \
+        --all \
+        --analyze-in-stages

--- a/contrib/pg-upgrade/docker-compose.yml
+++ b/contrib/pg-upgrade/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       db-upgrade-version:
         condition: service_completed_successfully
     volumes:
-      - ${PROJECT_DIR:-.}/DockerData/dtm_db_data:/var/lib/postgresql/14/data
+      - pg-14-data:/var/lib/postgresql/14/data
       - pg-16-data:/var/lib/postgresql/16/data
     restart: "no"
     entrypoint: /bin/sh -c

--- a/contrib/pg-upgrade/upgrade-db.sh
+++ b/contrib/pg-upgrade/upgrade-db.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Pull upgrade container
+docker compose \
+    -f docker-compose.yml \
+    -f contrib/pg-upgrade/docker-compose.yml \
+    pull db-upgrade-version
+
+# Get exit code from db version check
+docker compose \
+    -f docker-compose.yml \
+    -f contrib/pg-upgrade/docker-compose.yml \
+    up db-check-upgrade --exit-code-from db-check-upgrade
+exit_code=$?
+
+# Exit script if upgrade complete
+if [ "$exit_code" -eq 1 ]; then
+    echo "Database is already upgraded. Skipping."
+
+    docker compose \
+        -f docker-compose.yml \
+        -f contrib/pg-upgrade/docker-compose.yml \
+        rm --force db-check-upgrade
+
+    exit 0
+fi
+
+# Stop any existing locks on db
+docker compose \
+    -f docker-compose.yml \
+    -f contrib/pg-upgrade/docker-compose.yml \
+    down
+
+# Do the db upgrade
+docker compose \
+    -f docker-compose.yml \
+    -f contrib/pg-upgrade/docker-compose.yml \
+    up -d db-upgrade
+
+# View any logs
+docker compose \
+    -f docker-compose.yml \
+    -f contrib/pg-upgrade/docker-compose.yml \
+    logs db-upgrade-version
+
+# Shut down db to prior to restart
+docker compose \
+    -f docker-compose.yml \
+    -f contrib/pg-upgrade/docker-compose.yml \
+    down

--- a/docker-compose.vm.yml
+++ b/docker-compose.vm.yml
@@ -22,13 +22,13 @@ services:
       - dtm-network
 
   db:
-    image: postgis/postgis:14-3.4-alpine
-    restart: always
+    image: postgis/postgis:16-3.4-alpine
     volumes:
-      - ${PROJECT_DIR:-.}/DockerData/dtm_db_data:/var/lib/postgresql/data/
+      - pg-16-data:/var/lib/postgresql/data
     env_file: .env
     networks:
       - dtm-network
+    restart: unless-stopped
     healthcheck:
       test: pg_isready -U ${POSTGRES_USER:-dtm} -d ${POSTGRES_DB:-dtm_db}
       start_period: 5s
@@ -80,3 +80,7 @@ services:
 networks:
   dtm-network:
     name: dtm-network
+
+volumes:
+  pg-16-data:
+    name: drone-tm-pg-16-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,8 @@
-version: "3"
-
 services:
   backend:
     build:
       context: .
       dockerfile: src/backend/Dockerfile
-    restart: always
     depends_on:
       - db
       - minio
@@ -16,6 +13,7 @@ services:
     env_file: .env
     networks:
       - dtm-network
+    restart: unless-stopped
 
   frontend:
     build:
@@ -34,13 +32,13 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 
   db:
-    image: postgis/postgis:14-3.4-alpine
-    restart: always
+    image: postgis/postgis:16-3.4-alpine
     volumes:
-      - ${PROJECT_DIR:-.}/DockerData/dtm_db_data:/var/lib/postgresql/data/
+      - pg-16-data:/var/lib/postgresql/data
     env_file: .env
     networks:
       - dtm-network
+    restart: unless-stopped
     healthcheck:
       test: pg_isready -U ${POSTGRES_USER:-dtm} -d ${POSTGRES_DB:-dtm_db}
       start_period: 5s
@@ -50,7 +48,6 @@ services:
 
   minio:
     image: "docker.io/minio/minio:${MINIO_TAG:-RELEASE.2023-10-25T06-33-25Z}"
-    restart: always
     command: server /export --console-address 0.0.0.0:9090 --address 0.0.0.0:9000
     volumes:
       - ${PROJECT_DIR:-.}/DockerData/minio_data:/export
@@ -63,6 +60,7 @@ services:
       - 9090:9090
     networks:
       - dtm-network
+    restart: unless-stopped
 
   createbuckets:
     image: "docker.io/minio/minio:${MINIO_TAG:-RELEASE.2023-10-25T06-33-25Z}"
@@ -74,6 +72,7 @@ services:
       - minio
     networks:
       - dtm-network
+    restart: "no"
 
   migrations:
     build:
@@ -94,3 +93,7 @@ services:
 networks:
   dtm-network:
     name: dtm-network
+
+volumes:
+  pg-16-data:
+    name: drone-tm-pg-16-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - ${PROJECT_DIR:-.}/src/frontend:/app
       - /var/run/docker.sock:/var/run/docker.sock
 
+  # If error, please upgrade the db `bash contrib/pg-upgrade/upgrade-db.sh`
   db:
     image: postgis/postgis:16-3.4-alpine
     volumes:


### PR DESCRIPTION
Fixes #72

## Problem Solved

- Upgrading Postgres 14 --> 16, including a migration for the live server.

## Solution

- This was harder than I imagined!
- I made a separate docker-compose file to orchestrate the database upgrade.
- A script `contrib/pg-upgrade/upgrade-db.sh` can be used to automate the upgrade process.
- It checks if the upgrade has already taken place & is idempotent, so can be ran at every compose restart if required.
- See the comments in the compose file to see what each stage does.
- When redeploying to the AWS VM, it should upgrade automatically 🤞 

Let me know feedback / if anyone knows an easier way!
This is based on https://github.com/tianon/docker-postgres-upgrade