### PR TITLE
Feat: Add optional filter for projects by current user

### DIFF
--- a/src/backend/app/projects/project_schemas.py
+++ b/src/backend/app/projects/project_schemas.py
@@ -278,7 +278,7 @@ class DbProject(BaseModel):
 
     async def all(
         db: Connection,
-        user_id: Optional[uuid.UUID] = None,
+        user_id: Optional[str] = None,
         skip: int = 0,
         limit: int = 100,
     ):

--- a/src/backend/app/projects/project_schemas.py
+++ b/src/backend/app/projects/project_schemas.py
@@ -278,20 +278,27 @@ class DbProject(BaseModel):
 
     async def all(
         db: Connection,
+        user_id: Optional[uuid.UUID] = None,
         skip: int = 0,
         limit: int = 100,
     ):
-        """Get all projects."""
+        """
+        Get all projects. Optionally filter by the project creator (user).
+        """
         async with db.cursor(row_factory=dict_row) as cur:
             await cur.execute(
                 """
-            SELECT id, slug, name, description, per_task_instructions, ST_AsGeoJSON(outline)::jsonb AS outline, requires_approval_from_manager_for_locking
-            FROM projects
-            ORDER BY created_at DESC
-            OFFSET %(skip)s
-            LIMIT %(limit)s
-            """,
-                {"skip": skip, "limit": limit},
+                SELECT
+                    id, slug, name, description, per_task_instructions,
+                    ST_AsGeoJSON(outline)::jsonb AS outline,
+                    requires_approval_from_manager_for_locking
+                FROM projects
+                WHERE (author_id = COALESCE(%(user_id)s, author_id))
+                ORDER BY created_at DESC
+                OFFSET %(skip)s
+                LIMIT %(limit)s
+                """,
+                {"skip": skip, "limit": limit, "user_id": user_id},
             )
             db_projects = await cur.fetchall()
             return db_projects


### PR DESCRIPTION
### Description:

This pull request introduces a new feature to optionally filter projects based on the current user. 

### Changes:

- Added `filter_by_owner` to the `read_projects` endpoint to filter projects where the `author_id` matches the current user's ID. If `filter_by_owner` is set to `True`, the query will only return projects authored by the current user. If `filter_by_owner` is set to `False` or not provided, all projects will be returned.
