### PR TITLE
fix: index.html download always on restart & rm migration from entrypoint script

### DIFF
--- a/src/backend/docker-entrypoint.sh
+++ b/src/backend/docker-entrypoint.sh
@@ -37,13 +37,8 @@ wait_for_minio() {
 }
 
 get_frontend_index_html() {
-    if [ ! -f /project/src/backend/templates/index.html ]
-    then
-        echo "/project/src/backend/templates/index.html file does not exist...trying to download from object storage.."
-        curl --fail --create-dirs ${S3_ENDPOINT}/${FRONTEND_BUCKET_NAME}/index.html --output /project/src/backend/templates/index.html || echo "Failed to download index.html... Please retry manually for now...."
-    else
-        echo "/project/src/backend/templates/index.html found. Continuing..."
-    fi
+    echo "Downloading index.html from object storage.."
+    curl --fail --create-dirs ${S3_ENDPOINT}/${FRONTEND_BUCKET_NAME}/index.html --output /project/src/backend/templates/index.html || echo "Failed to download index.html... Please retry manually for now...."
 }
 
 # Start wait in background with tmp log files
@@ -51,9 +46,6 @@ wait_for_db &
 wait_for_minio &
 get_frontend_index_html &
 wait
-
-# Migrations
-pdm run alembic upgrade head
 
 exec "$@"
 


### PR DESCRIPTION
1. Fixes frontend ci not updating index.html
2. Removes migration cmd from entrypoint as we already have different service for it