### PR TITLE
hotfix: query to update state labels in task_details

### DIFF
--- a/src/backend/app/tasks/task_crud.py
+++ b/src/backend/app/tasks/task_crud.py
@@ -57,11 +57,8 @@ async def get_tasks_by_user(user_id: str, db: Database):
                 task_details.task_area,
                 task_details.created_at,
                 CASE
-                    WHEN task_details.state = 'REQUEST_FOR_MAPPING' THEN 'ongoing'
-                    WHEN task_details.state = 'UNLOCKED_TO_MAP' THEN 'ready to map'
-                    WHEN task_details.state = 'LOCKED_FOR_MAPPING' THEN 'locked for mapping'
-                    WHEN task_details.state = 'UNLOCKED_TO_VALIDATE' THEN 'mapped'
-                    WHEN task_details.state = 'LOCKED_FOR_VALIDATION' THEN 'mapped'
+                    WHEN task_details.state = 'REQUEST_FOR_MAPPING' THEN 'request logs'
+                    WHEN task_details.state = 'LOCKED_FOR_MAPPING' THEN 'ongoing'
                     WHEN task_details.state = 'UNLOCKED_DONE' THEN 'completed'
                     WHEN task_details.state = 'UNFLYABLE_TASK' THEN 'unflyable task'
                     ELSE 'unknown' -- Default case if the state does not match any expected values

--- a/src/backend/app/tasks/task_crud.py
+++ b/src/backend/app/tasks/task_crud.py
@@ -55,14 +55,19 @@ async def get_tasks_by_user(user_id: str, db: Database):
                 task_details.task_id,
                 task_details.project_id,
                 task_details.task_area,
-                task_details.created_at,
+                task_details.created_at, 
                 CASE
-                    WHEN task_details.state = 'REQUEST_FOR_MAPPING' THEN 'ongoing'
+                    WHEN task_details.state = 'REQUEST_FOR_MAPPING' THEN 'ongoing' 
+                    WHEN task_details.state = 'UNLOCKED_TO_MAP' THEN 'ready to map'
+                    WHEN task_details.state = 'LOCKED_FOR_MAPPING' THEN 'locked for mapping'
+                    WHEN task_details.state = 'UNLOCKED_TO_VALIDATE' THEN 'mapped'
+                    WHEN task_details.state = 'LOCKED_FOR_VALIDATION' THEN 'mapped'
                     WHEN task_details.state = 'UNLOCKED_DONE' THEN 'completed'
-                    WHEN task_details.state IN ('UNLOCKED_TO_VALIDATE', 'LOCKED_FOR_VALIDATION') THEN 'mapped'
-                    ELSE 'unknown'
+                    WHEN task_details.state = 'UNFLYABLE_TASK' THEN 'unflyable task'
+                    ELSE 'unknown' -- Default case if the state does not match any expected values
                 END AS state
-            FROM task_details
+            FROM task_details;
+
             """
 
         records = await db.fetch_all(query, values={"user_id": user_id})

--- a/src/backend/app/tasks/task_crud.py
+++ b/src/backend/app/tasks/task_crud.py
@@ -55,9 +55,9 @@ async def get_tasks_by_user(user_id: str, db: Database):
                 task_details.task_id,
                 task_details.project_id,
                 task_details.task_area,
-                task_details.created_at, 
+                task_details.created_at,
                 CASE
-                    WHEN task_details.state = 'REQUEST_FOR_MAPPING' THEN 'ongoing' 
+                    WHEN task_details.state = 'REQUEST_FOR_MAPPING' THEN 'ongoing'
                     WHEN task_details.state = 'UNLOCKED_TO_MAP' THEN 'ready to map'
                     WHEN task_details.state = 'LOCKED_FOR_MAPPING' THEN 'locked for mapping'
                     WHEN task_details.state = 'UNLOCKED_TO_VALIDATE' THEN 'mapped'

--- a/src/backend/app/tasks/task_routes.py
+++ b/src/backend/app/tasks/task_routes.py
@@ -69,8 +69,8 @@ async def get_task_stats(
         raise HTTPException(status_code=404, detail="User profile not found")
     raw_sql = """
         SELECT
-        COUNT(CASE WHEN te.state = 'LOCKED_FOR_MAPPING' THEN 1 END) AS ongoing_tasks,
         COUNT(CASE WHEN te.state = 'REQUEST_FOR_MAPPING' THEN 1 END) AS request_logs,
+        COUNT(CASE WHEN te.state = 'LOCKED_FOR_MAPPING' THEN 1 END) AS ongoing_tasks,
         COUNT(CASE WHEN te.state = 'UNLOCKED_DONE' THEN 1 END) AS completed_tasks,
         COUNT(CASE WHEN te.state = 'UNFLYABLE_TASK' THEN 1 END) AS unflyable_tasks
         FROM tasks t


### PR DESCRIPTION
#### Description
Updated the `task_details` query to map `state` values to more descriptive labels. Added a default case for unexpected values.

#### Changes
- Modified `CASE` statement for `state` labels:
  - 'REQUEST_FOR_MAPPING' → 'request logs'
  - 'LOCKED_FOR_MAPPING' → 'ongoing'
  - 'UNLOCKED_DONE' → 'completed'
  - 'UNFLYABLE_TASK' → 'unflyable task'
  - Added 'unknown' for any other values
