### PR TITLE
Fix: listing request logs based on user

### DIFF
--- a/src/backend/app/tasks/task_crud.py
+++ b/src/backend/app/tasks/task_crud.py
@@ -46,10 +46,9 @@ async def get_tasks_by_user(user_id: str, db: Database):
                     task_events.state
                 FROM
                     task_events
-                JOIN
+                LEFT JOIN
                     tasks ON task_events.task_id = tasks.id
-                WHERE
-                    task_events.user_id = :user_id
+                WHERE task_events.project_id IN (SELECT id FROM projects WHERE author_id = :user_id)
             )
             SELECT
                 task_details.task_id,
@@ -61,7 +60,7 @@ async def get_tasks_by_user(user_id: str, db: Database):
                     WHEN task_details.state = 'LOCKED_FOR_MAPPING' THEN 'ongoing'
                     WHEN task_details.state = 'UNLOCKED_DONE' THEN 'completed'
                     WHEN task_details.state = 'UNFLYABLE_TASK' THEN 'unflyable task'
-                    ELSE 'unknown' -- Default case if the state does not match any expected values
+                    ELSE ''
                 END AS state
             FROM task_details;
 

--- a/src/backend/app/tasks/task_crud.py
+++ b/src/backend/app/tasks/task_crud.py
@@ -34,39 +34,43 @@ async def get_task_geojson(db: Database, task_id: uuid.UUID):
     return json.loads(data["geom"])
 
 
-async def get_tasks_by_user(user_id: str, db: Database):
+async def get_tasks_by_user(user_id: str, db: Database, role: str):
     try:
-        query = """
-            WITH task_details AS (
-                SELECT
-                    tasks.id AS task_id,
-                    task_events.project_id AS project_id,
-                    ST_Area(ST_Transform(tasks.outline, 4326)) / 1000000 AS task_area,
-                    task_events.created_at,
-                    task_events.state
-                FROM
-                    task_events
-                LEFT JOIN
-                    tasks ON task_events.task_id = tasks.id
-                WHERE task_events.project_id IN (SELECT id FROM projects WHERE author_id = :user_id)
-            )
+        query = """WITH task_details AS (
             SELECT
-                task_details.task_id,
-                task_details.project_id,
-                task_details.task_area,
-                task_details.created_at,
-                CASE
-                    WHEN task_details.state = 'REQUEST_FOR_MAPPING' THEN 'request logs'
-                    WHEN task_details.state = 'LOCKED_FOR_MAPPING' THEN 'ongoing'
-                    WHEN task_details.state = 'UNLOCKED_DONE' THEN 'completed'
-                    WHEN task_details.state = 'UNFLYABLE_TASK' THEN 'unflyable task'
-                    ELSE ''
-                END AS state
-            FROM task_details;
-
-            """
-
-        records = await db.fetch_all(query, values={"user_id": user_id})
+                tasks.id AS task_id,
+                task_events.project_id AS project_id,
+                ST_Area(ST_Transform(tasks.outline, 4326)) / 1000000 AS task_area,
+                task_events.created_at,
+                task_events.state
+            FROM
+                task_events
+            LEFT JOIN
+                tasks ON task_events.task_id = tasks.id
+            WHERE
+                (
+                    :role = 'DRONE_PILOT' AND task_events.user_id = :user_id
+                )
+                OR
+                (
+                    :role != 'DRONE_PILOT' AND task_events.project_id IN (SELECT id FROM projects WHERE author_id = :user_id)
+                )
+        )
+        SELECT
+            task_details.task_id,
+            task_details.project_id,
+            task_details.task_area,
+            task_details.created_at,
+            CASE
+                WHEN task_details.state = 'REQUEST_FOR_MAPPING' THEN 'request logs'
+                WHEN task_details.state = 'LOCKED_FOR_MAPPING' THEN 'ongoing'
+                WHEN task_details.state = 'UNLOCKED_DONE' THEN 'completed'
+                WHEN task_details.state = 'UNFLYABLE_TASK' THEN 'unflyable task'
+                ELSE ''
+            END AS state
+        FROM task_details;
+        """
+        records = await db.fetch_all(query, values={"user_id": user_id, "role": role})
         return records
 
     except Exception as e:

--- a/src/backend/app/tasks/task_routes.py
+++ b/src/backend/app/tasks/task_routes.py
@@ -1,7 +1,7 @@
 import uuid
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from app.config import settings
-from app.models.enums import EventType, HTTPStatus, State
+from app.models.enums import EventType, HTTPStatus, State, UserRole
 from app.tasks import task_schemas, task_crud
 from app.users.user_deps import login_required
 from app.users.user_schemas import AuthUser
@@ -67,6 +67,13 @@ async def get_task_stats(
 
     if not records:
         raise HTTPException(status_code=404, detail="User profile not found")
+
+    roles = [record["role"] for record in records]
+    if UserRole.PROJECT_CREATOR.name in roles:
+        role = "PROJECT_CREATOR"
+    else:
+        role = "DRONE_PILOT"
+
     raw_sql = """
         SELECT
         COUNT(CASE WHEN te.state = 'REQUEST_FOR_MAPPING' THEN 1 END) AS request_logs,
@@ -75,11 +82,20 @@ async def get_task_stats(
         COUNT(CASE WHEN te.state = 'UNFLYABLE_TASK' THEN 1 END) AS unflyable_tasks
         FROM tasks t
         LEFT JOIN task_events te ON t.id = te.task_id
-        WHERE t.project_id IN (SELECT id FROM projects WHERE author_id = :user_id);
+        WHERE
+        (
+            :role = 'DRONE_PILOT' AND te.user_id = :user_id
+        )
+        OR
+        (
+            :role != 'DRONE_PILOT' AND t.project_id IN (SELECT id FROM projects WHERE author_id = :user_id)
+        )
         """
 
     try:
-        db_counts = await db.fetch_one(query=raw_sql, values={"user_id": user_id})
+        db_counts = await db.fetch_one(
+            query=raw_sql, values={"user_id": user_id, "role": role}
+        )
     except Exception as e:
         raise HTTPException(
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
@@ -93,10 +109,22 @@ async def list_tasks(
     db: Database = Depends(database.get_db),
     user_data: AuthUser = Depends(login_required),
 ):
-    """Get all tasks for a drone user."""
+    """Get all tasks for a all user."""
 
     user_id = user_data.id
-    return await task_crud.get_tasks_by_user(user_id, db)
+    query = """SELECT role FROM user_profile WHERE user_id = :user_id"""
+    records = await db.fetch_all(query, {"user_id": user_id})
+
+    roles = [record["role"] for record in records]
+    if UserRole.PROJECT_CREATOR.name in roles:
+        role = UserRole.PROJECT_CREATOR.name
+    else:
+        role = "DRONE_PILOT"
+
+    if not records:
+        raise HTTPException(status_code=404, detail="User profile not found")
+
+    return await task_crud.get_tasks_by_user(user_id, db, role)
 
 
 @router.get("/states/{project_id}")


### PR DESCRIPTION
### Description
This PR updates the SQL query used for fetching request logs, modifying it to filter pending logs based on the current user. Previously, the query returned pending logs for all users, which led to potential data exposure and confusion. Now, only the logs relevant to the logged-in user are displayed.

Key Changes:

- [X] SQL Query Update:
The SQL query now includes a condition to filter results based on the user_id, ensuring that each user only sees their own pending requests.
- [X] Bug Fix:
Fixed an issue where users were able to see pending request logs of other users.