### PR TITLE
hot-fix: ignore ts for animate presence of framer-motion

### DIFF
--- a/src/frontend/src/views/LandingPage/index.tsx
+++ b/src/frontend/src/views/LandingPage/index.tsx
@@ -20,6 +20,7 @@ export default function LandingPage() {
   return (
     <main className="landing-page naxatw-font-secondary">
       <Navbar />
+      {/* @ts-ignore */}
       <AnimatePresence>{openSignInMenu && <SignInOverlay />}</AnimatePresence>
       <Home />
       <AboutTM />


### PR DESCRIPTION
Ignore ts for AnimatePresence, cause it caused `AnimatePresence cannot be used as a JSX component` issue on build.