### PR TITLE
Fix: add Password Verification and Fix updated_at Field Fetch in task details endpoint

### DIFF
--- a/src/backend/app/users/user_routes.py
+++ b/src/backend/app/users/user_routes.py
@@ -76,6 +76,7 @@ async def update_user_profile(
     profile_update: UserProfileIn,
     db: Annotated[Connection, Depends(database.get_db)],
     user_data: Annotated[AuthUser, Depends(login_required)],
+    request: Request,
 ):
     """
     Update user profile based on provided user_id and profile_update data.
@@ -89,7 +90,6 @@ async def update_user_profile(
     """
 
     user = await user_schemas.DbUser.get_user_by_id(db, user_id)
-
     if user_data.id != user_id:
         raise HTTPException(
             status_code=HTTPStatus.FORBIDDEN,
@@ -98,6 +98,16 @@ async def update_user_profile(
 
     if not user:
         raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="User not found")
+
+    if request.method == "PATCH":
+        if not user_logic.verify_password(
+            profile_update.old_password, user.get("password")
+        ):
+            raise HTTPException(
+                status_code=HTTPStatus.BAD_REQUEST,
+                detail="Old password is incorrect",
+            )
+
     user = await user_schemas.DbUserProfile.update(db, user_id, profile_update)
     return JSONResponse(
         status_code=HTTPStatus.OK,

--- a/src/backend/app/users/user_schemas.py
+++ b/src/backend/app/users/user_schemas.py
@@ -127,7 +127,9 @@ class DbUserProfile(BaseUserProfile):
         """Update or insert a user profile."""
 
         # Prepare data for insert or update
-        model_dump = profile_update.model_dump(exclude_none=True, exclude=["password"])
+        model_dump = profile_update.model_dump(
+            exclude_none=True, exclude=["password", "old_password"]
+        )
         columns = ", ".join(model_dump.keys())
         value_placeholders = ", ".join(f"%({key})s" for key in model_dump.keys())
         sql = f"""

--- a/src/backend/app/users/user_schemas.py
+++ b/src/backend/app/users/user_schemas.py
@@ -114,6 +114,7 @@ class BaseUserProfile(BaseModel):
 
 class UserProfileIn(BaseUserProfile):
     password: Optional[str] = None
+    old_password: Optional[str] = None
 
 
 class DbUserProfile(BaseUserProfile):


### PR DESCRIPTION

### What Type of PR :
- [x] Bugfix
- [x] Feature update

### Related Issue:
N/A 

### Description:
- Updated the Profit Edit API to use a PATCH request .
- Added logic to verify the old password against the user's current password when updating their profile.
- Fixed an issue where the `updated_at` field was not being correctly fetched in the task read query.
