### PR TITLE
Fix Permission Issue for Task State Change by Project Creator

### DIFF
--- a/src/backend/app/tasks/task_logic.py
+++ b/src/backend/app/tasks/task_logic.py
@@ -605,7 +605,8 @@ async def handle_event(
                     detail="Task state does not match expected state for image upload.",
                 )
 
-            if user_id != locked_user_id:
+            is_author = project["author_id"] == user_id
+            if not is_author and user_id != locked_user_id:
                 raise HTTPException(
                     status_code=403,
                     detail="You cannot upload an image for this task as it is locked by another user.",


### PR DESCRIPTION
## Description  
Previously, the project creator was unable to change the state of a task if another user had locked it due to a permission issue. This has now been fixed by adding a check to allow the project creator to unlock the task unless it is locked by another user.  

## Changes  
- Added a condition to verify if the user is the project creator.  
- If the user is neither the project creator nor the one who locked the task, a `403 Forbidden` error is raised.  

## Code Added  
```python
is_author = project["author_id"] == user_id
if not is_author and user_id != locked_user_id:
    raise HTTPException(
        status_code=403,
        detail="You cannot unlock this task as it is locked by another user.",
    )