### PR TITLE
Update add_elevation_from_dem.py

### DIFF
--- a/src/backend/packages/drone-flightplan/drone_flightplan/add_elevation_from_dem.py
+++ b/src/backend/packages/drone-flightplan/drone_flightplan/add_elevation_from_dem.py
@@ -107,8 +107,8 @@ def add_elevation_from_dem(raster_file, points, outfile):
     for feature in lyr:
         geom = feature.GetGeometryRef()
         pointXYRasterCRS = transform.TransformPoint(geom.GetX(), geom.GetY())
-        mapX = pointXYRasterCRS[1]
-        mapY = pointXYRasterCRS[0]
+        mapX = pointXYRasterCRS[0]
+        mapY = pointXYRasterCRS[1]
         pixcoords = gdal.ApplyGeoTransform(reverse, mapX, mapY)
         pixX = math.floor(pixcoords[0])
         pixY = math.floor(pixcoords[1])


### PR DESCRIPTION
fix an issue where points were being report as outside of the raster bounds due to an incorrect transform

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Example: Fixes #123

## Describe this PR

When I tried using this utility, I found it was not adding the elevation due to the points being outside the bounds of the raster, despite the raster covering the extent of the points.

Stepping through the code I found that the coordinates were being flipped here which cause the points to be assigned an incorrect location in the raster SRS.

I know that GDAL changed some things around coordinates order around v3, but I believe I'm using the Debian system install GDAL which is 3.10.3 rather than the 3.6.2 as specified in the dependencies.
