### PR TITLE
Fix: Complete profile as a new role

### DIFF
--- a/src/frontend/src/components/GoogleAuth/index.tsx
+++ b/src/frontend/src/components/GoogleAuth/index.tsx
@@ -37,23 +37,22 @@ function GoogleAuth() {
             credentials: 'include',
             headers: { 'access-token': token.access_token },
           });
-          setTimeout(async () => {
-            const userDetails = await response2.json();
-            // stringify the response and set it to local storage
-            const userDetailsString = JSON.stringify(userDetails);
-            localStorage.setItem('userprofile', userDetailsString);
-            setUserProfileDetails(userDetails);
 
-            // navigate according the user profile completion
-            if (
-              userDetails?.has_user_profile &&
-              userDetails?.role?.includes(signedInAs)
-            ) {
-              navigate('/projects');
-            } else {
-              navigate('/complete-profile');
-            }
-          });
+          const userDetails = await response2.json();
+          // stringify the response and set it to local storage
+          const userDetailsString = JSON.stringify(userDetails);
+          localStorage.setItem('userprofile', userDetailsString);
+          setUserProfileDetails(userDetails);
+
+          // navigate according the user profile completion
+          if (
+            userDetails?.has_user_profile &&
+            userDetails?.role?.includes(signedInAs)
+          ) {
+            navigate('/projects');
+          } else {
+            navigate('/complete-profile');
+          }
         };
         await completeLogin();
         toast.success('Logged In Successfully');

--- a/src/frontend/src/components/GoogleAuth/index.tsx
+++ b/src/frontend/src/components/GoogleAuth/index.tsx
@@ -37,19 +37,23 @@ function GoogleAuth() {
             credentials: 'include',
             headers: { 'access-token': token.access_token },
           });
-          const userDetails = await response2.json();
+          setTimeout(async () => {
+            const userDetails = await response2.json();
+            // stringify the response and set it to local storage
+            const userDetailsString = JSON.stringify(userDetails);
+            localStorage.setItem('userprofile', userDetailsString);
+            setUserProfileDetails(userDetails);
 
-          // stringify the response and set it to local storage
-          const userDetailsString = JSON.stringify(userDetails);
-          localStorage.setItem('userprofile', userDetailsString);
-          setUserProfileDetails(userDetails);
-
-          // navigate according the user
-          if (userDetails?.has_user_profile) {
-            navigate('/projects');
-          } else {
-            navigate('/complete-profile');
-          }
+            // navigate according the user profile completion
+            if (
+              userDetails?.has_user_profile &&
+              userDetails?.role?.includes(signedInAs)
+            ) {
+              navigate('/projects');
+            } else {
+              navigate('/complete-profile');
+            }
+          });
         };
         await completeLogin();
         toast.success('Logged In Successfully');
@@ -57,7 +61,7 @@ function GoogleAuth() {
       setIsReadyToRedirect(true);
     };
     loginRedirect();
-  }, [location.search, navigate]);
+  }, [location.search, navigate, signedInAs]);
 
   return (
     <Flex className="naxatw-h-screen-nav naxatw-w-full naxatw-animate-pulse naxatw-items-center naxatw-justify-center">

--- a/src/frontend/src/components/IndividualProject/MapSection/index.tsx
+++ b/src/frontend/src/components/IndividualProject/MapSection/index.tsx
@@ -76,7 +76,7 @@ const MapSection = ({ projectData }: { projectData: Record<string, any> }) => {
       }
     },
     onError: (err: any) => {
-      toast.error(err.message);
+      toast.error(err?.response?.data?.detail || err?.message || '');
     },
   });
 
@@ -90,7 +90,7 @@ const MapSection = ({ projectData }: { projectData: Record<string, any> }) => {
       toast.success('Task Unlocked Successfully');
     },
     onError: (err: any) => {
-      toast.error(err.message);
+      toast.error(err?.response?.data?.detail || err?.message || '');
     },
   });
 

--- a/src/frontend/src/components/common/UserProfile/index.tsx
+++ b/src/frontend/src/components/common/UserProfile/index.tsx
@@ -7,23 +7,17 @@ import { useNavigate } from 'react-router-dom';
 import UserAvatar from '@Components/common/UserAvatar';
 import { toast } from 'react-toastify';
 import { getLocalStorageValue } from '@Utils/getLocalStorageValue';
-import { useGetUserDetailsQuery } from '@Api/projects';
 
 export default function UserProfile() {
   const [toggle, setToggle] = useState(false);
   const navigate = useNavigate();
-
-  const { data: userDetails, isFetching }: Record<string, any> =
-    useGetUserDetailsQuery();
-
   const userProfile = getLocalStorageValue('userprofile');
   const role = localStorage.getItem('signedInAs');
 
   useEffect(() => {
-    if (!userDetails || userDetails?.role?.includes(role) || isFetching) return;
-    if (!userDetails?.has_user_profile || !userDetails?.role?.includes(role))
-      navigate('/complete-profile');
-  }, [userDetails, role, navigate, isFetching]);
+    if (!userProfile || userProfile?.role?.includes(role)) return;
+    navigate('/complete-profile');
+  }, [userProfile, role, navigate]);
 
   const settingOptions = [
     {

--- a/src/frontend/src/modules/user-auth-module/src/components/Authentication/Login/index.tsx
+++ b/src/frontend/src/modules/user-auth-module/src/components/Authentication/Login/index.tsx
@@ -52,7 +52,16 @@ export default function Login() {
       const userDetails = await response2.json();
       const userDetailsString = JSON.stringify(userDetails);
       localStorage.setItem('userprofile', userDetailsString);
-      navigate('/projects');
+
+      // navigate according the user profile completion
+      if (
+        userDetails?.has_user_profile &&
+        userDetails?.role?.includes(signedInAs)
+      ) {
+        navigate('/projects');
+      } else {
+        navigate('/complete-profile');
+      }
     },
     onError: err => {
       toast.error(err.response.data.detail);


### PR DESCRIPTION
## Description
This PR includes the feature to enable user details updation/addition if the user is logged in as a different role.
For example, if the user is already signed in as a Project creator and wants to sign in as a drone pilot, he/she can log in with the same email/user_id but needs to update details related to the drone pilot. So, if he/she logs in as a drone operator for the first time, the system redirects to the complete profile section.

- [x] Show response message on task lock/unlock 
- [x] Save user details on local storage on login and use from local storage wherever needed.