### PR TITLE
Refactor: update S3 bucket structure for project files and task images

### DIFF
--- a/src/backend/app/projects/project_logic.py
+++ b/src/backend/app/projects/project_logic.py
@@ -14,7 +14,7 @@ from app.config import settings
 
 
 async def upload_file_to_s3(
-    project_id: uuid.UUID, file: UploadFile, folder: str, file_extension: str
+    project_id: uuid.UUID, file: UploadFile, file_name: str
 ) -> str:
     """
     Upload a file (image or DEM) to S3.
@@ -28,14 +28,8 @@ async def upload_file_to_s3(
     Returns:
         str: The S3 URL for the uploaded file.
     """
-    # If the folder is 'images', use 'screenshot.png' as the filename
-    if folder == "images":
-        file_name = "screenshot.png"
-    else:
-        file_name = f"dem.{file_extension}"
-
     # Define the S3 file path
-    file_path = f"/{folder}/{project_id}/{file_name}"
+    file_path = f"/projects/{project_id}/{file_name}"
 
     # Read the file bytes
     file_bytes = await file.read()
@@ -55,7 +49,7 @@ async def upload_file_to_s3(
     return file_url
 
 
-async def update_url(db: Connection, project_id: uuid.UUID, url: str, url_type: str):
+async def update_url(db: Connection, project_id: uuid.UUID, url: str):
     """
     Update the URL (DEM or image) for a project in the database.
 
@@ -70,9 +64,9 @@ async def update_url(db: Connection, project_id: uuid.UUID, url: str, url_type: 
     """
     async with db.cursor() as cur:
         await cur.execute(
-            f"""
+            """
             UPDATE projects
-            SET {url_type} = %(url)s
+            SET dem_url = %(url)s
             WHERE id = %(project_id)s""",
             {"url": url, "project_id": project_id},
         )

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -133,16 +133,16 @@ async def create_project(
 
     # Upload DEM and Image to S3
     dem_url = (
-        await project_logic.upload_file_to_s3(project_id, dem, "dem", "tif")
+        await project_logic.upload_file_to_s3(project_id, dem, "dem.tif")
         if dem
         else None
     )
     await project_logic.upload_file_to_s3(
-        project_id, image, "images", "png"
+        project_id, image, "map_screenshot.png"
     ) if image else None
 
     # Update DEM and Image URLs in the database
-    await project_logic.update_url(db, project_id, dem_url, "dem_url")
+    await project_logic.update_url(db, project_id, dem_url)
 
     if not project_id:
         raise HTTPException(

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -240,7 +240,7 @@ async def generate_presigned_url(
         client = s3_client()
         urls = []
         for image in data.image_name:
-            image_path = f"publicuploads/{data.project_id}/{data.task_id}/{image}"
+            image_path = f"projects/{data.project_id}/{data.task_id}/images/{image}"
 
             url = client.get_presigned_url(
                 "PUT",

--- a/src/backend/app/projects/project_schemas.py
+++ b/src/backend/app/projects/project_schemas.py
@@ -419,7 +419,7 @@ class ProjectOut(BaseModel):
         """Set image_url before rendering the model."""
         project_id = values.id
         if project_id:
-            image_dir = f"images/{project_id}/screenshot.png"
+            image_dir = f"projects/{project_id}/map_screenshot.png"
             values.image_url = get_image_dir_url(settings.S3_BUCKET_NAME, image_dir)
         return values
 


### PR DESCRIPTION
### PR Description:
This PR updates the MinIO S3 bucket path structure to better organize project files and task-related images:

- **Project-level files** such as `dem.tif` and `map_screenshot.jpg` are stored directly under the project directory.
- **Task-specific images** are now grouped under a dedicated `images` folder within each task directory.

The new structure is as follows:

```
projects/
└── project_id/
    ├── dem.tif
    ├── map_screenshot.jpg
    └── task_id/
        └── images/
            ├── image_1.jpg
            ├── image_2.jpg
            ├── image_3.jpg
```
### screenshot
![image](https://github.com/user-attachments/assets/2e76da08-aae3-41f4-b2a6-dda96772bcd0)
