### PR TITLE
fix(hot-fix):  listed pending task based on project creator

### DIFF
--- a/src/backend/app/tasks/task_crud.py
+++ b/src/backend/app/tasks/task_crud.py
@@ -204,19 +204,15 @@ async def get_requested_user_id(
     return result["user_id"]
 
 
-async def get_project_task_by_id(db: Database, project_id: uuid.UUID, user_id):
-    """Get all tasks associated with a specific project by project_id."""
+async def get_project_task_by_id(db: Database, user_id: str):
+    """Get a list of pending tasks for a specific project and user."""
     raw_sql = """
-        SELECT t.id AS task_id, te.event_id, te.user_id, te.comment, te.state, te.created_at
+        SELECT t.id AS task_id, te.event_id, te.user_id, te.project_id, te.comment, te.state, te.created_at
         FROM tasks t
         LEFT JOIN task_events te ON t.id = te.task_id
-        WHERE t.project_id = :project_id
-        AND te.user_id = :user_id
-
+        WHERE te.user_id = :user_id
+        AND te.state = 'REQUEST_FOR_MAPPING'
         ORDER BY t.project_task_index;
     """
-    db_tasks = await db.fetch_all(
-        raw_sql, {"project_id": project_id, "user_id": user_id}
-    )
-
+    db_tasks = await db.fetch_all(raw_sql, {"user_id": user_id})
     return db_tasks

--- a/src/backend/app/tasks/task_crud.py
+++ b/src/backend/app/tasks/task_crud.py
@@ -205,7 +205,7 @@ async def get_requested_user_id(
 
 
 async def get_project_task_by_id(db: Database, user_id: str):
-    """Get a list of pending tasks for a specific project and user."""
+    """Get a list of pending tasks for a specific user(project creator)."""
     raw_sql = """
         SELECT t.id AS task_id, te.event_id, te.user_id, te.project_id, te.comment, te.state, te.created_at
         FROM tasks t

--- a/src/backend/app/tasks/task_routes.py
+++ b/src/backend/app/tasks/task_routes.py
@@ -215,7 +215,7 @@ async def get_pending_tasks(
     user_data: AuthUser = Depends(login_required),
     db: Database = Depends(database.get_db),
 ):
-    """Get a list of pending tasks for a specific project and user."""
+    """Get a list of pending tasks for a project creator."""
     user_id = user_data.id
     query = """SELECT role FROM user_profile WHERE user_id = :user_id"""
     record = await db.fetch_one(query, {"user_id": user_id})

--- a/src/backend/app/tasks/task_routes.py
+++ b/src/backend/app/tasks/task_routes.py
@@ -1,7 +1,7 @@
 import uuid
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from app.config import settings
-from app.models.enums import EventType, State
+from app.models.enums import EventType, State, UserRole
 from app.tasks import task_schemas, task_crud
 from app.users.user_deps import login_required
 from app.users.user_schemas import AuthUser
@@ -210,16 +210,25 @@ async def new_event(
     return True
 
 
-@router.get("/requested_tasks/{project_id}/pending")
+@router.get("/requested_tasks/pending")
 async def get_pending_tasks(
-    project_id: uuid.UUID,
     user_data: AuthUser = Depends(login_required),
     db: Database = Depends(database.get_db),
 ):
     """Get a list of pending tasks for a specific project and user."""
     user_id = user_data.id
+    query = """SELECT role FROM user_profile WHERE user_id = :user_id"""
+    record = await db.fetch_one(query, {"user_id": user_id})
 
-    pending_tasks = await task_crud.get_project_task_by_id(db, project_id, user_id)
+    if not record:
+        raise HTTPException(status_code=404, detail="User profile not found")
+
+    if record.role != UserRole.PROJECT_CREATOR.name:
+        raise HTTPException(
+            status_code=403, detail="Access forbidden for non-Project Creator users"
+        )
+
+    pending_tasks = await task_crud.get_project_task_by_id(db, user_id)
     if pending_tasks is None:
         raise HTTPException(status_code=404, detail="Project not found")
     return pending_tasks


### PR DESCRIPTION
### PR Description
This PR adds a new endpoint to list pending tasks for project creators in a FastAPI application.

**Changes:**
1. **Function `get_project_task_by_id`:**
   - Fetches pending tasks (`REQUEST_FOR_MAPPING` state) for a specific user(Project Creator).

2. **Endpoint `/requested_tasks/pending`:**
   - Validates the authenticated user is a `PROJECT_CREATOR`.
   - Returns the list of pending tasks or appropriate error messages.
