### PR TITLE
Feat: Updated endpoints(download-assets) to fetch task assets status.

### DIFF
--- a/src/backend/app/db/database.py
+++ b/src/backend/app/db/database.py
@@ -9,7 +9,9 @@ from app.config import settings
 
 async def get_db_connection_pool() -> AsyncConnectionPool:
     """Get the connection pool for psycopg."""
-    return AsyncConnectionPool(conninfo=settings.DTM_DB_URL.unicode_string())
+    pool = AsyncConnectionPool(conninfo=settings.DTM_DB_URL.unicode_string())
+    await pool.open()  # Explicitly open the pool
+    return pool
 
 
 async def get_db(request: Request) -> AsyncGenerator[Connection, None]:

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -392,6 +392,7 @@ async def process_imagery(
     tags=["Image Processing"],
 )
 async def get_assets_info(
+    user_data: Annotated[AuthUser, Depends(login_required)],
     db: Annotated[Connection, Depends(database.get_db)],
     project: Annotated[
         project_schemas.DbProject, Depends(project_deps.get_project_by_id)

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -404,14 +404,13 @@ async def get_assets_info(
     for all tasks associated with the project.
     """
     if task_id is None:
-        print("*" * 100)
         # Fetch all tasks associated with the project
         tasks = await project_deps.get_tasks_by_project_id(project.id, db)
 
         results = []
 
         for task in tasks:
-            task_info = await project_logic.get_project_info_from_s3(
+            task_info = project_logic.get_project_info_from_s3(
                 project.id, task.get("id")
             )
             results.append(task_info)

--- a/src/backend/app/projects/project_schemas.py
+++ b/src/backend/app/projects/project_schemas.py
@@ -146,24 +146,6 @@ class TaskOut(BaseModel):
     image_count: Optional[int] = None
     assets_url: Optional[str] = None
 
-    # @model_validator(mode="after")
-    # def set_assets_url(cls, values):
-    #     """Set image_url and image count before rendering the model."""
-    #     task_id = values.id
-    #     project_id = values.project_id
-
-    #     if task_id and project_id:
-    #         data = project_logic.get_project_info_from_s3(project_id, task_id)
-    #         if data:
-    #             return values.copy(
-    #                 update={
-    #                     "assets_url": data.assets_url,
-    #                     "image_count": data.image_count,
-    #                 }
-    #             )
-
-    #     return values
-
 
 class DbProject(BaseModel):
     """Project model for extracting from database."""

--- a/src/backend/app/projects/project_schemas.py
+++ b/src/backend/app/projects/project_schemas.py
@@ -2,7 +2,6 @@ import json
 import uuid
 from typing import Annotated, Optional, List
 from datetime import datetime, date
-from app.projects import project_logic
 import geojson
 from loguru import logger as log
 from pydantic import BaseModel, computed_field, Field, model_validator, root_validator
@@ -147,23 +146,23 @@ class TaskOut(BaseModel):
     image_count: Optional[int] = None
     assets_url: Optional[str] = None
 
-    @model_validator(mode="after")
-    def set_assets_url(cls, values):
-        """Set image_url and image count before rendering the model."""
-        task_id = values.id
-        project_id = values.project_id
+    # @model_validator(mode="after")
+    # def set_assets_url(cls, values):
+    #     """Set image_url and image count before rendering the model."""
+    #     task_id = values.id
+    #     project_id = values.project_id
 
-        if task_id and project_id:
-            data = project_logic.get_project_info_from_s3(project_id, task_id)
-            if data:
-                return values.copy(
-                    update={
-                        "assets_url": data.assets_url,
-                        "image_count": data.image_count,
-                    }
-                )
+    #     if task_id and project_id:
+    #         data = project_logic.get_project_info_from_s3(project_id, task_id)
+    #         if data:
+    #             return values.copy(
+    #                 update={
+    #                     "assets_url": data.assets_url,
+    #                     "image_count": data.image_count,
+    #                 }
+    #             )
 
-        return values
+    #     return values
 
 
 class DbProject(BaseModel):

--- a/src/backend/pdm.lock
+++ b/src/backend/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default"]
 strategy = ["cross_platform"]
 lock_version = "4.5.0"
-content_hash = "sha256:99dcee931aca5cd6b30de348304d4698e73e08c6c2eb7246423cb7d50969ac90"
+content_hash = "sha256:5af1cd91bffbaffb22f9affb9a5dea337d37697f4a6b024b7ace22cd9c73c6a2"
 
 [[metadata.targets]]
 requires_python = ">=3.11"
@@ -278,7 +278,7 @@ files = [
 
 [[package]]
 name = "drone-flightplan"
-version = "0.3.1rc4"
+version = "0.3.1"
 requires_python = ">=3.10"
 summary = "Generates an optimized flight plan for drones to conduct precise and efficient aerial mapping"
 dependencies = [
@@ -287,8 +287,8 @@ dependencies = [
     "shapely>=2.0.0",
 ]
 files = [
-    {file = "drone_flightplan-0.3.1rc4-py3-none-any.whl", hash = "sha256:d0150655091c187a8db8a3f5170ed4a3d85bc25408ff463f02478a9ed4f29666"},
-    {file = "drone_flightplan-0.3.1rc4.tar.gz", hash = "sha256:badce959ffcf062028e0245e8a00b8f7e9cac52c356f673b0eccdbed5c92a961"},
+    {file = "drone_flightplan-0.3.1-py3-none-any.whl", hash = "sha256:e1e880ed93a048865442f20a72e701fba6e9f54ae9cd1ccbb90222628fd9c8bb"},
+    {file = "drone_flightplan-0.3.1.tar.gz", hash = "sha256:1d79589085cb4e3000b165b610453e889958ea3630b6d76ebdd8b650b93e7f8f"},
 ]
 
 [[package]]
@@ -794,26 +794,32 @@ files = [
 
 [[package]]
 name = "pyproj"
-version = "3.6.1"
-requires_python = ">=3.9"
+version = "3.7.0"
+requires_python = ">=3.10"
 summary = "Python interface to PROJ (cartographic projections and coordinate transformations library)"
 dependencies = [
     "certifi",
 ]
 files = [
-    {file = "pyproj-3.6.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ebfbdbd0936e178091309f6cd4fcb4decd9eab12aa513cdd9add89efa3ec2882"},
-    {file = "pyproj-3.6.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:447db19c7efad70ff161e5e46a54ab9cc2399acebb656b6ccf63e4bc4a04b97a"},
-    {file = "pyproj-3.6.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7e13c40183884ec7f94eb8e0f622f08f1d5716150b8d7a134de48c6110fee85"},
-    {file = "pyproj-3.6.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:65ad699e0c830e2b8565afe42bd58cc972b47d829b2e0e48ad9638386d994915"},
-    {file = "pyproj-3.6.1-cp311-cp311-win32.whl", hash = "sha256:8b8acc31fb8702c54625f4d5a2a6543557bec3c28a0ef638778b7ab1d1772132"},
-    {file = "pyproj-3.6.1-cp311-cp311-win_amd64.whl", hash = "sha256:38a3361941eb72b82bd9a18f60c78b0df8408416f9340521df442cebfc4306e2"},
-    {file = "pyproj-3.6.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:1e9fbaf920f0f9b4ee62aab832be3ae3968f33f24e2e3f7fbb8c6728ef1d9746"},
-    {file = "pyproj-3.6.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6d227a865356f225591b6732430b1d1781e946893789a609bb34f59d09b8b0f8"},
-    {file = "pyproj-3.6.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83039e5ae04e5afc974f7d25ee0870a80a6bd6b7957c3aca5613ccbe0d3e72bf"},
-    {file = "pyproj-3.6.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fffb059ba3bced6f6725961ba758649261d85ed6ce670d3e3b0a26e81cf1aa8d"},
-    {file = "pyproj-3.6.1-cp312-cp312-win32.whl", hash = "sha256:2d6ff73cc6dbbce3766b6c0bce70ce070193105d8de17aa2470009463682a8eb"},
-    {file = "pyproj-3.6.1-cp312-cp312-win_amd64.whl", hash = "sha256:7a27151ddad8e1439ba70c9b4b2b617b290c39395fa9ddb7411ebb0eb86d6fb0"},
-    {file = "pyproj-3.6.1.tar.gz", hash = "sha256:44aa7c704c2b7d8fb3d483bbf75af6cb2350d30a63b144279a09b75fead501bf"},
+    {file = "pyproj-3.7.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:e66d8d42dbdf232e121546c5a1dec097caf0454e4885c09a8e03cdcee0753c03"},
+    {file = "pyproj-3.7.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:7764b64a0aefe40134a2828b3a40be88f6c8b7832c45d8a9f2bd592ace4b2a3b"},
+    {file = "pyproj-3.7.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:53c442c5081dc95346996f5c4323fde2caafc69c6e60b4707aa46e88244f1e04"},
+    {file = "pyproj-3.7.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc5b305d4d5d7697885681d9b660623e328227612823d5c660e0a9566cb48838"},
+    {file = "pyproj-3.7.0-cp311-cp311-win32.whl", hash = "sha256:de2b47d748dc41cccb6b3b713d4d7dc9aa1046a82141c8665026908726426abc"},
+    {file = "pyproj-3.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:38cba7c4c5679e40242dd959133e95b908d3b912dd66291094fd13510e8517ff"},
+    {file = "pyproj-3.7.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:8cbec92bdd6e9933ca08795c12717d1384e9b51cf4b1acf0d753db255a75c51e"},
+    {file = "pyproj-3.7.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8c4a8e4d3ba76c3adac3c087544cf92f7f9a19ea34946904a13fca48cc1c0106"},
+    {file = "pyproj-3.7.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:82624fb42aa31f6b1a860fbc0316babd07fd712642bc31022df4e9b4056bf463"},
+    {file = "pyproj-3.7.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:34e1bbb3f89c68d4a6835c40b2da8b27680eec60e8cc7cdb08c09bcc725b2b62"},
+    {file = "pyproj-3.7.0-cp312-cp312-win32.whl", hash = "sha256:952515d5592167ad4436b355485f82acebed2a49b46722159e4584b75a763dd3"},
+    {file = "pyproj-3.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:0692f806224e8ed82fe4acfa57268ff444fdaf9f330689f24c0d96e59480cce1"},
+    {file = "pyproj-3.7.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:94e8b903a9e83448fd2379c49dec3e8cd83c9ed36f54354e68b601cef56d5426"},
+    {file = "pyproj-3.7.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:64cb5c17d6f6305a8b978a40f95560c87c5b363fcac40632337955664437875a"},
+    {file = "pyproj-3.7.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c54e9bdda7ab9c4a5af50f9d6e6ee7704e05fafd504896b96ed1208c7aea098"},
+    {file = "pyproj-3.7.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24fa4e9e0abba875f9524808410cc520067eaf38fd5549ed0ef7c43ac39923c9"},
+    {file = "pyproj-3.7.0-cp313-cp313-win32.whl", hash = "sha256:b9e8353fc3c79dc14d1f5ac758a1a6e4eee04102c3c0b138670f121f5ac52eb4"},
+    {file = "pyproj-3.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:10a8dc6ec61af97c89ff032647d743f8dc023645773da42ef43f7ae1125b3509"},
+    {file = "pyproj-3.7.0.tar.gz", hash = "sha256:bf658f4aaf815d9d03c8121650b6f0b8067265c36e31bc6660b98ef144d81813"},
 ]
 
 [[package]]

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -30,10 +30,10 @@ dependencies = [
     "GDAL==3.6.2",
     "aiosmtplib>=3.0.1",
     "python-slugify>=8.0.4",
-    "drone-flightplan==0.3.1rc4",
     "psycopg2>=2.9.9",
     "pyodm>=1.5.11",
     "asgiref>=3.8.1",
+    "drone-flightplan>=0.3.1",
 ]
 requires-python = ">=3.11"
 license = {text = "GPL-3.0-only"}

--- a/src/frontend/src/api/projects.ts
+++ b/src/frontend/src/api/projects.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 import { UseQueryOptions, useQuery } from '@tanstack/react-query';
 import { getProjectsList, getProjectDetail } from '@Services/createproject';
-import { getTaskStates } from '@Services/project';
+import { getAllAssetsUrl, getTaskStates } from '@Services/project';
 import { getUserProfileInfo } from '@Services/common';
 
 export const useGetProjectsListQuery = (
@@ -58,6 +58,18 @@ export const useGetUserDetailsQuery = (
       localStorage.setItem('userprofile', userDetailsString as string);
       return userDetails;
     },
+    ...queryOptions,
+  });
+};
+
+export const useGetAllAssetsUrlQuery = (
+  projectId: string,
+  queryOptions?: Partial<UseQueryOptions>,
+) => {
+  return useQuery({
+    queryKey: ['all-assets-url'],
+    queryFn: () => getAllAssetsUrl(projectId),
+    select: (data: any) => data.data,
     ...queryOptions,
   });
 };

--- a/src/frontend/src/components/DroneOperatorTask/MapSection/index.tsx
+++ b/src/frontend/src/components/DroneOperatorTask/MapSection/index.tsx
@@ -254,7 +254,7 @@ const MapSection = ({ className }: { className?: string }) => {
             </>
           )}
 
-          <div className="naxatw-absolute naxatw-bottom-3 naxatw-right-[calc(50%-5.4rem)] naxatw-z-30 lg:naxatw-right-3 lg:naxatw-top-3">
+          <div className="naxatw-absolute naxatw-bottom-3 naxatw-right-[calc(50%-5.4rem)] naxatw-z-30 naxatw-h-fit lg:naxatw-right-3 lg:naxatw-top-3">
             <Button
               withLoader
               leftIcon="place"

--- a/src/frontend/src/components/IndividualProject/Contributions/TableSection/index.tsx
+++ b/src/frontend/src/components/IndividualProject/Contributions/TableSection/index.tsx
@@ -67,8 +67,8 @@ export default function TableSection({ isFetching }: { isFetching: boolean }) {
           user: curr?.name || '-',
           task_mapped: `Task# ${curr?.project_task_index}`,
           task_state: curr?.state,
-          assets_url: curr?.assets_url,
-          image_count: curr?.image_count,
+          assets_url: curr?.assetsDetail?.assets_url,
+          image_count: curr?.assetsDetail?.image_count,
         },
       ];
     }, []);

--- a/src/frontend/src/constants/index.ts
+++ b/src/frontend/src/constants/index.ts
@@ -81,9 +81,8 @@ export const droneOperatorKeys = [
 ];
 
 export const rowsPerPageOptions = [
-  { label: '10', value: 10 },
-  { label: '20', value: 20 },
+  { label: '12', value: 12 },
+  { label: '18', value: 18 },
+  { label: '24', value: 24 },
   { label: '30', value: 30 },
-  { label: '50', value: 50 },
-  { label: '100', value: 100 },
 ];

--- a/src/frontend/src/services/project.ts
+++ b/src/frontend/src/services/project.ts
@@ -12,3 +12,6 @@ export const postTaskStatus = (payload: Record<string, any>) => {
 };
 export const getRequestedTasks = () =>
   authenticated(api).get('/tasks/requested_tasks/pending');
+
+export const getAllAssetsUrl = (projectId: string) =>
+  authenticated(api).get(`/projects/assets/${projectId}`);

--- a/src/frontend/src/services/tasks.ts
+++ b/src/frontend/src/services/tasks.ts
@@ -19,7 +19,7 @@ export const postTaskWaypoint = (payload: Record<string, any>) => {
   );
 };
 export const getTaskAssetsInfo = (projectId: string, taskId: string) =>
-  authenticated(api).get(`/projects/assets/${projectId}/${taskId}/`);
+  authenticated(api).get(`/projects/assets/${projectId}/?task_id=${taskId}`);
 
 export const postProcessImagery = (projectId: string, taskId: string) =>
   authenticated(api).post(`/projects/process_imagery/${projectId}/${taskId}/`);

--- a/src/frontend/src/views/IndividualProject/index.tsx
+++ b/src/frontend/src/views/IndividualProject/index.tsx
@@ -1,6 +1,9 @@
 /* eslint-disable jsx-a11y/interactive-supports-focus */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-import { useGetProjectsDetailQuery } from '@Api/projects';
+import {
+  useGetAllAssetsUrlQuery,
+  useGetProjectsDetailQuery,
+} from '@Api/projects';
 import Tab from '@Components/common/Tabs';
 import {
   Contributions,
@@ -43,14 +46,23 @@ const IndividualProject = () => {
     state => state.project.individualProjectActiveTab,
   );
 
+  const { data: allUrls, isFetching } = useGetAllAssetsUrlQuery(id as string);
+
+  const getTasksAssets = (taskID: string, assetsList: any[]) => {
+    if (!assetsList || !taskID) return null;
+    return assetsList.find((assets: any) => assets?.task_id === taskID);
+  };
+
   const { data: projectData, isFetching: isProjectDataFetching } =
     useGetProjectsDetailQuery(id as string, {
+      enabled: !!allUrls && !isFetching,
       onSuccess: (res: any) => {
         dispatch(
           setProjectState({
             // modify each task geojson and set locked user id and name to properties and save to redux state called taskData
             tasksData: res.tasks?.map((task: Record<string, any>) => ({
               ...task,
+              assetsDetail: getTasksAssets(task?.id, allUrls as any[]),
               outline: {
                 ...task.outline,
                 properties: {

--- a/src/frontend/src/views/Projects/index.tsx
+++ b/src/frontend/src/views/Projects/index.tsx
@@ -25,7 +25,7 @@ const Projects = () => {
   );
   const [paginationState, setSetPaginationState] = useState({
     activePage: 1,
-    selectedNumberOfRows: 10,
+    selectedNumberOfRows: 12,
   });
 
   const handlePaginationState = (value: Record<string, number>) => {
@@ -60,7 +60,7 @@ const Projects = () => {
       <ProjectsHeader />
       <div className="naxatw-grid naxatw-gap-2 naxatw-pb-10 md:naxatw-flex md:naxatw-h-[calc(100vh-11rem)] md:naxatw-pb-0">
         <div
-          className={`scrollbar naxatw-grid naxatw-grid-rows-[19rem] naxatw-gap-3 naxatw-overflow-y-auto naxatw-py-2 ${showMap ? 'naxatw-w-full naxatw-grid-cols-1 md:naxatw-w-1/3 md:naxatw-grid-cols-1 lg:naxatw-grid-cols-1 xl:naxatw-grid-cols-2' : 'naxatw-w-full naxatw-grid-cols-1 sm:naxatw-grid-cols-2 md:naxatw-grid-cols-3 lg:naxatw-grid-cols-5'}`}
+          className={`scrollbar naxatw-grid naxatw-grid-rows-[19rem] naxatw-gap-3 naxatw-overflow-y-auto naxatw-py-2 ${showMap ? 'naxatw-w-full naxatw-grid-cols-1 md:naxatw-w-1/2 md:naxatw-grid-cols-1 lg:naxatw-grid-cols-2 xl:naxatw-grid-cols-3' : 'naxatw-w-full naxatw-grid-cols-1 sm:naxatw-grid-cols-2 md:naxatw-grid-cols-3 lg:naxatw-grid-cols-6'}`}
           style={{ gridAutoRows: '19rem' }}
         >
           {isLoading ? (
@@ -93,7 +93,7 @@ const Projects = () => {
           )}
         </div>
         {showMap && (
-          <div className="naxatw-h-[70vh] naxatw-w-full naxatw-py-2 naxatw-shadow-xl md:naxatw-h-full md:naxatw-w-2/3">
+          <div className="naxatw-h-[70vh] naxatw-w-full naxatw-py-2 naxatw-shadow-xl md:naxatw-h-full md:naxatw-w-1/2">
             {!isLoading ? (
               <ProjectsMapSection projectList={projectListData?.results} />
             ) : (


### PR DESCRIPTION
### Description

This PR updates `drone_flightplan` to version 0.3.1 and improves the existing endpoints:

- Now able to retrieve all tasks and their task assets status for a given project.
- Allows for the retrieval of individual task status by `task_id`, or all tasks if no `task_id` is provided.
- **Fixes deprecation warning**: Resolved the deprecated async pool initialization for psycopg. Updated `get_db_connection_pool` to explicitly call `await pool.open()` and refactored `lifespan` to use `async with` for managing the connection pool lifecycle.

The following warning was addressed:

``` 
/project/.venv/lib/python3.11/site-packages/psycopg_pool/pool_async.py:138: RuntimeWarning: opening the async pool AsyncConnectionPool in the constructor is deprecated and will not be supported anymore in a future release. Please use `await pool.open()`, or use the pool as context manager using: `async with AsyncConnectionPool(...) as pool: ...`
```
