### PR TITLE
fix typo in pr labeller

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,7 +19,7 @@ devops:
           - ./**/.dockerfile
           - ./**/*entrypoint.sh
           - ./**/Justfile
-migration":
+migration:
   - changed-files:
       - any-glob-to-any-file: src/backend/app/migrations/**
 docs:


### PR DESCRIPTION
There is a typo in labeling migration label. 