### PR TITLE
Feat: add regulator emails on projection creation

### DIFF
--- a/src/frontend/src/components/CreateProject/CreateprojectLayout/index.tsx
+++ b/src/frontend/src/components/CreateProject/CreateprojectLayout/index.tsx
@@ -91,6 +91,12 @@ const CreateprojectLayout = () => {
   const imageMergeType = useTypedSelector(
     state => state.createproject.imageMergeType,
   );
+  const requiresApprovalFromRegulator = useTypedSelector(
+    state => state.createproject.requiresApprovalFromRegulator,
+  );
+  const regulatorEmails = useTypedSelector(
+    state => state.createproject.regulatorEmails,
+  );
 
   const initialState: FieldValues = {
     name: '',
@@ -108,6 +114,8 @@ const CreateprojectLayout = () => {
     dem: null,
     requires_approval_from_manager_for_locking: false,
     altitude_from_ground: 0,
+    requires_approval_from_regulator: false,
+    regulator_emails: [],
   };
 
   const {
@@ -214,6 +222,18 @@ const CreateprojectLayout = () => {
 
     if (activeStep === 4 && !splitGeojson) return;
 
+    if (activeStep === 5) {
+      if (requiresApprovalFromRegulator === 'required') {
+        if (regulatorEmails?.length) {
+          setValue('requires_approval_from_regulator', true);
+          setValue('regulator_emails', regulatorEmails);
+        } else {
+          toast.error("Please provide regulator's email");
+          return;
+        }
+      }
+    }
+
     if (activeStep !== 5) {
       dispatch(setCreateProjectState({ activeStep: activeStep + 1 }));
       return;
@@ -239,6 +259,10 @@ const CreateprojectLayout = () => {
         imageMergeType === 'spacing'
           ? getSideOverlap(agl, data?.side_spacing)
           : data?.side_overlap,
+
+      requires_approval_from_regulator:
+        requiresApprovalFromRegulator === 'required',
+      regulator_emails: regulatorEmails,
     };
     delete refactoredData?.forward_spacing;
     delete refactoredData?.side_spacing;
@@ -249,6 +273,8 @@ const CreateprojectLayout = () => {
     delete refactoredData?.dem;
     if (measurementType === 'gsd') delete refactoredData?.altitude_from_ground;
     else delete refactoredData?.gsd_cm_px;
+    if (requiresApprovalFromRegulator !== 'required')
+      delete refactoredData?.regulator_emails;
 
     // make form data with value JSON stringify to combine value on single json / form data with only 2 keys (backend didn't found project_info on non-stringified data)
     const formData = new FormData();

--- a/src/frontend/src/components/CreateProject/FormContents/Contributions/index.tsx
+++ b/src/frontend/src/components/CreateProject/FormContents/Contributions/index.tsx
@@ -4,8 +4,12 @@ import { FormControl, Label, Input } from '@Components/common/FormUI';
 import ErrorMessage from '@Components/common/ErrorMessage';
 import { UseFormPropsType } from '@Components/common/FormUI/types';
 import RadioButton from '@Components/common/RadioButton';
-import { lockApprovalOptions } from '@Constants/createProject';
+import {
+  lockApprovalOptions,
+  regulatorApprovalOptions,
+} from '@Constants/createProject';
 import { setCreateProjectState } from '@Store/actions/createproject';
+import MultipleEmailInput from '@Components/common/MultipleEmailInput';
 // import { contributionsOptions } from '@Constants/createProject';
 
 export default function Conditions({
@@ -17,6 +21,12 @@ export default function Conditions({
   const { register, errors } = formProps;
   const requireApprovalFromManagerForLocking = useTypedSelector(
     state => state.createproject.requireApprovalFromManagerForLocking,
+  );
+  const requiresApprovalFromRegulator = useTypedSelector(
+    state => state.createproject.requiresApprovalFromRegulator,
+  );
+  const regulatorEmails = useTypedSelector(
+    state => state.createproject.regulatorEmails,
   );
 
   return (
@@ -58,6 +68,37 @@ export default function Conditions({
         </div>
         <ErrorMessage message={errors?.deadline_at?.message as string} />
       </FormControl>
+
+      <FormControl>
+        <RadioButton
+          required
+          topic="Approval from Regulator"
+          options={regulatorApprovalOptions}
+          direction="column"
+          onChangeData={value => {
+            dispatch(
+              setCreateProjectState({
+                requiresApprovalFromRegulator: value,
+              }),
+            );
+          }}
+          value={requiresApprovalFromRegulator}
+        />
+      </FormControl>
+
+      {requiresApprovalFromRegulator === 'required' && (
+        <FormControl className="naxatw-gap-2">
+          <Label required>Approval Email</Label>
+          <MultipleEmailInput
+            emails={regulatorEmails}
+            onEmailAdd={emails => {
+              dispatch(setCreateProjectState({ regulatorEmails: emails }));
+            }}
+          />
+          <ErrorMessage message={errors?.regulator_emails?.message as string} />
+        </FormControl>
+      )}
+
       <FormControl>
         <RadioButton
           required

--- a/src/frontend/src/components/common/MultipleEmailInput/index.tsx
+++ b/src/frontend/src/components/common/MultipleEmailInput/index.tsx
@@ -1,0 +1,99 @@
+import { FormEvent, KeyboardEvent, useState } from 'react';
+import { FormControl, Input } from '../FormUI';
+import ErrorMessage from '../FormUI/ErrorMessage';
+import { FlexRow } from '../Layouts';
+
+interface IMultipleEmailInput {
+  emails: string[] | [];
+  // eslint-disable-next-line no-unused-vars
+  onEmailAdd: (emails: string[]) => void;
+}
+
+const MultipleEmailInput = ({ emails, onEmailAdd }: IMultipleEmailInput) => {
+  const [inputEmail, setInputEmail] = useState('');
+  const [emailList, setEmailList] = useState(emails || []);
+  const [error, setError] = useState('');
+
+  const handleChange = (e: FormEvent<HTMLInputElement>) => {
+    setInputEmail(e.currentTarget.value?.trim());
+    setError('');
+  };
+
+  const addInputEmailOnList = () => {
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/?.test(inputEmail))
+      return setError('Email is invalid');
+    if (emailList?.find(email => email === inputEmail))
+      return setError('Email already exists on list');
+    setInputEmail('');
+    const newEmailList = [...emailList, inputEmail];
+
+    setEmailList(prev => {
+      const newList = [...prev, inputEmail];
+      onEmailAdd(newList);
+      return newList;
+    });
+    onEmailAdd(newEmailList);
+    return () => {};
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      addInputEmailOnList();
+    }
+    return () => {};
+  };
+
+  const handleDeleteEmail = (email: string) => {
+    setEmailList(prev => {
+      const newList = prev?.filter(prevEmail => prevEmail !== email);
+      onEmailAdd(newList);
+      return newList;
+    });
+  };
+
+  return (
+    <FormControl className="naxatw-relative">
+      <Input
+        placeholder="Enter email and press enter or click  '+'  icon to add"
+        onChange={handleChange}
+        value={inputEmail}
+        onKeyDown={handleKeyDown}
+      />
+
+      <i
+        className="material-icons naxatw-absolute naxatw-right-2 naxatw-top-[6px] naxatw-z-30 naxatw-cursor-pointer naxatw-rounded-full naxatw-text-red hover:naxatw-bg-redlight"
+        onClick={() => addInputEmailOnList()}
+        role="button"
+        tabIndex={0}
+        onKeyDown={() => {}}
+      >
+        add
+      </i>
+
+      <ErrorMessage message={error} />
+      <FlexRow gap={2} className="naxatw-flex-wrap">
+        {emailList?.map((email: string) => (
+          <div
+            key={email}
+            className="naxatw-flex naxatw-w-fit naxatw-items-center naxatw-gap-1 naxatw-rounded-xl naxatw-border naxatw-border-black naxatw-bg-gray-50 naxatw-px-2 naxatw-py-0.5"
+          >
+            <div className="naxatw-flex naxatw-items-center naxatw-text-sm naxatw-leading-4">
+              {email}
+            </div>
+            <i
+              className="material-icons naxatw-cursor-pointer naxatw-rounded-full naxatw-text-center naxatw-text-base hover:naxatw-bg-redlight"
+              tabIndex={0}
+              role="button"
+              onKeyDown={() => {}}
+              onClick={() => handleDeleteEmail(email)}
+            >
+              close
+            </i>
+          </div>
+        ))}
+      </FlexRow>
+    </FormControl>
+  );
+};
+
+export default MultipleEmailInput;

--- a/src/frontend/src/constants/createProject.tsx
+++ b/src/frontend/src/constants/createProject.tsx
@@ -160,6 +160,15 @@ export const lockApprovalOptions = [
   { name: 'Not Required', label: 'Not Required', value: 'not_required' },
 ];
 
+export const regulatorApprovalOptions = [
+  { name: 'regulator approval Required', label: 'Required', value: 'required' },
+  {
+    name: 'regulator approval not Required',
+    label: 'Not Required',
+    value: 'not_required',
+  },
+];
+
 export const FinalOutputOptions = [
   { label: '2D Orthophoto', value: 'ORTHOPHOTO_2D', icon: orthoPhotoIcon },
   // { label: '3D Model', value: 'ORTHOPHOTO_3D', icon: _3DModal },

--- a/src/frontend/src/store/slices/createproject.ts
+++ b/src/frontend/src/store/slices/createproject.ts
@@ -24,6 +24,8 @@ export interface CreateProjectState {
   projectMapImage: any;
   imageMergeType: string;
   ProjectsFilterByOwner: 'yes' | 'no';
+  requiresApprovalFromRegulator: 'required' | 'not_required';
+  regulatorEmails: string[] | [];
 }
 
 const initialState: CreateProjectState = {
@@ -47,6 +49,8 @@ const initialState: CreateProjectState = {
   projectMapImage: null,
   imageMergeType: 'overlap',
   ProjectsFilterByOwner: 'no',
+  requiresApprovalFromRegulator: 'not_required',
+  regulatorEmails: [],
 };
 
 const setCreateProjectState: CaseReducer<


### PR DESCRIPTION
## Description
This PR introduces a new input field for a Regulator Email during the project creation process. The field allows users to specify the email of the regulatory body or responsible party associated with the project.

Screenshot of UI:
![Screenshot from 2024-11-20 09-20-10](https://github.com/user-attachments/assets/3fcee375-fa69-4114-8f0f-7bcfb029216c)
