### PR TITLE
add external flag on db-data volume on VM

### DIFF
--- a/docker-compose.vm.yml
+++ b/docker-compose.vm.yml
@@ -5,6 +5,7 @@ networks:
 volumes:
   db-data:
     name: drone-tm-db-data
+    external: true
 
 services:
   backend:


### PR DESCRIPTION
## Fixes CI failure where docker compose searches for volume created via compose file.