### PR TITLE
Fixing Multi Batch Rejections Test in Flight Tail Detection Tests

### DIFF
--- a/src/backend/tests/test_flight_tail_detection.py
+++ b/src/backend/tests/test_flight_tail_detection.py
@@ -589,12 +589,12 @@ async def test_multi_batch_rejections(db, create_test_project, auth_user):
                 ts = seg["start"] + timedelta(seconds=i * 2)
 
                 # Creating a path:
-                # 0-5: Vertical and moving up in altitude
-                # 6-12: Moving NORTH (azimuth 0)
-                # 13-60: Mission then moves EAST (azimuth 90)
+                # 0-3: Vertical and moving up in altitude
+                # 4-8: Moving NORTH (azimuth 0)
+                # 9: Mission moving EAST (azimuth 90)
 
-                is_vertical = i < 6
-                is_transit = 6 <= i < 13
+                is_vertical = i < 4
+                is_transit = 4 <= i < 9
 
                 if is_vertical:
                     lat, lon = -8.301, 115.46
@@ -603,10 +603,10 @@ async def test_multi_batch_rejections(db, create_test_project, auth_user):
                     lat, lon = -8.301 + (i * 0.0002), 115.46
                     alt = 200
                 else:
-                    lat, lon = -8.301 + (13 * 0.0002), 115.46 + ((i - 13) * 0.0002)
+                    lat, lon = -8.301 + (8 * 0.0002), 115.46 + ((i - 8) * 0.0002)
                     alt = 200
 
-                file_name = f"flight_takeoff_{i:03d}.jpg"
+                file_name = f"{seg['label']}_{i:03d}.jpg"
                 s3_key = f"dtm-data/projects/{project_id}/user-uploads/{file_name}"
                 hash_md5 = hashlib.md5(file_name.encode("utf-8")).hexdigest()
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [X] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

References: #702 

## Describe this PR
This PR fixes the test_multi_batch_rejections test.

- Moved the mission turn index to happen at index 9, ensuring its captured within the search limit. 
- Updated loop to add unique filenames per segment (flight_A, flight_B).

## Review Guide
I noticed some lag in test_projects_routes.py when running `just test backend`, and know there are refactors to S3 local dev usage, so I am submitting to verify core logic in CI environment 

## Checklist before requesting a review

- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
