### PR TITLE
Feat: added two new enums such as IMAGE_UPLOADED & IMAGE_PROCESSED

### DIFF
--- a/src/backend/app/migrations/versions/5235ef4afa9c_.py
+++ b/src/backend/app/migrations/versions/5235ef4afa9c_.py
@@ -1,0 +1,60 @@
+"""
+
+Revision ID: 5235ef4afa9c
+Revises: b4338a93f7bb
+Create Date: 2024-10-01 07:50:13.553835
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '5235ef4afa9c'
+down_revision: Union[str, None] = 'b4338a93f7bb'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Define the new enum type
+new_state_enum = sa.Enum(
+    "UNLOCKED_TO_MAP",
+    "LOCKED_FOR_MAPPING",
+    "UNLOCKED_TO_VALIDATE",
+    "LOCKED_FOR_VALIDATION",
+    "UNLOCKED_DONE",
+    "REQUEST_FOR_MAPPING",
+    "UNFLYABLE_TASK",
+    "IMAGE_UPLOADED",
+    "IMAGE_PROCESSED",
+    name="state",
+)
+
+old_state_enum = sa.Enum(
+    "UNLOCKED_TO_MAP",
+    "LOCKED_FOR_MAPPING",
+    "UNLOCKED_TO_VALIDATE",
+    "LOCKED_FOR_VALIDATION",
+    "UNLOCKED_DONE",
+    "REQUEST_FOR_MAPPING",
+    "UNFLYABLE_TASK",
+    name="state",
+)
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE state ADD VALUE 'IMAGE_UPLOADED'")
+    op.execute("ALTER TYPE state ADD VALUE 'IMAGE_PROCESSED'")
+    
+
+def downgrade() -> None:
+    # Rename the enum type
+    op.execute("ALTER TYPE state RENAME TO state_old")
+    # Recreate the old enum type
+    old_state_enum.create(op.get_bind(), checkfirst=False)
+    # Alter the column to use the old enum type
+    op.execute("ALTER TABLE task_events ALTER COLUMN state TYPE state_old USING state::state_old")
+    # Drop the old enum type
+    op.execute("DROP TYPE state_old")
+    

--- a/src/backend/app/migrations/versions/5235ef4afa9c_.py
+++ b/src/backend/app/migrations/versions/5235ef4afa9c_.py
@@ -5,6 +5,7 @@ Revises: b4338a93f7bb
 Create Date: 2024-10-01 07:50:13.553835
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op
@@ -12,8 +13,8 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = '5235ef4afa9c'
-down_revision: Union[str, None] = 'b4338a93f7bb'
+revision: str = "5235ef4afa9c"
+down_revision: Union[str, None] = "b4338a93f7bb"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -43,10 +44,11 @@ old_state_enum = sa.Enum(
     name="state",
 )
 
+
 def upgrade() -> None:
     op.execute("ALTER TYPE state ADD VALUE 'IMAGE_UPLOADED'")
     op.execute("ALTER TYPE state ADD VALUE 'IMAGE_PROCESSED'")
-    
+
 
 def downgrade() -> None:
     # Rename the enum type
@@ -54,7 +56,8 @@ def downgrade() -> None:
     # Recreate the old enum type
     old_state_enum.create(op.get_bind(), checkfirst=False)
     # Alter the column to use the old enum type
-    op.execute("ALTER TABLE task_events ALTER COLUMN state TYPE state_old USING state::state_old")
+    op.execute(
+        "ALTER TABLE task_events ALTER COLUMN state TYPE state_old USING state::state_old"
+    )
     # Drop the old enum type
     op.execute("DROP TYPE state_old")
-    

--- a/src/backend/app/models/enums.py
+++ b/src/backend/app/models/enums.py
@@ -142,6 +142,8 @@ class State(int, Enum):
     LOCKED_FOR_VALIDATION = 3
     UNLOCKED_DONE = 4
     UNFLYABLE_TASK = 5
+    IMAGE_UPLOADED = 6
+    IMAGE_PROCESSED = 7
 
 
 class EventType(str, Enum):


### PR DESCRIPTION

### Description:
This PR adds two new enums to the project:
- `IMAGE_UPLOADED`: Represents the state when an image has been uploaded.
- `IMAGE_PROCESSED`: Represents the state when an uploaded image has been processed.

### Screenshots:
![Screenshot from 2024-10-01 13-58-19](https://github.com/user-attachments/assets/96988ee6-f78f-4fa6-98a2-beb22c38d3f1)

