### PR TITLE
Fix: check s3 image url existence

### DIFF
--- a/src/backend/app/projects/project_schemas.py
+++ b/src/backend/app/projects/project_schemas.py
@@ -420,7 +420,9 @@ class ProjectOut(BaseModel):
         project_id = values.id
         if project_id:
             image_dir = f"images/{project_id}/screenshot.png"
-            values.image_url = get_image_dir_url(settings.S3_BUCKET_NAME, image_dir)
+            values.image_url = get_image_dir_url(
+                settings.S3_BUCKET_NAME, image_dir, project_id
+            )
         return values
 
 

--- a/src/backend/app/projects/project_schemas.py
+++ b/src/backend/app/projects/project_schemas.py
@@ -420,9 +420,7 @@ class ProjectOut(BaseModel):
         project_id = values.id
         if project_id:
             image_dir = f"images/{project_id}/screenshot.png"
-            values.image_url = get_image_dir_url(
-                settings.S3_BUCKET_NAME, image_dir, project_id
-            )
+            values.image_url = get_image_dir_url(settings.S3_BUCKET_NAME, image_dir)
         return values
 
 

--- a/src/backend/app/s3.py
+++ b/src/backend/app/s3.py
@@ -1,3 +1,4 @@
+import uuid
 from app.config import settings
 from loguru import logger as log
 from minio import Minio
@@ -135,7 +136,7 @@ def get_obj_from_bucket(bucket_name: str, s3_path: str) -> BytesIO:
             response.release_conn()
 
 
-def get_image_dir_url(bucket_name: str, image_dir: str) -> str:
+def get_image_dir_url(bucket_name: str, image_dir: str, project_id: uuid.UUID) -> str:
     """Generate the full URL for the image directory in an S3 bucket.
 
     Args:
@@ -153,7 +154,17 @@ def get_image_dir_url(bucket_name: str, image_dir: str) -> str:
 
     # Construct the full URL
     protocol = "https" if is_secure else "http"
+
     url = f"{protocol}://{minio_url}/{bucket_name}{image_dir}"
 
-    log.debug(f"Image directory URL: {url}")
-    return url
+    minio_client = s3_client()
+    try:
+        # List objects with a prefix to check if the directory exists
+        objects = minio_client.list_objects(bucket_name, prefix=image_dir.lstrip("/"))
+        if any(objects):
+            return url
+        else:
+            return None
+
+    except Exception as e:
+        log.error(f"Error checking directory existence: {str(e)}")

--- a/src/backend/app/s3.py
+++ b/src/backend/app/s3.py
@@ -1,4 +1,3 @@
-import uuid
 from app.config import settings
 from loguru import logger as log
 from minio import Minio
@@ -136,7 +135,7 @@ def get_obj_from_bucket(bucket_name: str, s3_path: str) -> BytesIO:
             response.release_conn()
 
 
-def get_image_dir_url(bucket_name: str, image_dir: str, project_id: uuid.UUID) -> str:
+def get_image_dir_url(bucket_name: str, image_dir: str):
     """Generate the full URL for the image directory in an S3 bucket.
 
     Args:


### PR DESCRIPTION
### Description
This PR improves the `get_image_dir_url` function by adding a check to verify the existence of the image directory in the S3 bucket. Previously, the function generated a URL without confirming whether the directory actually existed. With this change, the function now:

1. Uses `minio_client.list_objects` to check if any objects exist in the specified `image_dir`.
2. Returns the constructed URL if the directory exists.
3. Returns `None` if the directory does not exist.