### PR TITLE
Upload GCP along with Drone Images

### DIFF
--- a/src/backend/app/projects/image_processing.py
+++ b/src/backend/app/projects/image_processing.py
@@ -49,7 +49,9 @@ class DroneImageProcessor:
         return opts
 
     def download_object(self, bucket_name: str, obj, images_folder: str):
-        if obj.object_name.endswith((".jpg", ".jpeg", ".JPG", ".png", ".PNG")):
+        if obj.object_name.endswith(
+            (".jpg", ".jpeg", ".JPG", ".png", ".PNG", ".txt")
+        ):  # Images and GCP File
             local_path = Path(images_folder) / Path(obj.object_name).name
             local_path.parent.mkdir(parents=True, exist_ok=True)
             get_file_from_bucket(bucket_name, obj.object_name, local_path)
@@ -86,7 +88,12 @@ class DroneImageProcessor:
         path = Path(directory)
 
         for file in path.rglob("*"):
-            if file.suffix.lower() in {".jpg", ".jpeg", ".png"}:
+            if file.suffix.lower() in {
+                ".jpg",
+                ".jpeg",
+                ".png",
+                ".txt",
+            }:  # Images and GCP File
                 images.append(str(file))
         return images
 

--- a/src/frontend/src/components/DroneOperatorTask/DescriptionSection/UploadsBox/index.tsx
+++ b/src/frontend/src/components/DroneOperatorTask/DescriptionSection/UploadsBox/index.tsx
@@ -6,7 +6,11 @@ import { toggleModal } from '@Store/actions/common';
 import { setFiles } from '@Store/actions/droneOperatorTask';
 import { useTypedDispatch, useTypedSelector } from '@Store/hooks';
 
-const UploadsBox = ({ label = 'Upload Raw Image' }: { label?: string }) => {
+const UploadsBox = ({
+  label = 'Upload Images and GCP',
+}: {
+  label?: string;
+}) => {
   const dispatch = useTypedDispatch();
   const files = useTypedSelector(state => state.droneOperatorTask.files);
   const handleFileChange = (event: any) => {
@@ -34,9 +38,15 @@ const UploadsBox = ({ label = 'Upload Raw Image' }: { label?: string }) => {
             <span className="material-icons-outlined naxatw-text-red">
               cloud_upload
             </span>
-            <p className="naxatw-text-sm">
-              The supported file formats are .jpg, .jpeg, .png
-            </p>
+            <div className="naxatw-flex naxatw-flex-col naxatw-items-center naxatw-text-center">
+              <p className="naxatw-text-sm">
+                The supported file formats are .jpg, .jpeg, .png.
+              </p>
+              <p className="naxatw-text-sm">
+                The GCP file should be named gcp_list.txt
+              </p>
+            </div>
+
             {files.length > 0 && (
               <p className="naxatw-text-sm naxatw-text-green-700">
                 {files.length} items selected

--- a/src/frontend/src/constants/modalContents.tsx
+++ b/src/frontend/src/constants/modalContents.tsx
@@ -36,7 +36,7 @@ export function getModalContent(content: ModalContentsType): ModalReturnType {
     case 'raw-image-preview':
       return {
         className: '!naxatw-w-[95vw] md:!naxatw-w-[60vw]',
-        title: 'Upload Raw Image',
+        title: 'Upload Images and GCP',
         content: <ImageBoxPopOver />,
       };
 


### PR DESCRIPTION
## Feature: Upload GCP File with Drone Images
This pull request introduces a new feature to upload a gcp file. The file should be with the name `gcp_list.txt` and should be within the same folder as the images.
 
The files can be uploaded from this section in the task page.

![Screenshot from 2024-11-19 13-13-07](https://github.com/user-attachments/assets/082d2772-26aa-4996-aa9c-af6cf6eb47e9)
