### PR TITLE
Add small endpoint + button to ingest manually copied s3 imagery into project

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -22,6 +22,7 @@ mod build 'tasks/build'
 mod start 'tasks/start'
 mod config 'tasks/config'
 mod test 'tasks/test'
+mod process 'tasks/process'
 
 # List available commands
 [private]

--- a/src/backend/app/arq/tasks.py
+++ b/src/backend/app/arq/tasks.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import hashlib
 import io
 import zipfile
 from pathlib import Path
@@ -425,6 +426,107 @@ async def process_uploaded_image(
     except Exception as e:
         log.error(f"Failed (Job: {job_id}): {str(e)}")
         raise
+
+
+async def ingest_existing_uploads(
+    ctx: Dict[Any, Any],
+    project_id: str,
+    uploaded_by: str,
+    batch_id: str,
+    **_kwargs: Any,
+) -> Dict[str, Any]:
+    """Scan a project's user-uploads/ prefix and enqueue processing for untracked files.
+
+    Runs as a background job so the HTTP request returns immediately.
+
+    Concurrency safety:
+    - A Redis lock (lock:ingest:{project_id}, 30 min TTL) prevents parallel
+      ingest jobs for the same project — from retries or duplicate API calls.
+    - Each process_uploaded_image job gets a stable _job_id derived from
+      project_id + s3_key, so ARQ silently deduplicates re-enqueues of the
+      same object.
+    - Downstream MD5 hash check in process_uploaded_image is the final safety
+      net against duplicate DB rows.
+    """
+    job_id = ctx.get("job_id", "unknown")
+    log.info(f"Starting ingest job {job_id} for project {project_id}")
+
+    db_pool = ctx.get("db_pool")
+    redis: ArqRedis = ctx.get("redis")
+    if not db_pool or not redis:
+        raise RuntimeError("Database pool or Redis not initialized in ARQ context")
+
+    # Project-scoped lock: prevents parallel ingest runs (retries, double-clicks).
+    # TTL of 30 minutes — well beyond expected scan+enqueue time.
+    lock_key = f"lock:ingest:{project_id}"
+    acquired = await redis.set(lock_key, job_id, nx=True, ex=1800)
+    if not acquired:
+        log.warning(
+            f"Ingest job {job_id}: another ingest is already running for "
+            f"project {project_id}, skipping"
+        )
+        return {
+            "project_id": project_id,
+            "batch_id": batch_id,
+            "enqueued": 0,
+            "skipped": True,
+        }
+
+    try:
+        from app.s3 import list_objects_from_bucket
+
+        prefix = f"projects/{project_id}/user-uploads/"
+        bucket = settings.S3_BUCKET_NAME
+        image_extensions = {".jpg", ".jpeg", ".tif", ".tiff", ".png", ".dng"}
+
+        # Get already-tracked S3 keys
+        async with db_pool.connection() as db:
+            async with db.cursor() as cur:
+                await cur.execute(
+                    "SELECT s3_key FROM project_images WHERE project_id = %(pid)s",
+                    {"pid": project_id},
+                )
+                existing_keys = {row[0] for row in await cur.fetchall()}
+
+        enqueued = 0
+        for obj in list_objects_from_bucket(bucket, prefix):
+            if obj.is_dir:
+                continue
+            key = obj.object_name
+            filename = key.rsplit("/", 1)[-1]
+            if filename.startswith("thumb_"):
+                continue
+            ext = os.path.splitext(filename)[1].lower()
+            if ext not in image_extensions:
+                continue
+            if key in existing_keys:
+                continue
+
+            # Stable job ID: hash the S3 key so the identifier stays short/safe
+            # while remaining deterministic across retries and duplicate requests.
+            stable_child_id = (
+                f"ingest-img:{project_id}:"
+                f"{hashlib.md5(key.encode('utf-8')).hexdigest()}"
+            )
+            child_job = await redis.enqueue_job(
+                "process_uploaded_image",
+                project_id,
+                key,
+                filename,
+                uploaded_by,
+                batch_id,
+                _queue_name="default_queue",
+                _job_id=stable_child_id,
+            )
+            if child_job is not None:
+                enqueued += 1
+
+        log.info(
+            f"Ingest job {job_id}: enqueued {enqueued} images for project {project_id}"
+        )
+        return {"project_id": project_id, "batch_id": batch_id, "enqueued": enqueued}
+    finally:
+        await redis.delete(lock_key)
 
 
 async def classify_project_images(
@@ -1008,6 +1110,7 @@ class WorkerSettings:
         process_drone_images,
         process_all_drone_images,
         process_uploaded_image,
+        ingest_existing_uploads,
         classify_project_images,
         delete_batch_images,
         process_project_task_metrics,

--- a/src/backend/app/projects/classification_routes.py
+++ b/src/backend/app/projects/classification_routes.py
@@ -103,6 +103,58 @@ async def start_project_classification(
     }
 
 
+@router.post("/{project_id}/ingest-uploads/", tags=["Image Classification"])
+async def ingest_existing_uploads(
+    project_id: UUID,
+    redis: Annotated[ArqRedis, Depends(get_redis_pool)],
+    user: Annotated[AuthUser, Depends(login_required)],
+):
+    """Enqueue a background job to scan user-uploads/ and ingest untracked files.
+
+    The actual S3 scan and per-file enqueue happens in an ARQ worker so the
+    request returns immediately regardless of how many objects exist.
+
+    Uses a stable _job_id so ARQ deduplicates concurrent/retry requests for
+    the same project — a second call while the first is queued or running is
+    a no-op.
+    """
+    import uuid as _uuid
+
+    batch_id = str(_uuid.uuid4())
+    stable_job_id = f"ingest-uploads:{project_id}"
+    job = await redis.enqueue_job(
+        "ingest_existing_uploads",
+        str(project_id),
+        user.id,
+        batch_id,
+        _queue_name="default_queue",
+        _job_id=stable_job_id,
+    )
+
+    if job is None:
+        log.info(
+            f"Ingest-uploads: job already queued/running for project {project_id} "
+            f"(job_id {stable_job_id})"
+        )
+        return {
+            "message": "Ingestion job already queued",
+            "job_id": stable_job_id,
+            "project_id": str(project_id),
+            "batch_id": batch_id,
+        }
+
+    log.info(
+        f"Ingest-uploads: queued job {job.job_id} for project {project_id} "
+        f"(batch {batch_id})"
+    )
+    return {
+        "message": "Ingestion job queued",
+        "job_id": job.job_id,
+        "project_id": str(project_id),
+        "batch_id": batch_id,
+    }
+
+
 @router.get("/{project_id}/imagery/status/", tags=["Image Classification"])
 async def get_project_imagery_status(
     project_id: UUID,

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -109,6 +109,11 @@ skip = "*pnpm-lock.yaml,*CHANGELOG.md,src/frontend/src/assets/*"
 ignore-words-list = "ProjectIn,dateA,te,ALOS,algoritmos"
 write-changes = true
 
+[tool.pytest.ini_options]
+markers = [
+    "integration: marks tests that exercise integrated services or workflows",
+]
+
 #[tool.ruff]
 #fix = true
 #line-length = 88

--- a/src/backend/tests/test_classification_routes.py
+++ b/src/backend/tests/test_classification_routes.py
@@ -7,10 +7,18 @@ classification_routes.py router through the ASGI test client.
 import json
 import uuid
 from datetime import datetime, timezone
+from io import BytesIO
 
 import pytest
+import pytest_asyncio
 
-from app.arq.tasks import get_redis_pool
+from app.arq.tasks import (
+    get_redis_pool,
+    ingest_existing_uploads as ingest_existing_uploads_task,
+)
+from app.config import settings
+from app.db.database import get_db_connection_pool
+from app.s3 import add_obj_to_bucket, delete_objects_by_prefix
 
 # ─── Shared helpers ──────────────────────────────────────────────────────────
 
@@ -105,6 +113,26 @@ async def _insert_image(
     return image_id
 
 
+@pytest_asyncio.fixture
+async def redis_pool():
+    redis = await get_redis_pool()
+    await redis.flushdb()
+    try:
+        yield redis
+    finally:
+        await redis.flushdb()
+        await redis.aclose()
+
+
+@pytest_asyncio.fixture
+async def arq_ctx(redis_pool):
+    db_pool = await get_db_connection_pool()
+    try:
+        yield {"redis": redis_pool, "db_pool": db_pool, "job_id": "test-ingest-job"}
+    finally:
+        await db_pool.close()
+
+
 # ─── /classify/ ──────────────────────────────────────────────────────────────
 
 
@@ -181,6 +209,35 @@ async def test_start_project_classification_enqueues_job_for_staged_images(
     ]
 
 
+@pytest.mark.asyncio
+async def test_ingest_existing_uploads_route_deduplicates_top_level_job(
+    client, redis_pool, create_test_project
+):
+    project_id = create_test_project
+
+    resp1 = await client.post(f"/api/projects/{project_id}/ingest-uploads/")
+    assert resp1.status_code == 200
+    body1 = resp1.json()
+    assert body1["message"] == "Ingestion job queued"
+    assert body1["job_id"] == f"ingest-uploads:{project_id}"
+
+    resp2 = await client.post(f"/api/projects/{project_id}/ingest-uploads/")
+    assert resp2.status_code == 200
+    body2 = resp2.json()
+    assert body2["message"] == "Ingestion job already queued"
+    assert body2["job_id"] == f"ingest-uploads:{project_id}"
+
+    queued = await redis_pool.queued_jobs(queue_name="default_queue")
+    ingest_jobs = [job for job in queued if job.function == "ingest_existing_uploads"]
+    assert len(ingest_jobs) == 1
+    assert ingest_jobs[0].job_id == f"ingest-uploads:{project_id}"
+    assert ingest_jobs[0].args == (
+        project_id,
+        "101039844375937810000",
+        body1["batch_id"],
+    )
+
+
 # ─── /imagery/status/ ────────────────────────────────────────────────────────
 
 
@@ -191,6 +248,91 @@ async def test_imagery_status_empty_project(client, create_test_project):
     assert resp.status_code == 200
     body = resp.json()
     assert body["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_ingest_existing_uploads_task_enqueues_child_jobs_once(
+    arq_ctx, db, auth_user, create_test_project
+):
+    project_id = create_test_project
+    bucket = settings.S3_BUCKET_NAME
+    prefix = f"projects/{project_id}/user-uploads/"
+    keys = [
+        f"{prefix}alpha.jpg",
+        f"{prefix}beta.JPG",
+        f"{prefix}thumb_gamma.jpg",
+        f"{prefix}notes.txt",
+    ]
+
+    for key in keys:
+        add_obj_to_bucket(
+            bucket, BytesIO(b"test-bytes"), key, content_type="image/jpeg"
+        )
+
+    # One object is already tracked and should be skipped.
+    tracked_key = f"{prefix}alpha.jpg"
+    await _insert_image(
+        db,
+        project_id=project_id,
+        uploaded_by=auth_user.id,
+        status="staged",
+        filename="alpha.jpg",
+    )
+    async with db.cursor() as cur:
+        await cur.execute(
+            """
+            UPDATE project_images
+            SET s3_key = %(s3_key)s
+            WHERE project_id = %(project_id)s AND filename = 'alpha.jpg'
+            """,
+            {"s3_key": tracked_key, "project_id": project_id},
+        )
+    await db.commit()
+
+    batch_id = str(uuid.uuid4())
+    try:
+        result1 = await ingest_existing_uploads_task(
+            arq_ctx, project_id, auth_user.id, batch_id
+        )
+        result2 = await ingest_existing_uploads_task(
+            arq_ctx, project_id, auth_user.id, str(uuid.uuid4())
+        )
+
+        assert result1["enqueued"] == 1
+        assert result2["enqueued"] == 0
+
+        queued = await arq_ctx["redis"].queued_jobs(queue_name="default_queue")
+        child_jobs = [job for job in queued if job.function == "process_uploaded_image"]
+
+        assert len(child_jobs) == 1
+        assert child_jobs[0].args[0] == project_id
+        assert child_jobs[0].args[1] == f"{prefix}beta.JPG"
+        assert child_jobs[0].args[2] == "beta.JPG"
+    finally:
+        delete_objects_by_prefix(bucket, prefix)
+
+
+@pytest.mark.asyncio
+async def test_ingest_existing_uploads_task_skips_when_project_lock_is_held(
+    arq_ctx, auth_user, create_test_project
+):
+    project_id = create_test_project
+    lock_key = f"lock:ingest:{project_id}"
+    await arq_ctx["redis"].set(lock_key, "other-job", ex=1800)
+
+    result = await ingest_existing_uploads_task(
+        arq_ctx,
+        project_id,
+        auth_user.id,
+        str(uuid.uuid4()),
+    )
+
+    assert result["skipped"] is True
+    assert result["enqueued"] == 0
+
+    queued = await arq_ctx["redis"].queued_jobs(queue_name="default_queue")
+    child_jobs = [job for job in queued if job.function == "process_uploaded_image"]
+    assert child_jobs == []
 
 
 @pytest.mark.asyncio

--- a/src/frontend/src/api/projects.ts
+++ b/src/frontend/src/api/projects.ts
@@ -9,6 +9,7 @@ import { getTaskStates } from '@Services/project';
 import { getUserProfileInfo, getUsers } from '@Services/common';
 import {
   startProjectClassification,
+  ingestExistingUploads,
   getProjectStatus,
   getProjectImages,
   BatchStatusSummary,
@@ -134,6 +135,19 @@ export const useStartProjectClassificationMutation = (
   return useMutation({
     mutationFn: ({ projectId }) =>
       startProjectClassification(projectId),
+    ...mutationOptions,
+  });
+};
+
+export const useIngestExistingUploadsMutation = (
+  mutationOptions?: UseMutationOptions<
+    { message: string; job_id: string; project_id: string; batch_id: string },
+    Error,
+    { projectId: string }
+  >,
+) => {
+  return useMutation({
+    mutationFn: ({ projectId }) => ingestExistingUploads(projectId),
     ...mutationOptions,
   });
 };

--- a/src/frontend/src/components/DroneOperatorTask/DescriptionSection/DroneImageProcessingWorkflow/index.tsx
+++ b/src/frontend/src/components/DroneOperatorTask/DescriptionSection/DroneImageProcessingWorkflow/index.tsx
@@ -8,6 +8,7 @@ import { deleteBatch } from '@Services/classification';
 import type { ImageClassificationResult } from '@Services/classification';
 import {
   useStartProjectClassificationMutation,
+  useIngestExistingUploadsMutation,
   useGetProjectStatusQuery,
   useGetProjectImagesQuery,
 } from '@Api/projects';
@@ -35,11 +36,42 @@ export const UploadImageryDialog = ({
   const [showAbortConfirmation, setShowAbortConfirmation] = useState(false);
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
   const [isDeletingBatches, setIsDeletingBatches] = useState(false);
+  const [showIngestButton, setShowIngestButton] = useState(false);
+  const [ingestTriggered, setIngestTriggered] = useState(false);
+
+  const ingestMutation = useIngestExistingUploadsMutation({
+    onSuccess: () => {
+      toast.success('Ingestion job started. Images will appear in the Classify dialog as they are processed.');
+      setIngestTriggered(true);
+      setHasUploaded(true);
+    },
+    onError: (error: any) => {
+      toast.error(`Ingest failed: ${error?.message || 'Unknown error'}`);
+    },
+  });
+
+  // Hold Ctrl to reveal the ingest button (same pattern as NodeODM server prompt)
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Control') setShowIngestButton(true);
+    };
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (e.key === 'Control') setShowIngestButton(false);
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+    };
+  }, [isOpen]);
 
   useEffect(() => {
     if (isOpen) {
       setShowAbortConfirmation(false);
       setShowDeleteConfirmation(false);
+      setIngestTriggered(false);
     }
   }, [isOpen]);
 
@@ -114,9 +146,31 @@ export const UploadImageryDialog = ({
             />
           </div>
 
-          <div className="naxatw-flex naxatw-w-full naxatw-flex-shrink-0 naxatw-justify-end naxatw-border-t naxatw-pt-4">
-            <Button variant="outline" className="naxatw-border-gray-300" onClick={handleClose}>
-              Close
+          <div className="naxatw-flex naxatw-w-full naxatw-flex-shrink-0 naxatw-items-center naxatw-justify-between naxatw-border-t naxatw-pt-4">
+            {(showIngestButton || ingestTriggered) ? (
+              <div className="naxatw-flex naxatw-flex-col naxatw-gap-1">
+                <p className="naxatw-text-xs naxatw-text-gray-500">
+                  Already uploaded imagery directly to S3 that you need to ingest?
+                </p>
+                <Button
+                  variant="outline"
+                  className="naxatw-w-fit naxatw-border-gray-300 naxatw-text-sm"
+                  onClick={() => ingestMutation.mutate({ projectId })}
+                  disabled={ingestMutation.isPending || ingestTriggered}
+                  leftIcon="cloud_sync"
+                >
+                  {ingestTriggered ? 'Ingestion Started' : ingestMutation.isPending ? 'Starting...' : 'Ingest Existing S3 Imagery'}
+                </Button>
+              </div>
+            ) : (
+              <div />
+            )}
+            <Button
+              variant="ghost"
+              className="naxatw-bg-red naxatw-text-white"
+              onClick={handleClose}
+            >
+              Continue
             </Button>
           </div>
         </div>

--- a/src/frontend/src/services/classification.ts
+++ b/src/frontend/src/services/classification.ts
@@ -91,6 +91,21 @@ export const deleteBatch = async (
   return response.data;
 };
 
+/**
+ * Ingest existing S3 uploads — enqueues a background job to scan user-uploads/
+ * and process any files not yet tracked in the database.
+ */
+export const ingestExistingUploads = async (
+  projectId: string,
+): Promise<{ message: string; job_id: string; project_id: string; batch_id: string }> => {
+  const response = await authenticated(api).post(
+    `/projects/${projectId}/ingest-uploads/`,
+    {},
+    { headers: { 'Content-Type': 'application/json' } },
+  );
+  return response.data;
+};
+
 // ─── Project-scoped classification endpoints ────────────────────────────────
 
 /**

--- a/tasks/process
+++ b/tasks/process
@@ -1,0 +1,88 @@
+# Copyright (c) Humanitarian OpenStreetMap Team
+#
+# This file is part of Drone-TM.
+#
+#     Drone-TM is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     Drone-TM is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with Drone-TM.  If not, see <https:#www.gnu.org/licenses/>.
+#
+
+set dotenv-load
+
+# Auto-detect nerdctl when docker is not installed (e.g. after `just prep machine`)
+docker := env("DOCKER_ALIAS", if `command -v docker >/dev/null 2>&1 && echo found || echo missing` == "found" { "docker" } else { "nerdctl" })
+
+# DroneTM S3 config (from .env)
+dtm_endpoint := env("S3_ENDPOINT_UPLOAD", "http://localhost:9000")
+dtm_bucket   := env("S3_BUCKET_NAME", "dtm-bucket")
+dtm_access   := env("S3_ACCESS_KEY", "admin")
+dtm_secret   := env("S3_SECRET_KEY", "somelongpassword")
+
+# List available commands
+[private]
+default:
+  just --justfile {{justfile()}} --list process
+
+# Copy imagery from an external S3 path into a DroneTM project's user-uploads dir.
+#
+# Runs rclone in a docker container — no volume mounts needed (S3-to-S3).
+# Uses --checksum for efficient delta sync.
+#
+# After copying, open the Upload Imagery dialog in the DroneTM UI and click
+# "Ingest Existing S3 Imagery" to load the files into the database.
+# Then proceed to the Classify dialog as normal.
+#
+# Usage:
+#   just process import-imagery <project_id> \
+#       <src_bucket> <src_prefix> <src_endpoint> <src_access_key> <src_secret_key>
+#
+# Examples:
+#   # From AWS S3
+#   just process import-imagery abc-123-def \
+#       my-bucket surveys/2026-04/flight-data \
+#       https://s3.amazonaws.com AKIAEXAMPLE wJalrXUtnFEMI/EXAMPLEKEY
+#
+#   # From another MinIO instance
+#   just process import-imagery abc-123-def \
+#       source-bucket raw-images \
+#       http://other-minio:9000 otheradmin otherpassword
+import-imagery project_id src_bucket src_prefix src_endpoint src_access_key src_secret_key:
+  #!/usr/bin/env bash
+  set -euo pipefail
+
+  DEST="{{ dtm_bucket }}/projects/{{ project_id }}/user-uploads/"
+
+  echo "==> Copying imagery"
+  echo "    Source: {{ src_bucket }}/{{ src_prefix }}"
+  echo "    Dest:   ${DEST}"
+  echo "    Source endpoint: {{ src_endpoint }}"
+  echo "    Dest endpoint:   {{ dtm_endpoint }}"
+  echo ""
+
+  {{ docker }} run --rm --network host \
+    rclone/rclone:latest \
+    copy \
+      ":s3,provider=Other,endpoint={{ src_endpoint }},access_key_id={{ src_access_key }},secret_access_key={{ src_secret_key }}:{{ src_bucket }}/{{ src_prefix }}" \
+      ":s3,provider=Other,endpoint={{ dtm_endpoint }},access_key_id={{ dtm_access }},secret_access_key={{ dtm_secret }}:${DEST}" \
+      --checksum \
+      --include "*.jpg" --include "*.JPG" --include "*.jpeg" --include "*.JPEG" \
+      --include "*.tif" --include "*.TIF" --include "*.tiff" --include "*.TIFF" \
+      --include "*.png" --include "*.PNG" --include "*.dng"  --include "*.DNG" \
+      --s3-no-check-bucket \
+      --transfers 8 \
+      --progress \
+      -v
+
+  echo ""
+  echo "==> Copy complete."
+  echo "    Open the Upload Imagery dialog in the DroneTM UI and click"
+  echo "    'Ingest Existing S3 Imagery' to load files into the database."


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Related to https://github.com/hotosm/drone-tm/issues/761, but not specifically for that issue.

## Describe this PR


**Problem**:
- Sometimes we are receiving a dump of imagery into an S3 bucket that we need to sort through for processing.
- We need a step for de-duplicate any dup images, bin into suitable task sizes for processing, and also filter bad images (blurry, shadowed, etc).

**Solution**:
1. Create a project with an AOI covering the entire area of imagery collected.
2. Split into task areas, probably 1000m task squares, to reduce the total number to process.
3. I added a justfile command `just process import-imagery`, which can be used to copy all the imagery file prefixes from a given S3 bucket and path, into the dronetm project, under the `{project_id}/user-uploads` staging area.
4. In the uploader dialog in the UI, it's possible to **hold CTRL** and see a button to 'ingest existing imagery'.
5. Clicking this triggers reading all the imagery, analysing for dups, and making a db record for the EXIF of each image (will take time!).
6. Then the user can continue with the standard workflows, as if they uploaded directly via DroneTM --> classify --> verify --> process.
  - An alternative to processing in DroneTM could be to then rclone all the final task images (`{project_id}/{task_id}/images` for each task) onto a machine to do a more manual processing workflow described here: https://github.com/hotosm/ScaleODM/issues/3

**Potential issue**:
- Obviously by classifying the imagery into **new** task areas that don't conform with whatever was done in the field, means the _flight tail identification_ pipeline is probably a bit useless here...
- But the rest should all work!

## Screenshots

1. Created a project in DroneTM local dev.
2. Uploaded the imagery via Minio browser:

<img width="1666" height="885" alt="image" src="https://github.com/user-attachments/assets/3381cfbf-dc1e-4ef2-827d-80fd59d4a8d1" />

3. It's a test dataset, containing dups, and issue imagery:

<img width="2104" height="1062" alt="image" src="https://github.com/user-attachments/assets/757f91d0-de1b-4c67-b399-1e3e0b25ba20" />

4. Do to DroneTM project and hold CTRL on the imagery upload dialog:

<img width="2406" height="1144" alt="image" src="https://github.com/user-attachments/assets/f68874dc-880c-469f-a600-705fb6833b28" />

5. Backend logs

```
backend-1  | 2026-04-10 15:24:29.655 | INFO     | uvicorn.protocols.http.h11_impl:send:468 | 172.20.0.1:34944 - "OPTIONS /api/projects/95655c8d-73f2-49fb-a9ee-5ea943a0b821/ingest-uploads/ HTTP/1.1" 200
backend-1  | 2026-04-10 15:24:29.684 | INFO     | app.projects.classification_routes:ingest_existing_uploads:146 | Ingest-uploads: queued job ingest-uploads:95655c8d-73f2-49fb-a9ee-5ea943a0b821 for project 95655c8d-73f2-49fb-a9ee-5ea943a0b821 (batch c7271cc5-ebac-4e71-bf09-b2112512cd36)
backend-1  | 2026-04-10 15:24:29.685 | INFO     | uvicorn.protocols.http.h11_impl:send:468 | 172.20.0.1:34958 - "POST /api/projects/95655c8d-73f2-49fb-a9ee-5ea943a0b821/ingest-uploads/ HTTP/1.1" 200
```

6. arq worker logs

```
arq-worker-1  | 15:24:39:   3.92s ← ingest-img:95655c8d-73f2-49fb-a9ee-5ea943a0b821:c448c6dceed8bec8cfbffc72542d3809:process_uploaded_image ● {'image_id': 'b27daa96-057a-422f-8835-c1dd7e8141e5', 'status': <ImageStatus.STA…
arq-worker-1  |   3.92s ← ingest-img:95655c8d-73f2-49fb-a9ee-5ea943a0b821:c448c6dceed8bec8cfbffc72542d3809:process_uploaded_image ● {'image_id': 'b27daa96-057a-422f-8835-c1dd7e8141e5', 'status': <ImageStatus.STA…
arq-worker-1  | 15:24:39:   1.56s ← ingest-img:95655c8d-73f2-49fb-a9ee-5ea943a0b821:97d755f722a9d869a71b9041b88185e0:process_uploaded_image ● {'image_id': '6a4895db-2134-47bd-99fe-480b46850138', 'status': <ImageStatus.STA…
arq-worker-1  |   1.56s ← ingest-img:95655c8d-73f2-49fb-a9ee-5ea943a0b821:97d755f722a9d869a71b9041b88185e0:process_uploaded_image ● {'image_id': '6a4895db-2134-47bd-99fe-480b46850138', 'status': <ImageStatus.STA…
arq-worker-1  | 2026-04-10 15:24:39.995 | INFO     | app.arq.tasks:process_uploaded_image:364 - Uploading thumbnail to S3: projects/95655c8d-73f2-49fb-a9ee-5ea943a0b821/user-uploads/thumb_DJI_20251027143610_0009_D.JPG
arq-worker-1  | 2026-04-10 15:24:40.004 | INFO     | app.arq.tasks:process_uploaded_image:375 - Thumbnail generated and uploaded: projects/95655c8d-73f2-49fb-a9ee-5ea943a0b821/user-uploads/thumb_DJI_20251027143610_0009_D.JPG
arq-worker-1  | 2026-04-10 15:24:40.006 | INFO     | app.images.image_logic:create_project_image:333 - Created project image record: 0bd6ed63-31b0-4674-a646-94e5e74d3adc
arq-worker-1  | 2026-04-10 15:24:40.009 | INFO     | app.arq.tasks:_save_image_record:220 - Saved: DJI_20251027143610_0009_D.JPG | Status: ImageStatus.STAGED | GPS: True | EXIF: True | BatchID: c7271cc5-ebac-4e71-bf09-b2112512cd36
arq-worker-1  | 2026-04-10 15:24:40.010 | INFO     | app.arq.tasks:process_uploaded_image:413 - Completed (Job: ingest-img:95655c8d-73f2-49fb-a9ee-5ea943a0b821:74eba5afba9ac6e8b517ce5a9481fe7f): ID=0bd6ed63-31b0-4674-a646-94e5e74d3adc | Status=ImageStatus.STAGED | EXIF=Yes | GPS=Yes
arq-worker-1  | 15:24:40:   1.71s ← ingest-img:95655c8d-73f2-49fb-a9ee-5ea943a0b821:74eba5afba9ac6e8b517ce5a9481fe7f:process_uploaded_image ● {'image_id': '0bd6ed63-31b0-4674-a646-94e5e74d3adc', 'status': <ImageStatus.STA…
arq-worker-1  |   1.71s ← ingest-img:95655c8d-73f2-49fb-a9ee-5ea943a0b821:74eba5afba9ac6e8b517ce5a9481fe7f:process_uploaded_image ● {'image_id': '0bd6ed63-31b0-4674-a646-94e5e74d3adc', 'status': <ImageStatus.STA…
arq-worker-1  | 15:24:59: recording health: Apr-10 15:24:59 j_complete=50 j_failed=0 j_retried=0 j_ongoing=0 queued=0
arq-worker-1  | recording health: Apr-10 15:24:59 j_complete=50 j_failed=0 j_retried=0 j_ongoing=0 queued=0
```

7. View the classification dialog - all the imagery is there!

<img width="1788" height="1380" alt="image" src="https://github.com/user-attachments/assets/62b9b571-2fce-4977-8f7a-1744fa294349" />

> [!NOTE]
> The one image identified as with 'issues' before even classifying is an image without an EXIF data at all.

8. Continue through the Classify and Verify steps for the imagery, before exporting via rclone again to process manually on an EC2 😄 

## Alternative Approaches Considered

- Using an auth token from DroneTM and doing this all via Justfile / API. But I wanted to adhere to the standard DroneTM UI based workflow to avoid duplicated logic / work.

## Checklist before requesting a review

- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
