### PR TITLE
Upgrade backend to Python 3.11 + fix template dir permissions

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,16 @@
+"frontend":
+  - "src/frontend/**/*"
+"backend":
+  - "src/backend/**/*"
+"devops":
+  - ".github/**/*"
+  - "docker-*.yml"
+  - "**/Dockerfile"
+  - "**/*.dockerfile"
+  - "**/*entrypoint.sh"
+"migration":
+  - "src/backend/app/migrations/**/*"
+"docs":
+  - "docs/**/*"
+  - "mkdocs.yml"
+  - "README.md"

--- a/.github/workflows/pr_label.yml
+++ b/.github/workflows/pr_label.yml
@@ -1,0 +1,14 @@
+name: 🏷️ PR Label
+
+on:
+  pull_request_target:
+
+jobs:
+  pr-label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/labeler@v5
+        # Uses .github/labeler.yml definitions
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -1,5 +1,5 @@
 # ARG for the base image
-ARG PYTHON_BASE=3.10-slim-bookworm
+ARG PYTHON_BASE=3.11-slim-bookworm
 
 # Base build stage with dependencies required to build Python wheels
 FROM python:$PYTHON_BASE AS build

--- a/src/backend/docker-entrypoint.sh
+++ b/src/backend/docker-entrypoint.sh
@@ -39,6 +39,7 @@ wait_for_minio() {
 get_frontend_index_html() {
     echo "Downloading index.html from object storage.."
     curl --fail --create-dirs ${S3_ENDPOINT}/${FRONTEND_BUCKET_NAME}/index.html --output /project/src/backend/templates/index.html || echo "Failed to download index.html... Please retry manually for now...."
+    chmod -R 777 /project/src/backend/templates
 }
 
 # Start wait in background with tmp log files

--- a/src/backend/pdm.lock
+++ b/src/backend/pdm.lock
@@ -30,7 +30,6 @@ version = "3.7.1"
 requires_python = ">=3.7"
 summary = "High level compatibility layer for multiple asynchronous event loop implementations"
 dependencies = [
-    "exceptiongroup; python_version < \"3.11\"",
     "idna>=2.8",
     "sniffio>=1.1",
 ]
@@ -268,9 +267,7 @@ version = "8.14.0"
 requires_python = ">=3.9"
 summary = "IPython: Productive Interactive Computing"
 dependencies = [
-    "appnope; sys_platform == \"darwin\"",
     "backcall",
-    "colorama; sys_platform == \"win32\"",
     "decorator",
     "jedi>=0.16",
     "matplotlib-inline",
@@ -664,7 +661,6 @@ summary = "The lightning-fast ASGI server."
 dependencies = [
     "click>=7.0",
     "h11>=0.8",
-    "typing-extensions>=4.0; python_version < \"3.11\"",
 ]
 
 [[package]]

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "python-slugify>=8.0.4",
     "drone-flightplan>=0.1.2",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = {text = "GPL-3.0-only"}
 
 [project.optional-dependencies]


### PR DESCRIPTION
Small PR to:
- Upgrade image to Python 3.11 + dependencies lock.
- The backend was failing to build due to `root` ownership of `src/backend/templates` dir. I set the permissions to 777 in the entrypoint script.
- Also adds PR labeller workflow / config for automatic labeling.