### PR TITLE
Feat/Visualize task's and overall project orthophoto, options to start  processing without GCP  and other relative changes 

### DIFF
--- a/src/backend/app/s3.py
+++ b/src/backend/app/s3.py
@@ -241,7 +241,9 @@ def get_assets_url_for_project(project_id: str):
 
 def get_orthophoto_url_for_project(project_id: str):
     """Get the orthophoto URL for a project."""
-    project_orthophoto_path = f"dtm-data/projects/{project_id}/orthophoto/odm_orthophoto.tif"
+    project_orthophoto_path = (
+        f"dtm-data/projects/{project_id}/orthophoto/odm_orthophoto.tif"
+    )
     s3_download_root = settings.S3_DOWNLOAD_ROOT
     if s3_download_root:
         return urljoin(s3_download_root, project_orthophoto_path)

--- a/src/frontend/src/components/IndividualProject/GcpEditor/index.tsx
+++ b/src/frontend/src/components/IndividualProject/GcpEditor/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, createElement } from 'react';
+import { useEffect, createElement, useRef } from 'react';
 import '@hotosm/gcp-editor';
 import '@hotosm/gcp-editor/style.css';
 import { useDispatch } from 'react-redux';
@@ -13,6 +13,7 @@ const GcpEditor = ({
   //   handleProcessingStart,
   rawImageUrl,
 }: any) => {
+  const triggeredEvent = useRef(false);
   const { id } = useParams();
   const dispatch = useDispatch();
   const CUSTOM_EVENT: any = 'start-processing-click';
@@ -33,15 +34,23 @@ const GcpEditor = ({
     startImageProcessing({ projectId: id, gcp_file: gcpFile });
   };
 
+  const handleProcessingStart = (data: any) => {
+    if (triggeredEvent.current) return;
+    startProcessing(data);
+    triggeredEvent.current = true;
+  };
+
   useEffect(() => {
     document.addEventListener(
       CUSTOM_EVENT,
-      data => {
-        startProcessing(data);
-      },
+      handleProcessingStart,
       // When we use the {once: true} option when adding an event listener, the listener will be invoked at most once and immediately removed as soon as the event is invoked.
       { once: true },
     );
+
+    return () => {
+      document.removeEventListener(CUSTOM_EVENT, handleProcessingStart);
+    };
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [CUSTOM_EVENT, dispatch]);

--- a/src/frontend/src/components/IndividualProject/GcpEditor/index.tsx
+++ b/src/frontend/src/components/IndividualProject/GcpEditor/index.tsx
@@ -6,6 +6,7 @@ import { setProjectState } from '@Store/actions/project';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { processAllImagery } from '@Services/project';
 import { useParams } from 'react-router-dom';
+import { toast } from 'react-toastify';
 
 const GcpEditor = ({
   cogUrl,
@@ -24,6 +25,7 @@ const GcpEditor = ({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['project-detail'] });
       dispatch(setProjectState({ showGcpEditor: false }));
+      toast.success('Processing started');
     },
   });
 

--- a/src/frontend/src/components/IndividualProject/MapSection/index.tsx
+++ b/src/frontend/src/components/IndividualProject/MapSection/index.tsx
@@ -19,10 +19,13 @@ import { useTypedDispatch, useTypedSelector } from '@Store/hooks';
 import { useMutation } from '@tanstack/react-query';
 import getBbox from '@turf/bbox';
 import hasErrorBoundary from '@Utils/hasErrorBoundary';
+import COGOrthophotoViewer from '@Components/common/MapLibreComponents/COGOrthophotoViewer';
 import {
   getLayerOptionsByStatus,
   showPrimaryButton,
 } from '@Constants/projectDescription';
+import { Button } from '@Components/RadixComponents/Button';
+import ToolTip from '@Components/RadixComponents/ToolTip';
 import Legend from './Legend';
 
 const MapSection = ({ projectData }: { projectData: Record<string, any> }) => {
@@ -36,6 +39,9 @@ const MapSection = ({ projectData }: { projectData: Record<string, any> }) => {
   const [lockedUser, setLockedUser] = useState<Record<string, any> | null>(
     null,
   );
+
+  // eslint-disable-next-line no-unused-vars
+  const [showOverallOrthophoto, setShowOverallOrthophoto] = useState(false);
   const { data: userDetails }: Record<string, any> = useGetUserDetailsQuery();
 
   const { map, isMapLoaded } = useMapLibreGLMap({
@@ -55,6 +61,10 @@ const MapSection = ({ projectData }: { projectData: Record<string, any> }) => {
   const taskClickedOnTable = useTypedSelector(
     state => state.project.taskClickedOnTable,
   );
+  const visibleTaskOrthophoto = useTypedSelector(
+    state => state.project.visibleOrthophotoList,
+  );
+
   const { data: taskStates } = useGetTaskStatesQuery(id as string, {
     enabled: !!tasksData,
   });
@@ -182,6 +192,15 @@ const MapSection = ({ projectData }: { projectData: Record<string, any> }) => {
     });
   };
 
+  // const handleToggleOverallOrthophoto = () => {
+  //   map?.setLayoutProperty(
+  //     'task-orthophoto',
+  //     'visibility',
+  //     showOverallOrthophoto ? 'none' : 'visible',
+  //   );
+  //   setShowOverallOrthophoto(!showOverallOrthophoto);
+  // };
+
   return (
     <MapContainer
       map={map}
@@ -257,6 +276,45 @@ const MapSection = ({ projectData }: { projectData: Record<string, any> }) => {
             />
           );
         })}
+
+      {/* visualize tasks orthophoto */}
+      {visibleTaskOrthophoto?.map(orthophotoDetails => (
+        <COGOrthophotoViewer
+          key={orthophotoDetails.taskId}
+          id={orthophotoDetails.taskId}
+          source={orthophotoDetails.source}
+          visibleOnMap
+        />
+      ))}
+      {/* visualize tasks orthophoto end */}
+
+      {/* visualize overall project orthophoto */}
+      {/* {visibleTaskOrthophoto?.map(orthophotoDetails => (
+        <COGOrthophotoViewer
+          key={orthophotoDetails.taskId}
+          id={orthophotoDetails.taskId}
+          source={orthophotoDetails.source}
+          visibleOnMap
+        />
+      ))} */}
+      {/* visualize tasks orthophoto end */}
+
+      {/* additional controls */}
+      <div className="naxatw-absolute naxatw-left-[0.575rem] naxatw-top-[5.75rem] naxatw-z-30 naxatw-flex naxatw-h-fit naxatw-w-fit naxatw-flex-col naxatw-gap-3">
+        <Button
+          variant="ghost"
+          className={`naxatw-grid naxatw-h-[1.85rem] naxatw-place-items-center naxatw-border !naxatw-px-[0.315rem] ${showOverallOrthophoto ? 'naxatw-border-red naxatw-bg-[#ffe0e0]' : 'naxatw-border-gray-400 naxatw-bg-[#F5F5F5]'}`}
+          onClick={() => {}}
+        >
+          <ToolTip
+            name="visibility"
+            message="Show Orthophoto"
+            symbolType="material-icons"
+            iconClassName="!naxatw-text-xl !naxatw-text-black"
+            className="naxatw-mt-[-4px]"
+          />
+        </Button>
+      </div>
 
       <AsyncPopup
         map={map as Map}

--- a/src/frontend/src/components/IndividualProject/MapSection/index.tsx
+++ b/src/frontend/src/components/IndividualProject/MapSection/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-nested-ternary */
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { LngLatBoundsLike, Map } from 'maplibre-gl';
+import { LngLatBoundsLike, Map, RasterSourceSpecification } from 'maplibre-gl';
 import { FeatureCollection } from 'geojson';
 import { toast } from 'react-toastify';
 import { useGetTaskStatesQuery, useGetUserDetailsQuery } from '@Api/projects';
@@ -40,7 +40,6 @@ const MapSection = ({ projectData }: { projectData: Record<string, any> }) => {
     null,
   );
 
-  // eslint-disable-next-line no-unused-vars
   const [showOverallOrthophoto, setShowOverallOrthophoto] = useState(false);
   const { data: userDetails }: Record<string, any> = useGetUserDetailsQuery();
 
@@ -176,6 +175,15 @@ const MapSection = ({ projectData }: { projectData: Record<string, any> }) => {
     [taskStatusObj, userDetails, projectData],
   );
 
+  const projectOrthophotoSource: RasterSourceSpecification = useMemo(
+    () => ({
+      type: 'raster',
+      url: `cog://${projectData?.orthophoto_url}`,
+      tileSize: 256,
+    }),
+    [projectData?.orthophoto_url],
+  );
+
   const handleTaskLockClick = () => {
     lockTask({
       projectId: id,
@@ -192,14 +200,14 @@ const MapSection = ({ projectData }: { projectData: Record<string, any> }) => {
     });
   };
 
-  // const handleToggleOverallOrthophoto = () => {
-  //   map?.setLayoutProperty(
-  //     'task-orthophoto',
-  //     'visibility',
-  //     showOverallOrthophoto ? 'none' : 'visible',
-  //   );
-  //   setShowOverallOrthophoto(!showOverallOrthophoto);
-  // };
+  const handleToggleOverallOrthophoto = () => {
+    map?.setLayoutProperty(
+      'project-orthophoto',
+      'visibility',
+      showOverallOrthophoto ? 'none' : 'visible',
+    );
+    setShowOverallOrthophoto(!showOverallOrthophoto);
+  };
 
   return (
     <MapContainer
@@ -289,32 +297,34 @@ const MapSection = ({ projectData }: { projectData: Record<string, any> }) => {
       {/* visualize tasks orthophoto end */}
 
       {/* visualize overall project orthophoto */}
-      {/* {visibleTaskOrthophoto?.map(orthophotoDetails => (
+      {projectData?.orthophoto_url && (
         <COGOrthophotoViewer
-          key={orthophotoDetails.taskId}
-          id={orthophotoDetails.taskId}
-          source={orthophotoDetails.source}
+          id="project-orthophoto"
+          source={projectOrthophotoSource}
           visibleOnMap
         />
-      ))} */}
+      )}
       {/* visualize tasks orthophoto end */}
 
       {/* additional controls */}
       <div className="naxatw-absolute naxatw-left-[0.575rem] naxatw-top-[5.75rem] naxatw-z-30 naxatw-flex naxatw-h-fit naxatw-w-fit naxatw-flex-col naxatw-gap-3">
-        <Button
-          variant="ghost"
-          className={`naxatw-grid naxatw-h-[1.85rem] naxatw-place-items-center naxatw-border !naxatw-px-[0.315rem] ${showOverallOrthophoto ? 'naxatw-border-red naxatw-bg-[#ffe0e0]' : 'naxatw-border-gray-400 naxatw-bg-[#F5F5F5]'}`}
-          onClick={() => {}}
-        >
-          <ToolTip
-            name="visibility"
-            message="Show Orthophoto"
-            symbolType="material-icons"
-            iconClassName="!naxatw-text-xl !naxatw-text-black"
-            className="naxatw-mt-[-4px]"
-          />
-        </Button>
+        {projectData?.orthophoto_url && (
+          <Button
+            variant="ghost"
+            className={`naxatw-grid naxatw-h-[1.85rem] naxatw-place-items-center naxatw-border !naxatw-px-[0.315rem] ${showOverallOrthophoto ? 'naxatw-border-red naxatw-bg-[#ffe0e0]' : 'naxatw-border-gray-400 naxatw-bg-[#F5F5F5]'}`}
+            onClick={() => handleToggleOverallOrthophoto()}
+          >
+            <ToolTip
+              name="visibility"
+              message="Show Orthophoto"
+              symbolType="material-icons"
+              iconClassName="!naxatw-text-xl !naxatw-text-black"
+              className="naxatw-mt-[-4px]"
+            />
+          </Button>
+        )}
       </div>
+      {/*  additional controls */}
 
       <AsyncPopup
         map={map as Map}

--- a/src/frontend/src/components/IndividualProject/ModalContent/ChooseProcessingParameter.tsx
+++ b/src/frontend/src/components/IndividualProject/ModalContent/ChooseProcessingParameter.tsx
@@ -7,6 +7,7 @@ import { setProjectState } from '@Store/actions/project';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { toast } from 'react-toastify';
 
 const ChooseProcessingParameter = () => {
   const dispatch = useDispatch();
@@ -19,7 +20,7 @@ const ChooseProcessingParameter = () => {
     mutationFn: processAllImagery,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['project-detail'] });
-      dispatch(setProjectState({ showGcpEditor: false }));
+      toast.success('Processing started');
     },
   });
 

--- a/src/frontend/src/components/IndividualProject/ModalContent/ChooseProcessingParameter.tsx
+++ b/src/frontend/src/components/IndividualProject/ModalContent/ChooseProcessingParameter.tsx
@@ -1,0 +1,60 @@
+import RadioButton from '@Components/common/RadioButton';
+import { Button } from '@Components/RadixComponents/Button';
+import { startProcessingOptions } from '@Constants/projectDescription';
+import { processAllImagery } from '@Services/project';
+import { toggleModal } from '@Store/actions/common';
+import { setProjectState } from '@Store/actions/project';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useDispatch } from 'react-redux';
+
+const ChooseProcessingParameter = () => {
+  const dispatch = useDispatch();
+  const queryClient = useQueryClient();
+  const pathname = window.location.pathname?.split('/');
+  const projectId = pathname?.[2];
+
+  const [value, setValue] = useState('with_gcp');
+  const { mutate: startImageProcessing } = useMutation({
+    mutationFn: processAllImagery,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['project-detail'] });
+      dispatch(setProjectState({ showGcpEditor: false }));
+    },
+  });
+
+  return (
+    <div>
+      <p className="naxatw-text-sm naxatw-text-[#7A7676]">
+        Choose Processing Parameter
+      </p>
+      <div className="naxatw-py-1 naxatw-text-gray-700">
+        <RadioButton
+          className="!naxatw-text-black"
+          options={startProcessingOptions}
+          direction="column"
+          onChangeData={selectedValue => setValue(selectedValue)}
+          value={value}
+        />
+      </div>
+      <div className="naxatw naxatw-flex naxatw-justify-center naxatw-pt-3">
+        <Button
+          withLoader
+          className="naxatw-bg-red"
+          onClick={() => {
+            if (value === 'with_gcp') {
+              dispatch(setProjectState({ showGcpEditor: true }));
+            } else {
+              startImageProcessing({ projectId });
+            }
+            dispatch(toggleModal());
+          }}
+        >
+          Proceed
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default ChooseProcessingParameter;

--- a/src/frontend/src/components/RegulatorsApprovalPage/Description/DescriptionSection.tsx
+++ b/src/frontend/src/components/RegulatorsApprovalPage/Description/DescriptionSection.tsx
@@ -1,6 +1,7 @@
+/* eslint-disable no-nested-ternary */
 import { useDispatch } from 'react-redux';
 import { Button } from '@Components/RadixComponents/Button';
-import { setProjectState } from '@Store/actions/project';
+import { toggleModal } from '@Store/actions/common';
 import ApprovalSection from './ApprovalSection';
 
 const DescriptionSection = ({
@@ -68,18 +69,47 @@ const DescriptionSection = ({
         </div>
       </div>
       {page !== 'project-approval' &&
-        projectData?.image_processing_status !== 'SUCCESS' && (
-          <div>
-            <Button
-              className="naxatw-bg-red"
-              onClick={() => {
-                dispatch(setProjectState({ showGcpEditor: true }));
-              }}
-            >
-              Start Processing
-            </Button>
-          </div>
-        )}
+      projectData?.image_processing_status === 'NOT_STARTED' ? (
+        <div>
+          <Button
+            className="naxatw-bg-red"
+            withLoader
+            leftIcon="play_arrow"
+            onClick={() => {
+              dispatch(toggleModal('choose-processing-parameter'));
+            }}
+          >
+            Start Processing
+          </Button>
+        </div>
+      ) : projectData?.image_processing_status === 'SUCCESS' ? (
+        <></>
+      ) : projectData?.image_processing_status === 'PROCESSING' ? (
+        <div>
+          <Button
+            className="naxatw-bg-gray-500"
+            withLoader
+            isLoading
+            onClick={() => {}}
+          >
+            Processing
+          </Button>
+        </div>
+      ) : (
+        <div>
+          <Button
+            className="naxatw-bg-red"
+            withLoader
+            leftIcon="replay"
+            onClick={() => {
+              dispatch(toggleModal('choose-processing-parameter'));
+            }}
+          >
+            Re-start Processing
+          </Button>
+        </div>
+      )}
+
       {page === 'project-approval' &&
         projectData?.regulator_approval_status === 'PENDING' && (
           <ApprovalSection />

--- a/src/frontend/src/components/common/Breadcrumb/index.tsx
+++ b/src/frontend/src/components/common/Breadcrumb/index.tsx
@@ -16,6 +16,7 @@ const BreadCrumb = ({ data }: IBreadCrumbProps) => {
       {data.map((breadCrumbItem, index) => (
         <>
           <div
+            key={breadCrumbItem.name}
             onClick={() =>
               index < data.length - 1
                 ? navigate(breadCrumbItem.navLink)

--- a/src/frontend/src/components/common/MapLibreComponents/COGOrthophotoViewer/index.tsx
+++ b/src/frontend/src/components/common/MapLibreComponents/COGOrthophotoViewer/index.tsx
@@ -52,8 +52,8 @@ const COGOrthophotoViewer = ({
     // eslint-disable-next-line consistent-return
     return () => {
       if (map?.getSource(id)) {
-        map?.removeSource(id);
         if (map?.getLayer(id)) map?.removeLayer(id);
+        map?.removeSource(id);
         map.off('idle', handleZoomToGeoTiff);
       }
     };

--- a/src/frontend/src/constants/modalContents.tsx
+++ b/src/frontend/src/constants/modalContents.tsx
@@ -4,6 +4,7 @@ import ImageBoxPopOver from '@Components/DroneOperatorTask/DescriptionSection/Po
 import ImageMapBox from '@Components/DroneOperatorTask/DescriptionSection/PopoverBox/MapBox';
 import ChooseTakeOffPointOptions from '@Components/DroneOperatorTask/ModalContent/ChooseTakeOffPointOptions';
 import TaskOrthophotoPreview from '@Components/DroneOperatorTask/ModalContent/TaskOrthophotoPreview';
+import ChooseProcessingParameter from '@Components/IndividualProject/ModalContent/ChooseProcessingParameter';
 import { ReactElement } from 'react';
 
 export type ModalContentsType =
@@ -14,6 +15,7 @@ export type ModalContentsType =
   | 'update-flight-take-off-point'
   | 'task-ortho-photo-preview'
   | 'document-preview'
+  | 'choose-processing-parameter'
   | null;
 export type PromptDialogContentsType = 'delete-layer' | null;
 
@@ -35,6 +37,12 @@ export function getModalContent(content: ModalContentsType): ModalReturnType {
       return {
         title: 'Unsaved Changes!',
         content: <ExitCreateProjectModal />,
+      };
+    case 'choose-processing-parameter':
+      return {
+        className: 'naxatw-w-[92vw] naxatw-max-w-[25rem]',
+        title: 'Start Processing',
+        content: <ChooseProcessingParameter />,
       };
 
     case 'raw-image-preview':

--- a/src/frontend/src/constants/projectDescription.ts
+++ b/src/frontend/src/constants/projectDescription.ts
@@ -106,3 +106,16 @@ export const showPrimaryButton = (
       return false;
   }
 };
+
+export const startProcessingOptions = [
+  {
+    label: 'Start Processing with GCP',
+    value: 'with_gcp',
+    name: 'start_processing',
+  },
+  {
+    label: 'Start Processing without GCP',
+    value: 'without_gcp',
+    name: 'start_processing',
+  },
+];

--- a/src/frontend/src/services/project.ts
+++ b/src/frontend/src/services/project.ts
@@ -15,12 +15,12 @@ export const getRequestedTasks = () =>
   authenticated(api).get('/tasks/requested_tasks/pending');
 
 export const processAllImagery = (data: Record<string, any>) => {
-  const { projectId, gcp_file } = data;
-  return authenticated(api).post(
-    `/projects/process_all_imagery/${projectId}/`,
-    { gcp_file },
-  );
+  const { projectId } = data;
+  if (data?.gcp_file) {
+    return authenticated(api).post(
+      `/projects/process_all_imagery/${projectId}/`,
+      { gcp_file: data.gcp_file },
+    );
+  }
+  return authenticated(api).post(`/projects/process_all_imagery/${projectId}/`);
 };
-
-// export const getAllAssetsUrl = (projectId: string) =>
-//   authenticated(api).get(`/projects/assets/${projectId}/`);

--- a/src/frontend/src/store/slices/project.ts
+++ b/src/frontend/src/store/slices/project.ts
@@ -10,6 +10,7 @@ export interface ProjectState {
   taskClickedOnTable: Record<string, any> | null;
   showGcpEditor: boolean;
   gcpData: any;
+  visibleOrthophotoList: Record<string, any>[];
 }
 
 const initialState: ProjectState = {
@@ -20,6 +21,7 @@ const initialState: ProjectState = {
   taskClickedOnTable: null,
   showGcpEditor: false,
   gcpData: null,
+  visibleOrthophotoList: [],
 };
 
 const setProjectState: CaseReducer<


### PR DESCRIPTION
- [x] Visualize the overall project orthophoto
- [x] Visualize each task orthophoto
- [x] Add options to start processing (with and without GCP)
- [x] Show overall project processing status
- [x] Toggle each task visibility from the respective table row
- [x] Add overall orthophoto visibility toggle functionality 
- [x] Minor issue fixes 