### PR TITLE
In CONTRIBUTING.md, recommend uv for installing Python and pre-commit.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,19 @@ it's much easier to read.
 See a detailed guide on documentation contributions
 [here](https://docs.hotosm.org/techdoc).
 
+### Python environment
+
+Python 3.10 or later is required.
+
+We recommend you manage your Python environment with `uv`.
+These setup commands will install `uv` and
+ensure you have a sufficiently recent Python:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+uv python install
+```
+
 ### Pre-Commit Hooks
 
 [Pre-Commit Hooks][5] are used in this repo to enforce coding style:
@@ -100,7 +113,7 @@ See a detailed guide on documentation contributions
 Please install the pre-commit hooks before contributing:
 
 ```bash
-pip install pre-commit
+uv tool install pre-commit
 pre-commit install
 ```
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR

I ran into some trouble trying to contribute because the default Python on MacOS is 3.9, but pre-commit runs pyupgrade, which requires Python 3.10.  I have newer Pythons installed by Homebrew, but pre-commit won't use them.

Using `uv` to install both Python and pre-commit fixes this problem for me.  This edit recommends that all developers use `uv` this way.

## AI Tool Usage

- [ ] No AI tools were used
- [x] AI tools were used (complete below)

**If AI-assisted:**

- Tools used: Claude
- What was generated: Nothing; Claude helped me diagnose why pre-commit was failing

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/hotosm/drone-tm/blob/dev/CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](https://docs.hotosm.org/code-of-conduct)
- [x] PR is focused and small
- [ ] Tests are included or updated
- [x] I understand all code in this PR and can answer questions about it
- [x] No secrets, credentials, or sensitive data are included
- [x] Commit messages are descriptive
- [x] Related docs and screenshots are updated