### PR TITLE
fix: correct forgot password functionality

### DIFF
--- a/src/backend/app/users/user_routes.py
+++ b/src/backend/app/users/user_routes.py
@@ -226,7 +226,7 @@ async def my_data(
 @router.post("/forgot-password/")
 async def forgot_password(
     db: Annotated[Connection, Depends(database.get_db)],
-    email: EmailStr,
+    email: Annotated[EmailStr, Form()],
     background_tasks: BackgroundTasks,
 ):
     user = await DbUser.get_user_by_email(db, email)

--- a/src/frontend/src/modules/user-auth-module/src/components/Authentication/ForgotPassword/index.tsx
+++ b/src/frontend/src/modules/user-auth-module/src/components/Authentication/ForgotPassword/index.tsx
@@ -7,7 +7,8 @@ import { Button } from '@Components/RadixComponents/Button';
 import Icon from '@Components/common/Icon';
 import { Flex, FlexRow } from '@Components/common/Layouts';
 import ErrorMessage from '@Components/common/ErrorMessage';
-import { signInUser } from '@Services/common';
+import { forgotPassword } from '@Services/common';
+import { toast } from 'react-toastify';
 
 const initialState = {
   email: '',
@@ -17,11 +18,11 @@ export default function ForgotPassword() {
   const navigate = useNavigate();
 
   const { mutate, error } = useMutation<any, any, any, unknown>({
-    mutationFn: signInUser,
+    mutationFn: forgotPassword,
     onSuccess: () => {
-      setTimeout(() => {
-        navigate('/login');
-      }, 3000);
+      toast.success('Password reset email sent');
+
+      navigate('/login');
     },
   });
 
@@ -55,15 +56,6 @@ export default function ForgotPassword() {
         onSubmit={handleSubmit(onSubmit)}
         className="naxatw-flex naxatw-w-[60%] naxatw-flex-col naxatw-gap-5 naxatw-pt-7"
       >
-        {/* {isSuccess && (
-          <InfoDialog
-            status="success"
-            description={
-              successMessage?.data?.Message ||
-              'Email has been sent successfully.'
-            }
-          />
-        )} */}
         <FormControl>
           <Label htmlFor="email">Email</Label>
           <Input
@@ -72,7 +64,12 @@ export default function ForgotPassword() {
             placeholder="Email"
             {...register('email', { required: true })}
           />
-          <ErrorMessage message={error?.response?.data?.Message || ''} />
+          <ErrorMessage
+            message={
+              error?.response?.data?.detail?.[0]?.msg ||
+              'Error resetting password. Please try again.'
+            }
+          />
         </FormControl>
 
         <FlexRow className="naxatw-items-center naxatw-justify-between">

--- a/src/frontend/src/services/common.ts
+++ b/src/frontend/src/services/common.ts
@@ -12,6 +12,9 @@ export const signInCallBackUrl = () => api.get('/users/callback/');
 
 export const logoutUser = () => api.post('/user/logout/');
 
+export const forgotPassword = (data: any) =>
+  api.post('/users/forgot-password/', data);
+
 export const postUserProfile = ({
   userId,
   data,


### PR DESCRIPTION
On the frontend we needed to use the correct URL.  On the backend we needed to annotate the email param as a `Form`

If the API call succeeds, then a toast is shown and you are redirected to the `/login` page

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes: https://github.com/hotosm/drone-tm/issues/406

## Describe this PR

- Correct the route that the frontend was calling when the forgot password form is submitted
- Correct the `email` parameter on the backend to be of type `Form` to match the other login routes
- Use the first message from the backend or else default to generic message

## Screenshots

Error message from backend:
<img width="501" height="286" alt="image" src="https://github.com/user-attachments/assets/95e25f77-d1d9-4487-b78b-99cb52b87cfa" />

Email does not exist (generic message shown):
<img width="584" height="289" alt="image" src="https://github.com/user-attachments/assets/94b0e69e-86ea-4b5b-a3f5-cf594b58853c" />

Success case:
<img width="703" height="451" alt="image" src="https://github.com/user-attachments/assets/f7969208-4aa3-4652-bfbe-9290b28534e5" />


## Alternative Approaches Considered

None

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
