### PR TITLE
Add toggle to select drone type for flightplan generation & fix drone param calcs

### DIFF
--- a/src/backend/packages/drone-flightplan/README.md
+++ b/src/backend/packages/drone-flightplan/README.md
@@ -77,18 +77,18 @@ calculate_parameters(
 **Fixed Parameters:**
 
 - `Image interval` = 2 sec
-- `Vertical FOV` = 0.71
-- `Horizontal FOV` = 1.26
+- `Vertical FOV` = 0.99
+- `Horizontal FOV` = 1.25
 
 **Calculations:**
 
-- Forward Photo height = AGL _Vertical_FOV = 115_ 0.71 = 81.65
-- Side Photo width = AGL _Horizontal_FOV = 115_ 1.26 = 144
-- Forward overlap distance = Forward photo height _Forward overlap = 75 / 100_ 81.65 = 61.5
-- Side overlap distance = Side photo width _Side overlap = 75 / 100_ 144 = 108
-- Forward spacing = Forward photo height - Forward overlap distance = 81.65 - 61.5 = 20.15
-- Side spacing = Side photo width - Side overlap distance = 144 - 108 = 36
-- Ground speed = Forward spacing / Image interval = 10
+- Forward Photo height = AGL \_Vertical_FOV
+- Side Photo width = AGL \_Horizontal_FOV
+- Forward overlap distance = Forward photo height \_Forward overlap
+- Side overlap distance = Side photo width \_Side overlap
+- Forward spacing = Forward photo height - Forward overlap distance
+- Side spacing = Side photo width - Side overlap distance
+- Ground speed = Forward spacing / Image interval
 
 **Parameters:**
 

--- a/src/frontend/src/api/tasks.ts
+++ b/src/frontend/src/api/tasks.ts
@@ -10,13 +10,14 @@ export const useGetTaskWaypointQuery = (
   projectId: string,
   taskId: string,
   mode: string,
+  droneModel: string,
   rotationAngle: number,
   queryOptions?: Partial<UseQueryOptions>,
 ) => {
   return useQuery({
-    queryKey: ['task-waypoints', mode, rotationAngle],
+    queryKey: ['task-waypoints', mode, droneModel, rotationAngle],
     enabled: !!(projectId && taskId),
-    queryFn: () => getTaskWaypoint(projectId, taskId, mode, rotationAngle),
+    queryFn: () => getTaskWaypoint(projectId, taskId, mode, droneModel, rotationAngle),
     select: (res: any) => res.data,
     ...queryOptions,
   });

--- a/src/frontend/src/components/DroneOperatorTask/MapSection/MapSection.tsx
+++ b/src/frontend/src/components/DroneOperatorTask/MapSection/MapSection.tsx
@@ -24,7 +24,7 @@ import { postTaskWaypoint } from '@Services/tasks';
 import { useMapLibreGLMap } from '@Components/common/MapLibreComponents';
 import { GeojsonType } from '@Components/common/MapLibreComponents/types';
 import BaseLayerSwitcherUI from '@Components/common/BaseLayerSwitcher';
-import { waypointModeOptions } from '@Constants/taskDescription';
+import { waypointModeOptions, droneModelOptions } from '@Constants/taskDescription';
 import {
   setRotationAngle as setFinalRotationAngle,
   setRotatedFlightPlan,
@@ -33,6 +33,7 @@ import {
   setTaskAreaPolygon,
   setTaskAssetsInformation,
   setWaypointMode,
+  setDroneModel,
 } from '@Store/actions/droneOperatorTask';
 import rotateGeoJSON from '@Utils/rotateGeojsonData';
 import { findNearestCoordinate, swapFirstAndLast } from '@Utils/index';
@@ -78,6 +79,9 @@ const MapSection = ({ className }: { className?: string }) => {
   const waypointMode = useTypedSelector(
     state => state.droneOperatorTask.waypointMode,
   );
+  const droneModel = useTypedSelector(
+    state => state.droneOperatorTask.droneModel,
+  );
   const newTakeOffPoint = useTypedSelector(
     state => state.droneOperatorTask.selectedTakeOffPoint,
   );
@@ -115,6 +119,7 @@ const MapSection = ({ className }: { className?: string }) => {
       projectId as string,
       taskId as string,
       waypointMode as string,
+      droneModel as string,
       finalRotationAngle,
       {
         select: ({ data }: any) => {
@@ -135,6 +140,7 @@ const MapSection = ({ className }: { className?: string }) => {
               ],
             },
           };
+
           takeOffPointRef.current =
             modifiedTaskWayPointsData?.geojsonListOfPoint?.features[0]?.geometry?.coordinates;
           return modifiedTaskWayPointsData;
@@ -832,7 +838,18 @@ const MapSection = ({ className }: { className?: string }) => {
           getCoordOnProperties
         />
 
-        <div className="naxatw-absolute naxatw-right-3 naxatw-top-3 naxatw-z-10 lg:naxatw-right-64">
+        <div className="naxatw-absolute naxatw-top-3 naxatw-right-3 lg:naxatw-right-64 naxatw-z-10 flex gap-3 lg:gap-6">
+          <SwitchTab
+            activeClassName="naxatw-bg-red naxatw-text-white"
+            options={droneModelOptions}
+            labelKey="label"
+            valueKey="value"
+            selectedValue={droneModel}
+            onChange={(value: Record<string, any>) => {
+              dispatch(setDroneModel(value.value));
+            }}
+          />
+
           <SwitchTab
             activeClassName="naxatw-bg-red naxatw-text-white"
             options={waypointModeOptions}
@@ -844,6 +861,7 @@ const MapSection = ({ className }: { className?: string }) => {
             }}
           />
         </div>
+
         {/* additional controls */}
         <div className="naxatw-absolute naxatw-left-[0.575rem] naxatw-top-[5.75rem] naxatw-z-30 naxatw-flex naxatw-h-fit naxatw-w-fit naxatw-flex-col naxatw-gap-3">
           <Button

--- a/src/frontend/src/components/DroneOperatorTask/MapSection/MapSection.tsx
+++ b/src/frontend/src/components/DroneOperatorTask/MapSection/MapSection.tsx
@@ -538,7 +538,10 @@ const MapSection = ({ className }: { className?: string }) => {
     postWaypoint({
       projectId,
       taskId,
-      data: {
+      mode: waypointMode,
+      rotationAngle: finalRotationAngle,
+      droneModel: droneModel,
+      takeOffPoint: {
         longitude: lng,
         latitude: lat,
       },

--- a/src/frontend/src/constants/taskDescription.ts
+++ b/src/frontend/src/constants/taskDescription.ts
@@ -17,3 +17,9 @@ export const waypointModeOptions = [
   { label: 'Waylines', value: 'waylines' },
   { label: 'Waypoints', value: 'waypoints' },
 ];
+
+export const droneModelOptions = [
+  { label: 'DJI Mini 4 Pro', value: 'DJI_MINI_4_PRO' },
+  { label: 'DJI Air 3', value: 'DJI_AIR_3' },
+  { label: 'Potensic Atom 2', value: 'POTENSIC_ATOM_2' },
+];

--- a/src/frontend/src/services/tasks.ts
+++ b/src/frontend/src/services/tasks.ts
@@ -4,10 +4,11 @@ export const getTaskWaypoint = (
   projectId: string,
   taskId: string,
   mode: string,
+  droneModel: string,
   rotationAngle: number,
 ) =>
   authenticated(api).post(
-    `/waypoint/task/${taskId}/?project_id=${projectId}&download=false&mode=${mode}&rotation_angle=${rotationAngle}`,
+    `/waypoint/task/${taskId}/?project_id=${projectId}&download=false&mode=${mode}&drone_type=${droneModel}&rotation_angle=${rotationAngle}`,
   );
 
 export const getIndividualTask = (taskId: string) =>

--- a/src/frontend/src/services/tasks.ts
+++ b/src/frontend/src/services/tasks.ts
@@ -14,11 +14,12 @@ export const getTaskWaypoint = (
 export const getIndividualTask = (taskId: string) =>
   authenticated(api).get(`/tasks/${taskId}`);
 
+// TODO refactor this out and replace with getTaskWaypoint
 export const postTaskWaypoint = (payload: Record<string, any>) => {
-  const { taskId, projectId, data } = payload;
+  const { taskId, projectId, mode, rotationAngle, droneModel, takeOffPoint } = payload;
   return authenticated(api).post(
-    `/waypoint/task/${taskId}/?project_id=${projectId}&download=false`,
-    data,
+    `/waypoint/task/${taskId}/?project_id=${projectId}&download=false&mode=${mode}&drone_type=${droneModel}&rotation_angle=${rotationAngle}`,
+    takeOffPoint,
     {
       headers: { 'Content-Type': 'application/json' },
     },

--- a/src/frontend/src/store/actions/droneOperatorTask.ts
+++ b/src/frontend/src/store/actions/droneOperatorTask.ts
@@ -18,6 +18,7 @@ export const {
   setUploadProgress,
   resetFilesExifData,
   setWaypointMode,
+  setDroneModel,
   setTaskAssetsInformation,
   setRotatedFlightPlan,
   setRotationAngle,

--- a/src/frontend/src/store/slices/droneOperartorTask.ts
+++ b/src/frontend/src/store/slices/droneOperartorTask.ts
@@ -20,6 +20,7 @@ export interface IDroneOperatorTaskState {
   filesExifData: IFilesExifData[];
   uploadProgress: Record<string, any>;
   waypointMode: 'waylines' | 'waypoints';
+  droneModel: 'DJI_MINI_4_PRO' | 'DJI_AIR_3' | 'POTENSIC_ATOM_2';
   taskAssetsInformation: Record<string, any>;
   rotatedFlightPlan: Record<string, any>;
   rotationAngle: number;
@@ -40,6 +41,7 @@ const initialState: IDroneOperatorTaskState = {
   filesExifData: [],
   uploadProgress: {},
   waypointMode: 'waylines',
+  droneModel: 'DJI_MINI_4_PRO',
   taskAssetsInformation: {
     total_image_uploaded: 0,
     assets_url: '',
@@ -114,6 +116,9 @@ export const droneOperatorTaskSlice = createSlice({
     },
     setWaypointMode: (state, action) => {
       state.waypointMode = action.payload;
+    },
+    setDroneModel: (state, action) => {
+      state.droneModel = action.payload;
     },
     setTaskAssetsInformation: (state, action) => {
       state.taskAssetsInformation = action.payload;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Final part of https://github.com/hotosm/drone-tm/issues/543 and https://github.com/hotosm/drone-tm/issues/537

## Describe this PR

- Small bit of frontend code to add a toggle for drone type.
- This could be improved - it should probably be a dropdown in future as the list grows.
- Note I still need to test and improve the Potensic flightplan generation properly.

- [ ] Test the output thoroughly with some flights.
- [ ] Add good documentation for this, particularly the part about multiple flightplans in a single sqlite db + how to generate via command line.
  - Image interval to 2.
  - Use both flights if present.

> [!NOTE]
> The hard limit of 50 waypoints is overcome by adding multiple flights to the same sqlite database for the Potensic Pro app.

## Screenshots

![image](https://github.com/user-attachments/assets/926f61dc-2c84-47bd-90dd-5e8dab66fde6)

## Checklist before requesting a review

- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
