### PR TITLE
fix: ensure small areas merge with the nearest one in task splitting

### DIFF
--- a/src/backend/app/tasks/task_splitter.py
+++ b/src/backend/app/tasks/task_splitter.py
@@ -177,13 +177,13 @@ class TaskSplitter(object):
                     # Merge the small polygon with the nearest large polygon
                     merged_polygon = unary_union([small_polygon, nearest_polygon])
 
-                    if merged_polygon.geom_type == "MultiPolygon":
-                        # Handle MultiPolygon by adding the original small polygon back
-                        log.warning(
-                            "Found MultiPolygon, adding original small polygon..."
-                        )
-                        polygons.append(small_polygon)
-                        break
+                    # if merged_polygon.geom_type == "MultiPolygon":
+                    #     # Handle MultiPolygon by adding the original small polygon back
+                    #     log.warning(
+                    #         "Found MultiPolygon, adding original small polygon..."
+                    #     )
+                    #     polygons.append(small_polygon)
+                    #     break
 
                     # Remove both the small polygon and the nearest large polygon
                     polygons.remove(nearest_polygon)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR
- Resolved issue where very small areas were not merging with their nearest neighbor during task splitting.  

## Screenshots
- Before:
![image (1)](https://github.com/user-attachments/assets/30e192fa-d338-4cdd-9b81-2ebb1067c34a)

- After:
![Screenshot from 2024-12-03 09-48-11](https://github.com/user-attachments/assets/8ed34410-be5d-46e9-a8d5-20bd9f702868)


Please provide screenshots of the change.

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
