### PR TITLE
Feat: Update task locking flow with more detail on tasks

### DIFF
--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -149,7 +149,37 @@ async def get_project_info_by_id(db: Database, project_id: uuid.UUID):
     project_record = await db.fetch_one(query, {"project_id": project_id})
     if not project_record:
         return None
-    query = """ SELECT id, project_task_index, outline FROM tasks WHERE project_id = :project_id;"""
+    query = """
+        SELECT
+            t.id,
+            t.project_task_index,
+            t.outline,
+            ST_Area(ST_Transform(t.outline, 4326)) / 1000000 AS task_area,
+            te.user_id,
+            te.state,
+            u.name,
+            CASE
+                WHEN te.state = 'REQUEST_FOR_MAPPING' THEN 'request logs'
+                WHEN te.state = 'LOCKED_FOR_MAPPING' THEN 'ongoing'
+                WHEN te.state = 'UNLOCKED_DONE' THEN 'completed'
+                WHEN te.state = 'UNFLYABLE_TASK' THEN 'unflyable task'
+                ELSE '' -- Default case if the state does not match any expected values
+            END AS state
+
+        FROM
+            tasks t
+        LEFT JOIN
+            task_events te
+        ON
+            t.id = te.task_id
+        LEFT JOIN
+            users u
+        ON
+            te.user_id = u.id
+
+        WHERE
+            t.project_id = :project_id;"""
+
     task_records = await db.fetch_all(query, {"project_id": project_id})
     project_record.tasks = task_records if task_records is not None else []
     project_record.task_count = len(task_records)

--- a/src/backend/app/projects/project_schemas.py
+++ b/src/backend/app/projects/project_schemas.py
@@ -1,9 +1,9 @@
 import uuid
 import json
-from pydantic import BaseModel, computed_field, Field, validator, model_validator
+from pydantic import BaseModel, computed_field, Field, model_validator
 from typing import Any, Optional, Union, List
 from geojson_pydantic import Feature, FeatureCollection, Polygon
-from app.models.enums import FinalOutput, ProjectVisibility, State
+from app.models.enums import FinalOutput, ProjectVisibility
 from shapely import wkb
 from datetime import date
 from app.utils import (
@@ -96,17 +96,10 @@ class TaskOut(BaseModel):
     id: uuid.UUID
     project_task_index: int
     outline: Any = Field(exclude=True)
-    state: Optional[State] = None
-    contributor: Optional[str] = None
-
-    @validator("state", pre=True, always=True)
-    def validate_state(cls, v):
-        if isinstance(v, str):
-            try:
-                v = State[v]
-            except KeyError:
-                raise ValueError(f"Invalid state: {v}")
-        return v
+    state: Optional[str] = None
+    user_id: Optional[str] = None
+    task_area: Optional[float] = None
+    name: Optional[str] = None
 
     @computed_field
     @property

--- a/src/frontend/src/components/IndividualProject/MapSection/index.tsx
+++ b/src/frontend/src/components/IndividualProject/MapSection/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-nested-ternary */
 /* eslint-disable no-unused-vars */
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useCallback, useEffect, useState } from 'react';
 import { useTypedSelector, useTypedDispatch } from '@Store/hooks';
 import { useMapLibreGLMap } from '@Components/common/MapLibreComponents';
@@ -16,6 +16,7 @@ import { setProjectState } from '@Store/actions/project';
 import {
   useGetProjectsDetailQuery,
   useGetTaskStatesQuery,
+  useGetUserDetailsQuery,
 } from '@Api/projects';
 import lock from '@Assets/images/lock.png';
 import { postTaskStatus } from '@Services/project';
@@ -25,11 +26,16 @@ import hasErrorBoundary from '@Utils/hasErrorBoundary';
 
 const MapSection = () => {
   const { id } = useParams();
+  const navigate = useNavigate();
   const dispatch = useTypedDispatch();
   const [taskStatusObj, setTaskStatusObj] = useState<Record<
     string,
     any
   > | null>(null);
+  const [lockedUser, setLockedUser] = useState<Record<string, any> | null>(
+    null,
+  );
+  const { data: userDetails }: Record<string, any> = useGetUserDetailsQuery();
 
   const { data: projectData }: Record<string, any> = useGetProjectsDetailQuery(
     id as string,
@@ -67,6 +73,7 @@ const MapSection = () => {
         toast.success('Task Requested for Mapping');
       } else {
         toast.success('Task Locked for Mapping');
+        setLockedUser({ name: userDetails?.name, id: userDetails?.id });
       }
     },
     onError: (err: any) => {
@@ -114,9 +121,9 @@ const MapSection = () => {
           case 'UNLOCKED_TO_MAP':
             return 'This task is available for mapping';
           case 'REQUEST_FOR_MAPPING':
-            return 'This task is Requested for mapping';
+            return `This task is Requested for mapping ${properties.locked_user_name ? `by ${userDetails?.id === properties?.locked_user_id ? 'you' : properties?.locked_user_name}` : ''}`;
           case 'LOCKED_FOR_MAPPING':
-            return 'This task is locked for mapping';
+            return `This task is locked for mapping ${properties.locked_user_name ? `by ${userDetails?.id === properties?.locked_user_id ? 'you' : properties?.locked_user_name}` : ''}`;
           case 'UNFLYABLE_TASK':
             return 'This task is not flyable';
           default:
@@ -125,7 +132,7 @@ const MapSection = () => {
       };
       return <h6>{popupText(status)}</h6>;
     },
-    [taskStatusObj],
+    [taskStatusObj, userDetails],
   );
 
   const handleTaskLockClick = () => {
@@ -207,11 +214,28 @@ const MapSection = () => {
         title={`Task #${selectedTaskId}`}
         fetchPopupData={(properties: Record<string, any>) => {
           dispatch(setProjectState({ selectedTaskId: properties.id }));
-          // console.log(properties, 'properties');
+          setLockedUser({
+            id: properties?.locked_user_id || '',
+            name: properties?.locked_user_name || '',
+          });
         }}
-        hideButton={taskStatusObj?.[selectedTaskId] !== 'UNLOCKED_TO_MAP'}
-        buttonText="Lock Task"
-        handleBtnClick={() => handleTaskLockClick()}
+        hideButton={
+          !(
+            taskStatusObj?.[selectedTaskId] === 'UNLOCKED_TO_MAP' ||
+            (taskStatusObj?.[selectedTaskId] === 'LOCKED_FOR_MAPPING' &&
+              lockedUser?.id === userDetails?.id)
+          )
+        }
+        buttonText={
+          taskStatusObj?.[selectedTaskId] === 'UNLOCKED_TO_MAP'
+            ? 'Lock Task'
+            : 'Go To Task'
+        }
+        handleBtnClick={() =>
+          taskStatusObj?.[selectedTaskId] === 'UNLOCKED_TO_MAP'
+            ? handleTaskLockClick()
+            : navigate(`/projects/${id}/tasks/${selectedTaskId}`)
+        }
       />
       <BaseLayerSwitcher />
     </MapContainer>

--- a/src/frontend/src/components/IndividualProject/MapSection/index.tsx
+++ b/src/frontend/src/components/IndividualProject/MapSection/index.tsx
@@ -117,6 +117,8 @@ const MapSection = () => {
             return 'This task is Requested for mapping';
           case 'LOCKED_FOR_MAPPING':
             return 'This task is locked for mapping';
+          case 'UNFLYABLE_TASK':
+            return 'This task is not flyable';
           default:
             return 'This Task is completed';
         }
@@ -205,6 +207,7 @@ const MapSection = () => {
         title={`Task #${selectedTaskId}`}
         fetchPopupData={(properties: Record<string, any>) => {
           dispatch(setProjectState({ selectedTaskId: properties.id }));
+          // console.log(properties, 'properties');
         }}
         hideButton={taskStatusObj?.[selectedTaskId] !== 'UNLOCKED_TO_MAP'}
         buttonText="Lock Task"

--- a/src/frontend/src/views/IndividualProject/index.tsx
+++ b/src/frontend/src/views/IndividualProject/index.tsx
@@ -44,13 +44,25 @@ const IndividualProject = () => {
 
   const { data: projectData, isLoading: isProjectDataLoading } =
     useGetProjectsDetailQuery(id as string, {
-      onSuccess: (res: any) =>
+      onSuccess: (res: any) => {
         dispatch(
           setProjectState({
-            tasksData: res.tasks,
+            // modify each task geojson and set locked user id and name to properties and save to redux state called taskData
+            tasksData: res.tasks?.map((task: Record<string, any>) => ({
+              ...task,
+              outline_geojson: {
+                ...task.outline_geojson,
+                properties: {
+                  ...task.outline_geojson.properties,
+                  locked_user_id: task?.user_id,
+                  locked_user_name: task?.name,
+                },
+              },
+            })),
             projectArea: res.outline_geojson,
           }),
-        ),
+        );
+      },
     });
 
   return (


### PR DESCRIPTION
- [x] Add a `Go To Task` button on the popup to redirect the user to the task description page
       (Note: button is visible only if the task is locked by same user).
- [x] Show the task locking user  on popup
- [x] Show popup message if the task is unflyable.
Screenshot of popup having Go To Task button with user who locked the task :
![Screenshot from 2024-08-15 19-38-48](https://github.com/user-attachments/assets/37de5946-9f18-4706-8d81-dac4a7662efb)
