### PR TITLE
Replace redis with dragonflydb open-source alternative

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -2,8 +2,8 @@ dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 15.2.2
-- name: redis
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 18.1.0
-digest: sha256:3892a1c7d801e82c2466392de20084c59985bf25bb2899abcb97821e4fb30403
-generated: "2026-01-21T00:50:30.96085642Z"
+- name: dragonfly
+  repository: oci://ghcr.io/dragonflydb/dragonfly/helm
+  version: v1.36.0
+digest: sha256:05e84148ad47e52b5bf6a749e9f55c2f5d5518c2220d1a163a936e9f0b8a7e8e
+generated: "2026-01-22T00:10:15.994950595Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: drone-tm
 description: Drone Tasking Manager - coordinated drone mapping
-version: "0.1.2"
+version: "0.1.3"
 appVersion: "2025.5.0"
 maintainers:
   - email: sysadmin@hotosm.org
@@ -14,7 +14,7 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
     alias: postgresql
-  - name: redis
-    version: 18.1.0
-    repository: oci://registry-1.docker.io/bitnamicharts
-    alias: redis
+  - name: dragonfly
+    version: v1.36.0
+    repository: oci://ghcr.io/dragonflydb/dragonfly/helm
+    alias: dragonfly

--- a/chart/README.md
+++ b/chart/README.md
@@ -35,7 +35,7 @@ helm upgrade drone-tm ./chart -f values-local.yaml
 
 This chart includes the following subcharts:
 
-- **Redis**: Caching and task queue
+- **DragonflyDB**: Caching and task queue
 - **PostgreSQL**: Database with PostGIS extension (optional)
 
 ## Configuration
@@ -48,7 +48,7 @@ Key configuration areas:
 - **FrontendAssets**: Init container that syncs built frontend assets into `frontend_html` for the backend to serve
 - **Worker**: Background task processing
 - **PostgreSQL**: Database configuration
-- **Redis**: Cache and queue configuration
+- **DragonflyDB**: Cache and queue configuration
 
 ## Environment Variables
 
@@ -101,7 +101,7 @@ Your Secret should include (at minimum):
 - Database: `POSTGRES_PASSWORD`
 - S3 credentials: `S3_ACCESS_KEY`, `S3_SECRET_KEY`.
 - Auth: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `JAXA_AUTH_TOKEN`, `SECRET_KEY`.
-- Redis: (provided automatically by the chart; no `REDIS_DSN` needed)
+- DragonflyDB: (provided automatically by the chart; no `DRAGONFLY_DSN` needed)
 
 You will also typically want to set these **non-secret** environment variables via Helm values
 (`env` or `extraEnvFrom`), depending on your S3/CDN setup:

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -90,16 +90,13 @@ Name of the main app Secret containing env vars
 {{- end }}
 
 {{/*
-Redis service DNS (Bitnami redis subchart, master service).
+DragonflyDB service DNS.
 
-Bitnami Redis names the master Service:
-  {{ printf "%s-master" (include "common.names.fullname" .) }}
-
-And common.names.fullname expands to:
-  <release>-redis   (unless <release> already contains "redis")
+DragonflyDB Helm chart names the service:
+  {{ .Release.Name }}-dragonfly
 */}}
-{{- define "drone-tm.redis.fullname" -}}
-{{- $name := "redis" -}}
+{{- define "drone-tm.dragonfly.fullname" -}}
+{{- $name := "dragonfly" -}}
 {{- if contains $name .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -107,12 +104,12 @@ And common.names.fullname expands to:
 {{- end -}}
 {{- end }}
 
-{{- define "drone-tm.redis.masterServiceName" -}}
-{{- printf "%s-master" (include "drone-tm.redis.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- define "drone-tm.dragonfly.serviceName" -}}
+{{- include "drone-tm.dragonfly.fullname" . | trunc 63 | trimSuffix "-" -}}
 {{- end }}
 
-{{- define "drone-tm.redis.masterServiceFQDN" -}}
-{{- printf "%s.%s.svc.cluster.local" (include "drone-tm.redis.masterServiceName" .) .Release.Namespace -}}
+{{- define "drone-tm.dragonfly.serviceFQDN" -}}
+{{- printf "%s.%s.svc.cluster.local" (include "drone-tm.dragonfly.serviceName" .) .Release.Namespace -}}
 {{- end }}
 
 {{/*

--- a/chart/templates/backend-deployment.yaml
+++ b/chart/templates/backend-deployment.yaml
@@ -61,9 +61,9 @@ spec:
           {{- $extraEnvFrom := (.Values.extraEnvFrom | default list) -}}
           {{- include "drone-tm.renderEnvFrom" (dict "root" . "extraEnvFrom" $extraEnvFrom) | nindent 10 }}
           env:
-            - name: REDIS_DSN
-              value: "redis://{{ include "drone-tm.redis.masterServiceFQDN" . }}:6379/0"
-            {{- include "drone-tm.renderEnvOmit" (dict "env" (.Values.env | default dict) "omit" (dict "REDIS_DSN" true)) | nindent 12 }}
+            - name: DRAGONFLY_DSN
+              value: "redis://{{ include "drone-tm.dragonfly.serviceFQDN" . }}:6379/0"
+            {{- include "drone-tm.renderEnvOmit" (dict "env" (.Values.env | default dict) "omit" (dict "DRAGONFLY_DSN" true)) | nindent 12 }}
           resources:
             {{- toYaml .Values.backend.resources | nindent 12 }}
           livenessProbe:

--- a/chart/templates/migrations-job.yaml
+++ b/chart/templates/migrations-job.yaml
@@ -41,6 +41,6 @@ spec:
           {{- $env := (.Values.env | default dict) -}}
           {{- if $env }}
           env:
-            {{- include "drone-tm.renderEnvOmit" (dict "env" $env "omit" (dict "REDIS_DSN" true)) | nindent 12 }}
+            {{- include "drone-tm.renderEnvOmit" (dict "env" $env "omit" (dict "DRAGONFLY_DSN" true)) | nindent 12 }}
           {{- end }}
 {{- end }}

--- a/chart/templates/worker-deployment.yaml
+++ b/chart/templates/worker-deployment.yaml
@@ -47,9 +47,9 @@ spec:
           {{- $extraEnvFrom := (.Values.extraEnvFrom | default list) -}}
           {{- include "drone-tm.renderEnvFrom" (dict "root" . "extraEnvFrom" $extraEnvFrom) | nindent 10 }}
           env:
-            - name: REDIS_DSN
-              value: "redis://{{ include "drone-tm.redis.masterServiceFQDN" . }}:6379/0"
-            {{- include "drone-tm.renderEnvOmit" (dict "env" (.Values.env | default dict) "omit" (dict "REDIS_DSN" true)) | nindent 12 }}
+            - name: DRAGONFLY_DSN
+              value: "redis://{{ include "drone-tm.dragonfly.serviceFQDN" . }}:6379/0"
+            {{- include "drone-tm.renderEnvOmit" (dict "env" (.Values.env | default dict) "omit" (dict "DRAGONFLY_DSN" true)) | nindent 12 }}
           livenessProbe:
             {{- toYaml .Values.worker.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/chart/values-local.yaml
+++ b/chart/values-local.yaml
@@ -43,22 +43,21 @@ postgresql:
     persistence:
       size: 10Gi
 
-# Development Redis configuration
-redis:
+# Development DragonflyDB configuration
+dragonfly:
   enabled: true
-  auth:
+  replicaCount: 1
+  storage:
     enabled: false
-  architecture: standalone
-  master:
-    resources:
-      limits:
-        cpu: 500m
-        memory: 512Mi
-      requests:
-        cpu: 250m
-        memory: 256Mi
-    persistence:
-      size: 5Gi
+    storageClassName: ""
+    requests: 2Gi
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 256Mi
 
 existingSecret:
   name: drone-tm-local-secrets

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -35,7 +35,7 @@ env: {}
 #   # Optional: for cheaper/faster repeated downloads (CloudFront)
 #   # S3_ENDPOINT_DOWNLOAD: "https://your-cloudfront-domain.example.com"
 #   S3_BUCKET_NAME: "your-bucket"
-#   # REDIS_DSN is provided automatically by the chart (Bitnami Redis subchart)
+#   # DRAGONFLY_DSN is provided automatically by the chart (DragonflyDB subchart)
 #   # and does not need to be configured manually
 #
 #   # --- Optional ---
@@ -176,23 +176,21 @@ podDisruptionBudget:
     minAvailable: 1
 
 # Subchart configurations
-# https://github.com/bitnami/charts/blob/main/bitnami/redis/values.yaml
-redis:
-  image:
-    registry: docker.io
-    repository: bitnami/redis
-    tag: 7.2-debian-13
-  auth:
+# https://github.com/dragonflydb/dragonfly/blob/main/contrib/charts/dragonfly/values.yaml
+dragonfly:
+  enabled: true
+  replicaCount: 1
+  storage:
     enabled: false
-  architecture: standalone
-  master:
-    resources:
-      limits:
-        cpu: 500m
-        memory: 512Mi
-      requests:
-        cpu: 100m
-        memory: 128Mi
+    storageClassName: ""
+    requests: 2Gi
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 256Mi
 
 # https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
 postgresql:

--- a/compose.sub.yaml
+++ b/compose.sub.yaml
@@ -173,7 +173,7 @@ services:
     image: ghcr.io/hotosm/drone-tm/backend:${GIT_BRANCH:-main}
     command: arq app.arq.tasks.WorkerSettings
     depends_on:
-      redis:
+      dragonfly:
         condition: service_healthy
     env_file: .env
     networks:
@@ -186,8 +186,8 @@ services:
       retries: 2
       start_period: 20s
 
-  redis:
-    image: redis:7-alpine
+  dragonfly:
+    image: ghcr.io/dragonflydb/dragonfly:v1.36.0
     networks:
       - dtm-network
     restart: unless-stopped

--- a/compose.test.yaml
+++ b/compose.test.yaml
@@ -70,10 +70,10 @@ services:
       S3_ENDPOINT_UPLOAD: http://localhost:9000
       S3_ENDPOINT_DOWNLOAD: http://localhost:9000
 
-  redis:
+  dragonfly:
     extends:
       file: compose.yaml
-      service: redis
+      service: dragonfly
 
   nodeodm:
     extends:

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,8 +21,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      redis:
-        condition: service_started
       nodeodm:
         condition: service_started
       migrations:
@@ -49,6 +47,12 @@ services:
     networks:
       - dtm-network
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/__lbheartbeat__"]
+      start_period: 60s
+      interval: 10s
+      timeout: 5s
+      retries: 10
 
   frontend:
     image: ghcr.io/hotosm/drone-tm/frontend:debug
@@ -147,9 +151,9 @@ services:
     image: ghcr.io/hotosm/drone-tm/backend:debug
     command: arq --watch /project/src/backend/app app.arq.tasks.WorkerSettings
     depends_on:
-      db:
+      backend:
         condition: service_healthy
-      redis:
+      dragonfly:
         condition: service_started
       nodeodm:
         condition: service_started
@@ -165,10 +169,9 @@ services:
       retries: 2
       start_period: 20s
 
-  redis:
-    image: redis:7-alpine
-    networks:
-      - dtm-network
+  dragonfly:
+    image: ghcr.io/dragonflydb/dragonfly:v1.36.0
+    network_mode: service:backend
     restart: unless-stopped
 
   # This container does the actual imagery processing (not persistent, scalable)

--- a/contrib/webodm/compose.yaml
+++ b/contrib/webodm/compose.yaml
@@ -91,9 +91,9 @@ services:
     restart: unless-stopped
     oom_score_adj: 250
 
-  # Redis broker to manage job queue
+  # DragonflyDB broker to manage job queue
   odm-broker:
-    image: docker.io/redis:8.0.0
+    image: ghcr.io/dragonflydb/dragonfly:v1.36.0
     container_name: odm-broker
     networks:
       - net

--- a/src/backend/app/arq/tasks.py
+++ b/src/backend/app/arq/tasks.py
@@ -33,7 +33,7 @@ async def startup(ctx: Dict[Any, Any]) -> None:
     log.info("Starting ARQ worker")
 
     # Initialize Redis
-    ctx["redis"] = await create_pool(RedisSettings.from_dsn(settings.REDIS_DSN))
+    ctx["redis"] = await create_pool(RedisSettings.from_dsn(settings.DRAGONFLY_DSN))
     await log_redis_info(ctx["redis"], log.info)
 
     # Initialize Database pool
@@ -697,7 +697,7 @@ async def delete_batch_images(
 class WorkerSettings:
     """ARQ worker configuration"""
 
-    redis_settings = RedisSettings.from_dsn(settings.REDIS_DSN)
+    redis_settings = RedisSettings.from_dsn(settings.DRAGONFLY_DSN)
     functions = [
         sleep_task,
         count_project_tasks,
@@ -721,7 +721,7 @@ class WorkerSettings:
 async def get_redis_pool() -> ArqRedis:
     """Redis connection dependency"""
     try:
-        return await create_pool(RedisSettings.from_dsn(settings.REDIS_DSN))
+        return await create_pool(RedisSettings.from_dsn(settings.DRAGONFLY_DSN))
     except Exception as e:
         log.error(f"Redis connection failed: {str(e)}")
         raise HTTPException(

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -200,7 +200,7 @@ class Settings(BaseSettings):
     BACKEND_URL_INTERNAL: str = "http://backend:8000"
     # ODM (NodeODM) API endpoint
     ODM_ENDPOINT: Optional[str] = "http://nodeodm:9900"
-    REDIS_DSN: str = "redis://redis:6379/0"
+    DRAGONFLY_DSN: str = "redis://localhost:6379/0"
 
     # - S3_ENDPOINT_UPLOAD: endpoint used for presigned uploads (browser calls this; can be S3 TA).
     # - S3_ENDPOINT_DOWNLOAD: endpoint used for browser downloads/display (can be CloudFront).

--- a/tasks/test
+++ b/tasks/test
@@ -29,7 +29,7 @@ default:
 backend:
     {{docker}} compose -f compose.test.yaml build backend
 
-    {{docker}} compose -f compose.test.yaml up --detach db redis minio nodeodm arq-worker
+    {{docker}} compose -f compose.test.yaml up --detach db dragonfly minio nodeodm arq-worker
 
     {{docker}} compose -f compose.test.yaml run --rm createbuckets
     {{docker}} compose -f compose.test.yaml run --rm migrations


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [x] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR

- Redis changed it's license.
- The `arq` worker uses Redis. arq is in 'low-maintenance mode' and probably needs a review, but that's another issue.
- Two alternatives to Redis are ValKey and DragonflyDB.
  - ValKey is Linux Foundation so a big plus.
  - DragonflyDB has much better performance in benchmarks and a growing community.
- I thought we could give Dragonfly a go, so replaced usage of Redis - drop in replacement seems to work well,

## Review Guide

- Test imagery upload and classification - this uses the arq worker + dragonfly.

## Checklist before requesting a review

- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
