### PR TITLE
Fix: Improve polygon merging logic to merge with the polygon having maximum shared boundary

### DIFF
--- a/src/backend/app/projects/project_logic.py
+++ b/src/backend/app/projects/project_logic.py
@@ -2,7 +2,7 @@ import json
 import uuid
 from loguru import logger as log
 from fastapi import HTTPException, UploadFile
-from app.tasks.splitter import split_by_square
+from app.tasks.task_splitter import split_by_square
 from fastapi.concurrency import run_in_threadpool
 from psycopg import Connection
 from app.utils import merge_multipolygon

--- a/src/backend/app/tasks/task_splitter.py
+++ b/src/backend/app/tasks/task_splitter.py
@@ -119,13 +119,11 @@ class TaskSplitter(object):
         return shape(features[0].get("geometry"))
 
     def splitBySquare(self, meters: int) -> FeatureCollection:
-        
         xmin, ymin, xmax, ymax = self.aoi.bounds
-        
+
         meter = 0.0000114
         length = float(meters) * meter
         width = float(meters) * meter
-
 
         area_threshold = (length * width) / 4
 
@@ -161,7 +159,7 @@ class TaskSplitter(object):
                     # Get the adjacent polygon with the maximum shared boundary length
                     nearest_polygon = max(
                         adjacent_polygons,
-                        key=lambda p: small_polygon.intersection(p).length
+                        key=lambda p: small_polygon.intersection(p).length,
                     )
 
                     # Merge the small polygon with the nearest large polygon

--- a/src/backend/app/tasks/task_splitter.py
+++ b/src/backend/app/tasks/task_splitter.py
@@ -125,7 +125,7 @@ class TaskSplitter(object):
         length = float(meters) * meter
         width = float(meters) * meter
 
-        area_threshold = (length * width) / 4
+        area_threshold = (length * width) / 3
 
         # Generate grid columns and rows based on AOI bounds
         cols = np.arange(xmin, xmax + width, width)

--- a/src/backend/app/tasks/task_splitter.py
+++ b/src/backend/app/tasks/task_splitter.py
@@ -119,14 +119,14 @@ class TaskSplitter(object):
         return shape(features[0].get("geometry"))
 
     def splitBySquare(self, meters: int) -> FeatureCollection:
-        # Define bounds of the area of interest (AOI)
+        
         xmin, ymin, xmax, ymax = self.aoi.bounds
-        # Convert meters to degrees (assuming near-equator for simplicity)
+        
         meter = 0.0000114
         length = float(meters) * meter
         width = float(meters) * meter
 
-        # Calculate area threshold for distinguishing large and small polygons
+
         area_threshold = (length * width) / 4
 
         # Generate grid columns and rows based on AOI bounds
@@ -158,8 +158,11 @@ class TaskSplitter(object):
                     if small_polygon.touches(large_polygon)
                 ]
                 if adjacent_polygons:
-                    # Get the adjacent polygon with the minimum area
-                    nearest_polygon = min(adjacent_polygons, key=lambda p: p.area)
+                    # Get the adjacent polygon with the maximum shared boundary length
+                    nearest_polygon = max(
+                        adjacent_polygons,
+                        key=lambda p: small_polygon.intersection(p).length
+                    )
 
                     # Merge the small polygon with the nearest large polygon
                     merged_polygon = unary_union([small_polygon, nearest_polygon])


### PR DESCRIPTION

- **Description**: 
    - Previously, polygons were merged based on the smallest adjacent polygon area.
    - Now, small polygons are merged with adjacent polygons that share the maximum boundary length.
 - **Before**
![Screenshot from 2024-09-16 13-32-26](https://github.com/user-attachments/assets/b0e5759c-adda-4f44-a658-74b03aa1fbed)
- **After**
![image](https://github.com/user-attachments/assets/87a132f1-8498-4e40-9925-65e26fa77d16)

![image](https://github.com/user-attachments/assets/291b2791-991a-4ab4-8c1b-ea5c765694b4)

