### PR TITLE
refactor(frontend): reset takeoff point location, incase of errors

### DIFF
--- a/src/frontend/src/components/DroneOperatorTask/MapSection/index.tsx
+++ b/src/frontend/src/components/DroneOperatorTask/MapSection/index.tsx
@@ -88,6 +88,7 @@ const MapSection = ({ className }: { className?: string }) => {
       },
       onError: (err: any) => {
         toast.error(err?.response?.data?.detail || err.message);
+        dispatch(setSelectedTakeOffPoint(null));
       },
     });
 


### PR DESCRIPTION
…not valid

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [X] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Example: Fixes #123

## Describe this PR

- Reset state of takeoff location point if the location point is invalid. So that user can select takeoff point again

## Screenshots

![image](https://github.com/user-attachments/assets/ecfb7816-3b82-40f1-9a00-43e22efe556b)

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
