### PR TITLE
Implement ScaleODM remote scalable processing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,8 +54,16 @@ HANKO_API_URL=${HANKO_API_URL:-https://dev.login.hotosm.org}
 COOKIE_DOMAIN=${COOKIE_DOMAIN:-}
 
 # ---- External APIs ----
-# ODM endpoint (NodeODM typically) for processing
-ODM_ENDPOINT=${ODM_ENDPOINT:-http://nodeodm:9900}
+# ODM endpoint for processing. End-to-end runs require ScaleODM
+# (NodeODM has no S3 writer and cannot complete the new pipeline).
+# For local dev with ScaleODM running on the host, point this at
+# host.docker.internal:31100 - the in-network nodeodm container is
+# only a placeholder so the backend boots cleanly.
+ODM_ENDPOINT=${ODM_ENDPOINT:-http://host.docker.internal:31100}
+# In-cluster S3 endpoint for ScaleODM workflow pods. Only set when the
+# browser-facing S3 hostname differs from what workflow pods can reach
+# (self-hosted MinIO/RustFS).
+SCALEODM_S3_ENDPOINT=${SCALEODM_S3_ENDPOINT:-}
 
 # ---- Optional monitoring ----
 MONITORING=${MONITORING:-}

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,9 @@ src/backend/frontend_html
 *.json
 !**/package.json
 !**/tsconfig.json
+
+# LLM tools
+.claude
+.codex
+plans
+checkpoints

--- a/README.md
+++ b/README.md
@@ -107,11 +107,12 @@ To get started with DroneTM:
 |✅| 🖥️ improved user feedback and retry capabilities during imagery processing | [v2026.2.0][7] |
 |✅| 🖥️ identify flight gaps in the captured imagery, generating a second flightplan | [v2026.2.1][8] |
 |✅| 🖥️ Unified HOT login system, linking to other tools | [v2026.3.0][9] |
+|✅| 🖥️ scaling of ODM imagery processing to thousands of images in parallel | [v2026.5.0][10] |
 |⚙️| 📱 better method to load flightplans onto drones: direct send to drone, instead of manual copy | |
 |⚙️| 🖥️ separate workflows for processing individual images vs batch processing in ODM | |
-|⚙️| 🖥️ scaling of ODM imagery processing to hundreds of images in parallel | |
 |⚙️| 📱 capture of imagery at multiple (configurable) angles from the drone camera | |
 | | 📱 allow modification and division of flightplans by user before flight | |
+| | 🖥️ add processing workflows for thermal imagery and accuracy improvements at city-scale | |
 | | 🖥️ user access management for each part of the UI | |
 | | 🖥️ access to alternative high quality terrain models such as Copernicus GLO-30 | |
 | | 📱 & 🖥️ real-time notifications for drone flight progress & task status | |
@@ -176,3 +177,4 @@ Join us in transforming aerial mapping through community-powered drones and crea
 [7]: https://github.com/hotosm/drone-tm/releases/tag/2026.2.0
 [8]: https://github.com/hotosm/drone-tm/releases/tag/2026.2.1
 [9]: https://github.com/hotosm/drone-tm/releases/tag/2026.3.0
+[10]: https://github.com/hotosm/drone-tm/releases/tag/2026.5.0

--- a/compose.yaml
+++ b/compose.yaml
@@ -57,6 +57,9 @@ services:
       # In dev, use the host-exposed RustFS port for presigned URLs.
       # (Path-rewriting proxies like `/s3` break S3 presigned signatures.)
       S3_ENDPOINT_DOWNLOAD: ${S3_ENDPOINT_DOWNLOAD:-http://localhost:9000}
+      # Host-networked ScaleODM needs host-reachable URLs for S3 and webhooks.
+      SCALEODM_S3_ENDPOINT: ${SCALEODM_S3_ENDPOINT:-http://localhost:9000}
+      BACKEND_URL_INTERNAL: ${BACKEND_URL_INTERNAL:-http://localhost:${BACKEND_WEB_APP_PORT:-8000}}
       # Dev uses network_mode:service:backend (shared namespace), so localhost
       DRAGONFLY_DSN: redis://localhost:6379/0
     networks:
@@ -127,6 +130,8 @@ services:
     volumes:
       - rustfs-data:/data
     environment:
+      # NOTE we set these to match the dev credentials for ScaleODM S3 service too
+      # This allows us to test with ScaleODM, without having to re-configure access/secret
       RUSTFS_ACCESS_KEY: ${S3_ACCESS_KEY:-admin}
       RUSTFS_SECRET_KEY: ${S3_SECRET_KEY:-somelongpassword}
     network_mode: service:backend
@@ -231,6 +236,8 @@ services:
     env_file: .env
     environment:
       QGIS_URL: ${QGIS_URL:-http://localhost:8080}
+      SCALEODM_S3_ENDPOINT: ${SCALEODM_S3_ENDPOINT:-http://localhost:9000}
+      BACKEND_URL_INTERNAL: ${BACKEND_URL_INTERNAL:-http://localhost:${BACKEND_WEB_APP_PORT:-8000}}
       DRAGONFLY_DSN: redis://localhost:6379/0
     network_mode: service:backend
     restart: unless-stopped

--- a/docs/dev/setup.md
+++ b/docs/dev/setup.md
@@ -83,9 +83,33 @@ DroneTM Backend: [http://localhost:8000](http://localhost:8000)
 
 DroneTM Frontend: [http://localhost:3040](http://localhost:3040)
 
-Web ODM: [http://localhost:9900](http://localhost:9900)
-
-- Default user: `admin`
-- Default password: `password`
-
 > Note the ports may be different if you changed them in the dotenv file.
+
+## End-to-end imagery processing (ScaleODM)
+
+DroneTM submits processing jobs to **ScaleODM**, which reads imagery directly
+from S3 and writes outputs back to S3. The compose stack ships a small NodeODM
+container as a placeholder so the backend boots cleanly, **but NodeODM cannot
+complete an end-to-end run**: it has no S3 writer, so the finalize step (which
+expects the orthophoto to already be in S3) will fail. To exercise the full
+pipeline locally you need ScaleODM running.
+
+1. Start ScaleODM on your host (kind/k3d, see the [ScaleODM
+   quickstart](https://github.com/hotosm/scaleodm)). It exposes its API on
+   `localhost:31100` by default.
+2. Point the backend at it from inside the compose network. Set in `.env`:
+
+   ```dotenv
+   # Backend container reaches the host via host.docker.internal
+   ODM_ENDPOINT=http://host.docker.internal:31100
+   # Only set this if your S3 hostname differs from what ScaleODM workflow
+   # pods can resolve (self-hosted MinIO/RustFS):
+   # SCALEODM_S3_ENDPOINT=http://host.docker.internal:9000
+   ```
+
+3. Restart the backend: `just start backend`.
+
+When `just start all` runs it will probe `localhost:31100/info` and warn if
+ScaleODM isn't reachable. The warning is informational - the rest of DroneTM
+(uploads, ingest, classification, UI) works without ScaleODM; only the
+processing path needs it.

--- a/src/backend/app/arq/tasks.py
+++ b/src/backend/app/arq/tasks.py
@@ -51,10 +51,11 @@ from app.s3 import (
 from app.images.image_classification import ImageClassifier
 from app.jaxa.upload_dem import download_and_upload_dem
 from app.images.image_processing import (
-    OdmAssetTerminalError,
-    OdmAssetTransientError,
+    OrthophotoPostProcessingError,
     extract_and_upload_odm_assets,
-    process_assets_from_odm,
+    fetch_scaleodm_task_info,
+    remove_scaleodm_task,
+    reproject_orthophoto_in_place,
 )
 from app.models.enums import ImageProcessingStatus, State
 from app.tasks import task_logic
@@ -1189,36 +1190,38 @@ async def _persist_odm_failure(
         log.error(f"Failed to persist ODM failure state for {target}: {state_err}")
 
 
-async def process_odm_webhook_assets(
+async def finalize_scaleodm_task(
     ctx: Dict[Any, Any],
-    node_odm_url: str,
+    *,
+    scaleodm_url: str,
     dtm_project_id: str,
-    odm_task_id: str,
+    odm_task_uuid: str,
+    odm_status_code: int,
     state_name: Optional[str] = None,
     message: Optional[str] = None,
     dtm_task_id: Optional[str] = None,
-    odm_status_code: Optional[int] = None,
     **_kwargs: Any,
 ) -> Dict[str, Any]:
-    """ARQ wrapper for process_assets_from_odm (webhook flow).
+    """Finalize a ScaleODM task after a webhook (or reconciler) reports terminal status.
 
-    Offloads the heavy zip download, extraction, and GDAL reprojection
-    from the API server to the worker so it doesn't trigger liveness
-    probe failures.
-
-    Uses a Redis lock (SET NX) to prevent concurrent processing of the
-    same task, in addition to arq's ``_job_id`` dedup at enqueue time.
+    On status 40 (completed), pulls odm_orthophoto.tif from the ScaleODM
+    output prefix, reprojects it to EPSG:3857 COG, overwrites the same key,
+    sets ``assets_url`` and transitions to IMAGE_PROCESSING_FINISHED. On 30
+    (failed) records an error message and marks the task/project failed.
+    Either way, best-effort POST /task/remove cleans up the ScaleODM row.
     """
     job_id = ctx.get("job_id", "unknown")
     log.info(
-        "Starting process_odm_webhook_assets (Job ID: {}): project={} odm_task={}",
+        "Starting finalize_scaleodm_task (Job ID: {}): project={} odm_task={} code={}",
         job_id,
         dtm_project_id,
-        odm_task_id,
+        odm_task_uuid,
+        odm_status_code,
     )
 
-    # Distributed lock: prevent two workers from processing the same
-    # task concurrently (belt-and-suspenders alongside _job_id dedup).
+    # Distributed lock: belt-and-suspenders alongside arq's _job_id dedup.
+    # Lock key is intentionally identical to the legacy one so a webhook
+    # and a reconciliation pass can never race even across deploy boundaries.
     lock_target = dtm_task_id or dtm_project_id
     lock_key = f"lock:odm-assets:{lock_target}"
     redis = ctx.get("redis")
@@ -1228,58 +1231,138 @@ async def process_odm_webhook_assets(
             lock_key,
             job_id,
             nx=True,
-            ex=21600,  # 6 hours - must exceed worst-case download + reprojection
+            ex=21600,  # 6 hours - must exceed worst-case reprojection
         )
         if not lock_acquired:
             log.warning(
-                "Skipping process_odm_webhook_assets for {}: "
+                "Skipping finalize_scaleodm_task for {}: "
                 "another job already holds the lock",
                 lock_target,
             )
             return {"status": "skipped", "reason": "concurrent_lock"}
 
-    try:
-        project_uuid = UUID(dtm_project_id)
-        task_uuid = UUID(dtm_task_id) if dtm_task_id else None
-        state = State[state_name] if state_name else None
-        job_try = int(ctx.get("job_try") or 1)
-        max_tries = int(getattr(WorkerSettings, "max_tries", 3) or 3)
+    project_uuid = UUID(dtm_project_id)
+    task_uuid = UUID(dtm_task_id) if dtm_task_id else None
+    state = State[state_name] if state_name else None
+    db_pool = ctx.get("db_pool")
+    job_try = int(ctx.get("job_try") or 1)
+    max_tries = int(getattr(WorkerSettings, "max_tries", 3) or 3)
 
-        try:
-            await process_assets_from_odm(
-                node_odm_url=node_odm_url,
-                dtm_project_id=project_uuid,
-                odm_task_id=odm_task_id,
-                state=state,
-                message=message,
-                dtm_task_id=task_uuid,
-                odm_status_code=odm_status_code,
-                persist_failure_state=False,
-                db_pool=ctx.get("db_pool"),
-            )
-        except OdmAssetTransientError as e:
-            if job_try < max_tries:
+    try:
+        # Pre-flight: skip if the task is no longer in the expected state
+        # (a previous webhook + reconciler may have already finalized).
+        if task_uuid and state and db_pool:
+            try:
+                async with db_pool.connection() as conn:
+                    current = await task_logic.get_task_state(
+                        conn, project_uuid, task_uuid
+                    )
+                    current_state = current.get("state") if current else None
+                    if current_state and current_state != state.name:
+                        log.warning(
+                            "Skipping finalize for task {}: expected state {} "
+                            "but found {} (already handled)",
+                            task_uuid,
+                            state.name,
+                            current_state,
+                        )
+                        return {"status": "skipped", "reason": "state_mismatch"}
+            except Exception as e:
                 log.warning(
-                    f"Transient ODM asset processing error "
-                    f"(try {job_try}/{max_tries}), retrying: {e}",
+                    "Could not verify task state before finalizing (continuing): {}",
+                    e,
                 )
+
+        if int(odm_status_code) == 40:
+            try:
+                await asyncio.to_thread(
+                    reproject_orthophoto_in_place, project_uuid, task_uuid
+                )
+            except OrthophotoPostProcessingError as e:
+                if job_try < max_tries:
+                    log.warning(
+                        "Transient orthophoto post-processing failure "
+                        "(try {}/{}), retrying: {}",
+                        job_try,
+                        max_tries,
+                        e,
+                    )
+                    raise
+                log.error(
+                    "Orthophoto post-processing exhausted retries ({}/{}): {}",
+                    job_try,
+                    max_tries,
+                    e,
+                )
+                await _persist_odm_failure(ctx, project_uuid, task_uuid, state, str(e))
                 raise
 
-            log.error(
-                f"ODM asset processing exhausted retries ({job_try}/{max_tries}): {e}",
+            task_segment = f"{task_uuid}/" if task_uuid else ""
+            assets_prefix = f"projects/{dtm_project_id}/{task_segment}odm/"
+
+            if db_pool:
+                async with db_pool.connection() as conn:
+                    if task_uuid and state:
+                        await task_logic.update_task_state_system(
+                            db=conn,
+                            project_id=project_uuid,
+                            task_id=task_uuid,
+                            comment=message,
+                            initial_state=state,
+                            final_state=State.IMAGE_PROCESSING_FINISHED,
+                            updated_at=timestamp(),
+                        )
+                        await project_logic.update_task_field(
+                            conn,
+                            project_uuid,
+                            task_uuid,
+                            "assets_url",
+                            assets_prefix,
+                        )
+                        log.info(
+                            f"Task {task_uuid} state updated to IMAGE_PROCESSING_FINISHED."
+                        )
+                    elif not task_uuid:
+                        await project_logic.update_processing_status(
+                            conn, project_uuid, ImageProcessingStatus.SUCCESS
+                        )
+                        log.info(f"Project {project_uuid} status updated to SUCCESS.")
+                    await conn.commit()
+
+            await remove_scaleodm_task(
+                scaleodm_url=scaleodm_url, odm_task_uuid=odm_task_uuid
             )
-            await _persist_odm_failure(ctx, project_uuid, task_uuid, state, str(e))
-            raise
-        except OdmAssetTerminalError as e:
-            log.error(f"Terminal ODM asset processing error: {e}")
-            await _persist_odm_failure(ctx, project_uuid, task_uuid, state, str(e))
+            return {"status": "completed", "project_id": dtm_project_id}
+
+        if int(odm_status_code) == 30:
+            error_detail = message or "ODM processing failed"
+            info = await fetch_scaleodm_task_info(
+                scaleodm_url=scaleodm_url, odm_task_uuid=odm_task_uuid
+            )
+            if info and isinstance(info, dict):
+                err = info.get("errorMessage") or info.get("error")
+                if err:
+                    error_detail = str(err)
+
+            await _persist_odm_failure(
+                ctx, project_uuid, task_uuid, state, error_detail
+            )
+
+            await remove_scaleodm_task(
+                scaleodm_url=scaleodm_url, odm_task_uuid=odm_task_uuid
+            )
             return {
                 "status": "failed",
-                "reason": "terminal_error",
+                "reason": "odm_status_30",
                 "project_id": dtm_project_id,
             }
 
-        return {"status": "completed", "project_id": dtm_project_id}
+        log.warning(
+            "finalize_scaleodm_task called with unexpected status code {} "
+            "(expected 30 or 40); skipping",
+            odm_status_code,
+        )
+        return {"status": "skipped", "reason": "unexpected_status_code"}
     finally:
         if redis and lock_acquired:
             await redis.delete(lock_key)
@@ -1690,7 +1773,7 @@ class WorkerSettings:
         download_and_upload_dem,
         generate_qfield_project,
         process_imported_odm_assets,
-        process_odm_webhook_assets,
+        finalize_scaleodm_task,
         create_project_from_imagery_exif,
     ]
 

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -203,8 +203,12 @@ class Settings(BaseSettings):
 
     # Internal backend URL for Docker-internal services (webhooks from ODM, etc.)
     BACKEND_URL_INTERNAL: str = "http://backend:8000"
-    # ODM (NodeODM) API endpoint
-    ODM_ENDPOINT: Optional[str] = "http://nodeodm:9900"
+    # ODM (ScaleODM) API endpoint
+    ODM_ENDPOINT: Optional[str] = "http://host.docker.internal:31100"
+    # In-cluster S3 endpoint passed to ScaleODM workflow pods.
+    # Needed when the browser-facing S3 hostname differs from what
+    # workflow pods can resolve (self-hosted MinIO/RustFS).
+    SCALEODM_S3_ENDPOINT: Optional[str] = None
     QGIS_URL: Optional[str] = "http://qgis:8080"
     DRAGONFLY_DSN: str = "redis://dragonfly:6379/0"
 

--- a/src/backend/app/images/image_processing.py
+++ b/src/backend/app/images/image_processing.py
@@ -1,378 +1,159 @@
-import asyncio
+import json
 import os
-import shutil
 import tempfile
 import uuid
 import zipfile
-from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Literal, Optional
 
 import aiohttp
 from loguru import logger as log
 from osgeo import gdal
-from psycopg import Connection
-from pyodm import Node
 
 from app.config import settings
-from app.db import database
-from app.models.enums import ImageProcessingStatus, State
-from app.projects import project_logic
 from app.s3 import (
     add_file_to_bucket,
     delete_objects_by_prefix,
-    generate_presigned_get_url,
     get_file_from_bucket,
-    list_objects_from_bucket,
-)
-from app.tasks import task_logic
-from app.utils import timestamp
-
-ODM_GET_TASK_TIMEOUT_SEC = 60
-ODM_DOWNLOAD_ZIP_TIMEOUT_SEC = (
-    7200  # 2 hours - large projects can produce multi-GB zips
 )
 
 
-class OdmAssetProcessingError(RuntimeError):
-    """Base exception for ODM asset post-processing failures."""
+SCALEODM_SUBMIT_TIMEOUT_SEC = 30
 
 
-class OdmAssetTransientError(OdmAssetProcessingError):
-    """Retryable ODM asset post-processing failure."""
+ProcessingMode = Literal["standard", "merge-existing", "thermal", "city-scale"]
 
 
-class OdmAssetTerminalError(OdmAssetProcessingError):
-    """Non-retryable ODM asset post-processing failure."""
+class ScaleOdmSubmitError(RuntimeError):
+    """Raised when POST /task/new is rejected by ScaleODM."""
+
+    def __init__(self, message: str, *, status: Optional[int] = None) -> None:
+        super().__init__(message)
+        self.status = status
 
 
-def _is_retryable_odm_exception(exc: Exception) -> bool:
-    if isinstance(exc, (asyncio.TimeoutError, TimeoutError, ConnectionError, OSError)):
-        return True
-
-    details = str(exc).lower()
-    transient_markers = (
-        "no route to host",
-        "max retries exceeded",
-        "failed to establish a new connection",
-        "connection refused",
-        "temporarily unavailable",
-        "temporary failure",
-        "timed out",
-    )
-    return any(marker in details for marker in transient_markers)
+class OrthophotoPostProcessingError(RuntimeError):
+    """Raised when the in-place orthophoto reprojection fails."""
 
 
-class DroneImageProcessor:
-    def __init__(
-        self,
-        node_odm_url: str,
-        project_id: uuid.UUID,
-        user_id: str,
-        db: Connection,
-        task_id: Optional[uuid.UUID] = None,
-        task_ids: Optional[List[uuid.UUID]] = None,
-    ):
-        """Base initialization for drone image processing.
+async def submit_scaleodm_task(
+    *,
+    scaleodm_url: str,
+    read_s3_path: str,
+    write_s3_path: str,
+    name: str,
+    options: list[dict[str, Any]],
+    webhook: str,
+    processing_mode: ProcessingMode = "standard",
+    s3_scan_depth: int = 1,
+    use_default_excludes: bool = True,
+    exclude_paths: Optional[list[str]] = None,
+    s3_endpoint: Optional[str] = None,
+) -> str:
+    """Create a ScaleODM task via POST /task/new.
 
-        :param node_odm_url: URL of the ODM node
-        :param project_id: Project UUID
-        :param user_id: User ID
-        :param db: Database connection
-        :param task_id: Optional single task ID
-        :param task_ids: Optional list of task IDs
-        """
-        self.node = Node.from_url(node_odm_url)
-        self.project_id = project_id
-        self.user_id = user_id
-        self.db = db
-        self.task_id = task_id
-        self.task_ids = task_ids or ([] if task_id is None else [task_id])
-        self.max_concurrent_downloads = 4
+    Returns the ScaleODM task UUID. Raises :class:`ScaleOdmSubmitError`
+    on a non-2xx response (with the server's ``error``/``errorMessage``
+    string when present).
+    """
+    body: dict[str, Any] = {
+        "name": name,
+        "readS3Path": read_s3_path,
+        "writeS3Path": write_s3_path,
+        "webhook": webhook,
+        "processingMode": processing_mode,
+        "s3ScanDepth": s3_scan_depth,
+        "useDefaultExcludes": use_default_excludes,
+    }
+    if options:
+        body["options"] = json.dumps(options)
+    if exclude_paths:
+        body["excludePaths"] = json.dumps(exclude_paths)
+    if s3_endpoint:
+        body["s3Endpoint"] = s3_endpoint
 
-    def options_list_to_dict(
-        self, options: List[Dict[str, Any]] = None
-    ) -> Dict[str, Any]:
-        """Convert options list to a dictionary.
+    base = scaleodm_url.rstrip("/")
+    url = f"{base}/task/new"
+    timeout = aiohttp.ClientTimeout(total=SCALEODM_SUBMIT_TIMEOUT_SEC)
 
-        :param options: List of option dictionaries
-        :return: Dictionary of options
-        """
-        opts = {}
-        if options is not None:
-            for o in options:
-                opts[o["name"]] = o["value"]
-        return opts
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with session.post(url, json=body) as resp:
+            text = await resp.text()
+            payload: Optional[dict[str, Any]] = None
+            try:
+                payload = json.loads(text) if text else None
+            except json.JSONDecodeError:
+                payload = None
 
-    @staticmethod
-    def _is_thumbnail_object_key(object_key: str) -> bool:
-        normalized_key = object_key.lower().replace("\\", "/")
-        return "/thumbs/" in normalized_key or Path(normalized_key).name.startswith(
-            "thumb_"
-        )
-
-    def list_images(self, directory: str) -> List[str]:
-        """List all image files in a directory.
-
-        :param directory: Directory path
-        :return: List of image file paths
-        """
-        images = []
-        path = Path(directory)
-
-        for file in path.rglob("*"):
-            if file.suffix.lower() not in {".jpg", ".jpeg", ".png", ".txt", ".laz"}:
-                continue
-            if self._is_thumbnail_object_key(str(file)):
-                continue
-            images.append(str(file))
-        return images
-
-    async def download_image(self, session, url, save_path) -> bool:
-        """Download a single image from URL to local path.
-
-        Returns:
-            bool: True if download succeeded, False otherwise
-        """
-        try:
-            async with session.get(url) as response:
-                if response.status == 200:
-                    with open(save_path, "wb") as f:
-                        f.write(await response.read())
-                    return True
-                else:
-                    log.error(f"Failed to download {url}, status: {response.status}")
-                    return False
-        except Exception as e:
-            log.error(f"Error downloading {url}: {e}")
-            return False
-
-    async def download_images_from_s3(
-        self,
-        bucket_name: str,
-        local_dir: str,
-        task_id: uuid.UUID,
-        batch_size: int = 20,
-    ):
-        """Asynchronously download images from S3 in batches.
-
-        :param bucket_name: Bucket name
-        :param local_dir: Local directory to save images
-        :param task_id: Optional specific task ID
-        :param batch_size: Number of images to download concurrently
-        """
-        prefix = f"projects/{self.project_id}/{task_id}/images"
-        objects = list_objects_from_bucket(bucket_name, prefix)
-
-        if not objects:
-            log.warning(f"No images found in S3 for task {task_id}")
-            return
-
-        log.info(f"Downloading images from S3 for task {task_id}...")
-
-        accepted_file_extensions = (".jpg", ".jpeg", ".png", ".txt", ".laz")
-
-        # Use internal=True so the presigned URL is signed against S3 directly,
-        # not against CloudFront (which would fail with AccessDenied).
-        object_urls = [
-            generate_presigned_get_url(bucket_name, obj.object_name, 12, internal=True)
-            for obj in objects
-            if obj.object_name.lower().endswith(accepted_file_extensions)
-            and not self._is_thumbnail_object_key(obj.object_name)
-        ]
-
-        total_files = len(object_urls)
-        log.info(f"{total_files} images found in S3 for task {task_id}")
-
-        successful_downloads = 0
-        failed_downloads = 0
-
-        async with aiohttp.ClientSession() as session:
-            for i in range(0, total_files, batch_size):
-                batch = object_urls[i : i + batch_size]
-                batch_number = i // batch_size + 1
-                total_batches = (total_files + batch_size - 1) // batch_size
-
-                log.info(f"Downloading batch {batch_number}/{total_batches}")
-                tasks = [
-                    self.download_image(
-                        session,
-                        url,
-                        os.path.join(local_dir, f"{task_id}_file_{i + j + 1}.jpg"),
+            if resp.status >= 400:
+                err = None
+                if isinstance(payload, dict):
+                    err = (
+                        payload.get("error")
+                        or payload.get("errorMessage")
+                        or payload.get("message")
                     )
-                    for j, url in enumerate(batch)
-                ]
-                results = await asyncio.gather(*tasks)
-                successful_downloads += sum(1 for r in results if r)
-                failed_downloads += sum(1 for r in results if not r)
+                raise ScaleOdmSubmitError(
+                    err
+                    or f"ScaleODM /task/new returned HTTP {resp.status}: {text[:300]}",
+                    status=resp.status,
+                )
 
-        log.info(
-            f"Completed downloading {successful_downloads}/{total_files} images "
-            f"({failed_downloads} failed)"
-        )
-
-        if successful_downloads < 3:
-            log.error(
-                f"Only {successful_downloads} images downloaded successfully. "
-                f"ODM requires at least 3 images."
+            uuid_value = (
+                (payload or {}).get("uuid") if isinstance(payload, dict) else None
             )
+            if not uuid_value:
+                raise ScaleOdmSubmitError(
+                    f"ScaleODM /task/new response missing uuid: {text[:300]}"
+                )
+            log.info(f"ScaleODM accepted task {uuid_value} ({name})")
+            return str(uuid_value)
 
-    def process_new_task(
-        self,
-        images: List[str],
-        name: Optional[str] = None,
-        options: Optional[List[Dict[str, Any]]] = None,
-        progress_callback: Optional[Any] = None,
-        webhook: Optional[str] = None,
-    ):
-        """Create a new processing task.
 
-        :param images: List of image file paths
-        :param name: Task name
-        :param options: Processing options
-        :param progress_callback: Progress tracking callback
-        :param webhook: Webhook URL
-        :return: Created task object
-        """
-        opts = self.options_list_to_dict(options)
-        task = self.node.create_task(
-            images, opts, name, progress_callback, webhook=webhook
-        )
-        return task
-
-    async def _process_images(
-        self,
-        bucket_name: str,
-        name: Optional[str] = None,
-        options: Optional[List[Dict[str, Any]]] = None,
-        webhook: Optional[str] = None,
-        single_task: bool = True,
-    ):
-        """Internal method to process images for a single task or multiple tasks.
-
-        :param bucket_name: Bucket name
-        :param name: Task name
-        :param options: Processing options
-        :param webhook: Webhook URL
-        :param single_task: Whether processing a single or multiple tasks
-        :return: Created task object
-        """
-        # Create a temporary directory to store downloaded images
-        temp_dir = tempfile.mkdtemp()
-        try:
-            images_list = []
-            # Download images based on single or multiple task processing
-            if single_task:  # and self.task_id:
-                await self.download_images_from_s3(bucket_name, temp_dir, self.task_id)
-                images_list = self.list_images(temp_dir)
-            else:
-                gcp_list_file = f"projects/{self.project_id}/gcp.txt"
-                gcp_file_path = os.path.join(temp_dir, "gcp.txt")
-
-                # Check and add the GCP file to the images list if it exists
-                if get_file_from_bucket(bucket_name, gcp_list_file, gcp_file_path):
-                    images_list.append(gcp_file_path)
-                else:
-                    log.info(
-                        f"GCP file not available for project ID {self.project_id}."
+async def remove_scaleodm_task(*, scaleodm_url: str, odm_task_uuid: str) -> None:
+    """Best-effort POST /task/remove. Logs and swallows failures."""
+    base = scaleodm_url.rstrip("/")
+    url = f"{base}/task/remove"
+    try:
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=SCALEODM_SUBMIT_TIMEOUT_SEC)
+        ) as session:
+            async with session.post(url, json={"uuid": odm_task_uuid}) as resp:
+                if resp.status >= 400:
+                    body = await resp.text()
+                    log.warning(
+                        "ScaleODM /task/remove returned HTTP {} for {}: {}",
+                        resp.status,
+                        odm_task_uuid,
+                        body[:200],
                     )
+                    return
+        log.info(f"Removed ScaleODM task {odm_task_uuid}")
+    except Exception as e:
+        log.warning(f"Failed to remove ScaleODM task {odm_task_uuid}: {e}")
 
-                for task_id in self.task_ids:
-                    await self.download_images_from_s3(bucket_name, temp_dir, task_id)
-                    images_list.extend(self.list_images(temp_dir))
 
-            # Start a new processing task
-            task = self.process_new_task(
-                list(set(images_list)),
-                name=name
-                or (
-                    f"DTM-Task-{self.task_id}"
-                    if single_task
-                    else f"DTM-Project-{self.project_id}"
-                ),
-                options=options,
-                webhook=webhook,
-            )
-
-            return task
-        finally:
-            # Clean up temporary directory
-            shutil.rmtree(temp_dir)
-
-    async def process_single_task(
-        self,
-        bucket_name: str,
-        name: Optional[str] = None,
-        options: Optional[List[Dict[str, Any]]] = None,
-        webhook: Optional[str] = None,
-    ):
-        """Process images for a single task.
-
-        :param bucket_name: Bucket name
-        :param name: Task name
-        :param options: Processing options
-        :param webhook: Webhook URL
-        :return: Created task object
-        """
-        return await self._process_images(
-            bucket_name, name=name, options=options, webhook=webhook, single_task=True
-        )
-
-    async def process_multiple_tasks(
-        self,
-        bucket_name: str,
-        name: Optional[str] = None,
-        options: Optional[List[Dict[str, Any]]] = None,
-        webhook: Optional[str] = None,
-    ):
-        """Process images for multiple tasks.
-
-        :param bucket_name: Bucket name
-        :param name: Task name
-        :param options: Processing options
-        :param webhook: Webhook URL
-        :return: Created task object
-        """
-        return await self._process_images(
-            bucket_name, name=name, options=options, webhook=webhook, single_task=False
-        )
-
-    def monitor_task(self, task):
-        """Monitors the task progress until completion.
-
-        :param task: The task object.
-        """
-        log.info(f"Monitoring task {task.uuid}...")
-        task.wait_for_completion(interval=5)
-        log.info("Task completed.")
-        return task
-
-    async def process_images_from_s3(
-        self,
-        bucket_name: str,
-        name: Optional[str] = None,
-        options: Optional[List[Dict[str, Any]]] = None,
-        webhook: Optional[str] = None,
-    ):
-        """Process images from S3 for a single task."""
-        task = await self.process_single_task(
-            bucket_name, name=name, options=options, webhook=webhook
-        )
-
-        return task
-
-    async def process_images_for_all_tasks(
-        self,
-        bucket_name: str,
-        name_prefix: Optional[str] = None,
-        options: Optional[List[Dict[str, Any]]] = None,
-        webhook: Optional[str] = None,
-    ):
-        """Process images for all tasks in a project."""
-        task = await self.process_multiple_tasks(
-            bucket_name, name=name_prefix, options=options, webhook=webhook
-        )
-
-        return task
+async def fetch_scaleodm_task_info(
+    *, scaleodm_url: str, odm_task_uuid: str
+) -> Optional[dict[str, Any]]:
+    """Fetch /task/{uuid}/info from ScaleODM. Returns ``None`` on failure."""
+    base = scaleodm_url.rstrip("/")
+    url = f"{base}/task/{odm_task_uuid}/info"
+    try:
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=15)
+        ) as session:
+            async with session.get(url) as resp:
+                if resp.status != 200:
+                    log.warning(
+                        "ScaleODM /task/{}/info returned HTTP {}",
+                        odm_task_uuid,
+                        resp.status,
+                    )
+                    return None
+                return await resp.json()
+    except Exception as e:
+        log.warning(f"Failed to fetch ScaleODM task info for {odm_task_uuid}: {e}")
+        return None
 
 
 def reproject_to_web_mercator(input_file, output_file):
@@ -381,17 +162,11 @@ def reproject_to_web_mercator(input_file, output_file):
     Done in two steps to avoid a known issue where combining the COG
     driver with Warp + creationOptions + memory caps produces truncated
     output: first Warp to a plain GeoTIFF, then Translate that to COG.
-
-    Args:
-        input_file (str): Path to the input orthophoto.
-        output_file (str): Path to the final reprojected COG.
     """
     warped_path = output_file + ".warped.tif"
     try:
-        # Cap GDAL block cache so large orthophotos don't OOM the worker.
         gdal.SetConfigOption("GDAL_CACHEMAX", "256")
 
-        # Step 1: Warp to an intermediate GeoTIFF in EPSG:3857.
         gdal.Warp(
             warped_path,
             input_file,
@@ -403,7 +178,6 @@ def reproject_to_web_mercator(input_file, output_file):
             creationOptions=["COMPRESS=DEFLATE", "BIGTIFF=IF_SAFER", "TILED=YES"],
         )
 
-        # Step 2: Convert the warped GeoTIFF into a proper COG.
         gdal.Translate(
             output_file,
             warped_path,
@@ -423,33 +197,111 @@ def reproject_to_web_mercator(input_file, output_file):
                 pass
 
 
+def _orthophoto_s3_key(project_id: uuid.UUID, task_id: Optional[uuid.UUID]) -> str:
+    task_segment = f"{task_id}/" if task_id else ""
+    return f"projects/{project_id}/{task_segment}odm/odm_orthophoto/odm_orthophoto.tif"
+
+
+def reproject_orthophoto_in_place(
+    project_id: uuid.UUID,
+    task_id: Optional[uuid.UUID],
+) -> None:
+    """Pull odm_orthophoto.tif from S3, reproject to EPSG:3857 COG, overwrite the same key.
+
+    Single-file equivalent of the orthophoto branch inside
+    extract_and_upload_odm_assets, used as the only post-processing step
+    after a ScaleODM run completes.
+    """
+    s3_key = _orthophoto_s3_key(project_id, task_id)
+
+    temp_dir = tempfile.mkdtemp()
+    src_path = os.path.join(temp_dir, "odm_orthophoto.tif")
+    out_path = os.path.join(temp_dir, "odm_orthophoto_3857.tif")
+
+    try:
+        ok = get_file_from_bucket(settings.S3_BUCKET_NAME, s3_key, src_path)
+        if ok is False or not os.path.exists(src_path):
+            raise OrthophotoPostProcessingError(
+                f"Could not download orthophoto from s3://{settings.S3_BUCKET_NAME}/{s3_key}"
+            )
+
+        try:
+            src_ds = gdal.Open(src_path)
+            if src_ds is not None:
+                log.info(
+                    "Source ScaleODM orthophoto: size={}x{}, bands={}, "
+                    "filesize={} bytes, geotransform={}, projection={}",
+                    src_ds.RasterXSize,
+                    src_ds.RasterYSize,
+                    src_ds.RasterCount,
+                    os.path.getsize(src_path),
+                    src_ds.GetGeoTransform(),
+                    (src_ds.GetProjection() or "(none)")[:200],
+                )
+                src_ds = None
+            else:
+                log.warning(f"GDAL could not open source ortho at {src_path}")
+        except Exception as inspect_err:
+            log.warning(f"Failed to inspect source ortho: {inspect_err}")
+
+        try:
+            reproject_to_web_mercator(src_path, out_path)
+        except Exception as e:
+            raise OrthophotoPostProcessingError(
+                f"Reprojection failed for {s3_key}: {e}"
+            ) from e
+
+        try:
+            out_ds = gdal.Open(out_path)
+            if out_ds is not None:
+                log.info(
+                    "Reprojected COG orthophoto: size={}x{}, filesize={} bytes",
+                    out_ds.RasterXSize,
+                    out_ds.RasterYSize,
+                    os.path.getsize(out_path),
+                )
+                out_ds = None
+        except Exception:
+            pass
+
+        try:
+            add_file_to_bucket(settings.S3_BUCKET_NAME, out_path, s3_key)
+        except Exception as e:
+            raise OrthophotoPostProcessingError(
+                f"Upload of reprojected ortho failed for {s3_key}: {e}"
+            ) from e
+
+        log.info(f"Uploaded reprojected COG orthophoto to {s3_key}")
+
+    finally:
+        for path in (src_path, out_path, out_path + ".warped.tif"):
+            if os.path.exists(path):
+                try:
+                    os.remove(path)
+                except Exception:
+                    pass
+        try:
+            os.rmdir(temp_dir)
+        except Exception:
+            pass
+
+
 def extract_and_upload_odm_assets(
     zip_path: str,
     temp_dir: str,
     project_id: uuid.UUID,
-    task_id: uuid.UUID | None,
+    task_id: Optional[uuid.UUID],
 ) -> bool:
     """Extract files from an ODM zip one-by-one and upload each to S3.
 
-    Uploads individual files under ``projects/{pid}/{tid}/odm/``.  The raw
-    orthophoto is **not** uploaded; instead it is reprojected to EPSG:3857
-    COG and the COG is stored at
-    ``projects/{pid}/{tid}/odm/odm_orthophoto/odm_orthophoto.tif``,
-    eliminating the previous duplication into a separate ``orthophoto/``
-    prefix.
-
-    Uses a single pass over the zip.  The orthophoto is *kept* on disk
-    (without uploading the raw version) so that reprojection can happen
-    after the zip is deleted - cutting peak disk usage roughly in half
-    for large archives.
-
-    Returns True on success.
+    Used by the manual ODM zip import flow. Uploads individual files
+    under ``projects/{pid}/{tid}/odm/`` and replaces the raw orthophoto
+    with an EPSG:3857 COG at
+    ``projects/{pid}/{tid}/odm/odm_orthophoto/odm_orthophoto.tif``.
     """
     task_segment = f"{task_id}/" if task_id else ""
     odm_prefix = f"projects/{project_id}/{task_segment}odm/"
 
-    # Clear any existing objects under the prefix so retries/reimports
-    # produce a clean set rather than a union of old and new files.
     existing = delete_objects_by_prefix(settings.S3_BUCKET_NAME, odm_prefix)
     if existing:
         log.info(f"Cleared {existing} existing objects under {odm_prefix}")
@@ -457,16 +309,11 @@ def extract_and_upload_odm_assets(
     ortho_member = "odm_orthophoto/odm_orthophoto.tif"
     ortho_local: str | None = None
 
-    # Single pass: extract, upload, and delete - except the orthophoto,
-    # which we keep on disk for post-processing after the zip is removed.
-    # The raw orthophoto is NOT uploaded here; it is replaced by the
-    # reprojected COG after the zip is deleted (saves ~50% ortho storage).
     with zipfile.ZipFile(zip_path, "r") as zf:
         for member in zf.namelist():
             if member.endswith("/"):
                 continue
 
-            # Reject path-traversal attempts (absolute paths or ../ components)
             resolved = os.path.realpath(os.path.join(temp_dir, member))
             if not resolved.startswith(os.path.realpath(temp_dir) + os.sep):
                 log.warning(f"Skipping zip member with unsafe path: {member}")
@@ -474,7 +321,6 @@ def extract_and_upload_odm_assets(
 
             extracted_path = zf.extract(member, temp_dir)
 
-            # Keep orthophoto on disk only (don't upload raw - COG replaces it later)
             if member == ortho_member:
                 ortho_local = extracted_path
                 continue
@@ -490,22 +336,14 @@ def extract_and_upload_odm_assets(
 
             os.remove(extracted_path)
 
-    # Delete the zip now to free disk before the expensive reprojection.
-    # The orthophoto we kept is independent of the zip.
     if os.path.exists(zip_path):
         os.remove(zip_path)
         log.info(f"Deleted zip {zip_path} to free disk before reprojection")
 
-    # Reproject orthophoto and upload the COG directly into the odm/ tree,
-    # replacing the raw version (which was intentionally not uploaded above).
     if ortho_local and os.path.exists(ortho_local):
-        # Log the source orthophoto's dimensions and CRS up front so we can
-        # tell whether a tiny output is caused by a bad source from ODM or
-        # by the reprojection step itself.
         try:
             src_ds = gdal.Open(ortho_local)
             if src_ds is not None:
-                src_proj = src_ds.GetProjection() or "(none)"
                 log.info(
                     "Source ODM orthophoto: size={}x{}, bands={}, "
                     "filesize={} bytes, geotransform={}, projection={}",
@@ -514,7 +352,7 @@ def extract_and_upload_odm_assets(
                     src_ds.RasterCount,
                     os.path.getsize(ortho_local),
                     src_ds.GetGeoTransform(),
-                    src_proj[:200],
+                    (src_ds.GetProjection() or "(none)")[:200],
                 )
                 src_ds = None
             else:
@@ -526,7 +364,6 @@ def extract_and_upload_odm_assets(
         try:
             reproject_to_web_mercator(ortho_local, reprojected_path)
 
-            # Log reprojected dimensions for comparison.
             try:
                 out_ds = gdal.Open(reprojected_path)
                 if out_ds is not None:
@@ -554,224 +391,3 @@ def extract_and_upload_odm_assets(
         )
 
     return True
-
-
-async def process_assets_from_odm(
-    node_odm_url: str,
-    dtm_project_id: uuid.UUID,
-    odm_task_id: str,
-    state=None,
-    message=None,
-    dtm_task_id=None,
-    odm_status_code: Optional[int] = None,
-    persist_failure_state: bool = True,
-    db_pool=None,
-):
-    """Downloads results from ODM, reprojects the orthophoto, and uploads assets to S3.
-    Updates task state if required.
-
-    :param node_odm_url: URL of the ODM node.
-    :param dtm_project_id: UUID of the project.
-    :param odm_task_id: UUID of the ODM task.
-    :param state: Current state of the task.
-    :param message: Message to log upon completion.
-    :param dtm_task_id: Task ID for state updates.
-    :param db_pool: Optional shared connection pool (e.g. from arq worker context).
-        When provided, this pool is reused instead of creating throwaway pools.
-    """
-
-    async def _get_conn():
-        """Get a DB connection from the shared pool or a one-off pool."""
-        if db_pool:
-            return db_pool.connection()
-        # Fallback: create a temporary pool (legacy / test usage).
-        pool = await database.get_db_connection_pool()
-        return pool.connection()
-
-    # Deduplication: verify the task is still in the expected state before
-    # doing any heavy work.  This prevents double-processing when both a
-    # webhook and the reconciliation loop fire for the same task.
-    if dtm_task_id and state:
-        try:
-            async with await _get_conn() as conn:
-                current = await task_logic.get_task_state(
-                    conn, dtm_project_id, dtm_task_id
-                )
-                current_state = current.get("state") if current else None
-                if current_state and current_state != state.name:
-                    log.warning(
-                        "Skipping process_assets_from_odm for task {}: "
-                        "expected state {} but found {} (already handled)",
-                        dtm_task_id,
-                        state.name,
-                        current_state,
-                    )
-                    return
-        except Exception as e:
-            log.warning(
-                "Could not verify task state before processing (continuing): {}", e
-            )
-
-    log.info(f"Starting processing for project {dtm_project_id}")
-    node = Node.from_url(node_odm_url)
-    output_file_path = f"/tmp/{uuid.uuid4()}"
-    task = None
-
-    try:
-        os.makedirs(output_file_path, exist_ok=True)
-        try:
-            task = await asyncio.wait_for(
-                asyncio.to_thread(node.get_task, odm_task_id),
-                timeout=ODM_GET_TASK_TIMEOUT_SEC,
-            )
-        except asyncio.TimeoutError as e:
-            raise OdmAssetTransientError(
-                f"Timed out fetching ODM task info after {ODM_GET_TASK_TIMEOUT_SEC}s"
-            ) from e
-        except Exception as e:
-            if _is_retryable_odm_exception(e):
-                raise OdmAssetTransientError(
-                    f"Failed to fetch ODM task info: {e}"
-                ) from e
-            raise
-
-        log.info(f"Downloading results for task {odm_task_id} to {output_file_path}")
-
-        if str(odm_status_code) == "30":
-            status = ImageProcessingStatus.FAILED
-        elif str(odm_status_code) == "40":
-            try:
-                assets_path = await asyncio.wait_for(
-                    asyncio.to_thread(task.download_zip, output_file_path),
-                    timeout=ODM_DOWNLOAD_ZIP_TIMEOUT_SEC,
-                )
-            except asyncio.TimeoutError as e:
-                raise OdmAssetTransientError(
-                    f"Timed out downloading ODM assets after {ODM_DOWNLOAD_ZIP_TIMEOUT_SEC}s"
-                ) from e
-            except Exception as e:
-                if _is_retryable_odm_exception(e):
-                    raise OdmAssetTransientError(
-                        f"Failed to download ODM assets: {e}"
-                    ) from e
-                raise
-
-            if not os.path.exists(assets_path):
-                log.error(f"Downloaded file not found: {assets_path}")
-                raise FileNotFoundError(f"Downloaded file not found: {assets_path}")
-            log.info(f"Successfully downloaded ZIP to {assets_path}")
-
-            # Extract all ODM files individually to S3 under odm/ prefix
-            # and reproject the orthophoto to EPSG:3857.  The helper deletes
-            # the zip after extraction to free disk before the expensive
-            # GDAL reprojection step.
-            extract_and_upload_odm_assets(
-                assets_path, output_file_path, dtm_project_id, dtm_task_id
-            )
-
-            log.info(f"Processing complete for project {dtm_project_id}")
-
-            if state and dtm_task_id:
-                async with await _get_conn() as conn:
-                    await task_logic.update_task_state_system(
-                        db=conn,
-                        project_id=dtm_project_id,
-                        task_id=dtm_task_id,
-                        comment=message,
-                        initial_state=state,
-                        final_state=State.IMAGE_PROCESSING_FINISHED,
-                        updated_at=timestamp(),
-                    )
-                    log.info(
-                        f"Task {dtm_task_id} state updated to IMAGE_PROCESSING_FINISHED in the database."
-                    )
-
-                    task_segment = f"{dtm_task_id}/" if dtm_task_id else ""
-                    assets_prefix = f"projects/{dtm_project_id}/{task_segment}odm/"
-                    await project_logic.update_task_field(
-                        conn,
-                        dtm_project_id,
-                        dtm_task_id,
-                        "assets_url",
-                        assets_prefix,
-                    )
-
-            status = ImageProcessingStatus.SUCCESS
-        if not dtm_task_id:
-            # Update the image processing status
-            async with await _get_conn() as conn:
-                await project_logic.update_processing_status(
-                    conn, dtm_project_id, status
-                )
-
-    except Exception as e:
-        log.error(f"Error during processing for project {dtm_project_id}: {e}")
-
-        # Clean up any partially-uploaded ODM assets so a retry starts clean.
-        try:
-            task_segment = f"{dtm_task_id}/" if dtm_task_id else ""
-            partial_prefix = f"projects/{dtm_project_id}/{task_segment}odm/"
-            delete_objects_by_prefix(settings.S3_BUCKET_NAME, partial_prefix)
-            target = dtm_task_id or dtm_project_id
-            log.info(f"Cleaned up partial ODM assets for {target}")
-        except Exception as cleanup_err:
-            log.warning(
-                f"Failed to clean up partial ODM assets: {cleanup_err}",
-            )
-
-        if persist_failure_state:
-            try:
-                async with await _get_conn() as conn:
-                    if state and dtm_task_id:
-                        await task_logic.update_task_state_system(
-                            db=conn,
-                            project_id=dtm_project_id,
-                            task_id=dtm_task_id,
-                            comment=f"Image processing failed: {e}",
-                            initial_state=state,
-                            final_state=State.IMAGE_PROCESSING_FAILED,
-                            updated_at=timestamp(),
-                        )
-                        log.info(
-                            f"Task {dtm_task_id} state updated to IMAGE_PROCESSING_FAILED."
-                        )
-                    elif not dtm_task_id:
-                        await project_logic.update_processing_status(
-                            conn, dtm_project_id, ImageProcessingStatus.FAILED
-                        )
-                        log.info(f"Project {dtm_project_id} status updated to FAILED.")
-            except Exception as state_err:
-                target = dtm_task_id or dtm_project_id
-                log.error(f"Failed to persist failure state for {target}: {state_err}")
-
-        if isinstance(e, OdmAssetTerminalError):
-            raise
-        if isinstance(e, OdmAssetTransientError):
-            raise
-
-        if _is_retryable_odm_exception(e):
-            raise OdmAssetTransientError(str(e)) from e
-
-        raise OdmAssetTerminalError(str(e)) from e
-
-    finally:
-        if task:
-            try:
-                log.info(f"Attempting to delete task {odm_task_id} from NodeODM.")
-                task.remove()
-                log.info(
-                    f"Successful attempt at deleting task {odm_task_id} from NodeODM."
-                )
-            except Exception as e:
-                log.error(
-                    f"Error occurred while cleaning up task {odm_task_id} from NodeODM: {e}."
-                )
-
-        if os.path.exists(output_file_path):
-            try:
-                shutil.rmtree(output_file_path)
-                log.info(f"Temporary directory {output_file_path} cleaned up.")
-            except Exception as cleanup_error:
-                log.error(
-                    f"Error cleaning up directory {output_file_path}: {cleanup_error}"
-                )

--- a/src/backend/app/projects/project_logic.py
+++ b/src/backend/app/projects/project_logic.py
@@ -19,7 +19,6 @@ from loguru import logger as log
 from minio.error import S3Error
 from psycopg import Connection
 from psycopg.rows import dict_row
-from pyodm.exceptions import NodeResponseError
 from shapely.errors import GEOSException
 from shapely.geometry import shape
 from shapely.ops import transform
@@ -36,7 +35,10 @@ from drone_flightplan.enums import FlightMode
 from app.config import settings
 from app.models.enums import ImageProcessingStatus, OAMUploadStatus, State
 from app.projects import project_schemas
-from app.images.image_processing import DroneImageProcessor
+from app.images.image_processing import (
+    ScaleOdmSubmitError,
+    submit_scaleodm_task,
+)
 from app.s3 import (
     s3_client,
     add_obj_to_bucket,
@@ -67,10 +69,11 @@ ODM_STATUS_LABELS = {
 
 
 def parse_odm_status(raw_status) -> tuple[int, str]:
-    """Parse a NodeODM status field into (status_code, status_label).
+    """Parse an ODM status field into (status_code, status_label).
 
-    NodeODM returns status as an object like ``{"code": 20}`` or as a plain
-    integer.  We normalise both forms into an ``(int, str)`` pair.
+    ScaleODM preserves the NodeODM payload shape: status is either an
+    object like ``{"code": 20}`` or a plain integer. We normalise both
+    forms into an ``(int, str)`` pair.
     """
     if isinstance(raw_status, dict):
         code = raw_status.get("code", 0)
@@ -83,11 +86,12 @@ def parse_odm_status(raw_status) -> tuple[int, str]:
 
 
 def extract_valid_odm_task_info(payload: dict | None) -> dict | None:
-    """Return only real NodeODM task info payloads.
+    """Return only real ODM task info payloads.
 
-    NodeODM can return HTTP 200 with an error JSON for deleted tasks, for example
-    ``{"error": "<uuid> not found"}``. Those payloads should be treated as
-    missing task info so the DB-backed fallback logic can classify the task.
+    ScaleODM (like NodeODM) can return HTTP 200 with an error JSON for
+    deleted tasks, e.g. ``{"error": "<uuid> not found"}``. Those payloads
+    should be treated as missing so the DB-backed fallback logic can
+    classify the task.
     """
     if not isinstance(payload, dict):
         return None
@@ -125,8 +129,8 @@ async def reconcile_project_level_odm(
 ) -> dict:
     """Handle queue-info for project-level ODM runs (no per-task ODM UUIDs).
 
-    Fetches the single project-level ODM task status and reconciles:
-    - Completed but webhook missed -> enqueue asset download
+    Fetches the single project-level ScaleODM task status and reconciles:
+    - Completed but webhook missed -> enqueue finalize job (reproject + state)
     - Failed/canceled -> mark project FAILED
     - Not found (age > threshold) -> mark project FAILED
     - Otherwise -> report current status
@@ -147,7 +151,7 @@ async def reconcile_project_level_odm(
     if not project_odm_uuid or project_status != "PROCESSING":
         return empty
 
-    # Fetch status from NodeODM
+    # Fetch status from ScaleODM
     path = f"{parsed_url.path.rstrip('/')}/task/{project_odm_uuid}/info"
     info_url = urlunparse(
         (parsed_url.scheme, parsed_url.netloc, path, "", odm_query, "")
@@ -173,7 +177,7 @@ async def reconcile_project_level_odm(
         fetch_failed = True
 
     if fetch_failed:
-        # Can't reach NodeODM - show as running, don't reconcile.
+        # Can't reach ScaleODM - show as running, don't reconcile.
         task_entry = project_schemas.OdmQueueTask(
             uuid=project_odm_uuid,
             name=f"Project {project.id}",
@@ -200,21 +204,21 @@ async def reconcile_project_level_odm(
         status_code, status_label = parse_odm_status(odm_info.get("status"))
 
         if status_code == 40:
-            # Completed but webhook was missed - enqueue asset download.
-            node_odm_endpoint = (
+            # Completed but webhook was missed - enqueue finalize job.
+            scaleodm_endpoint = (
                 getattr(project, "odm_endpoint_used", None) or settings.ODM_ENDPOINT
             )
             await redis_pool.enqueue_job(
-                "process_odm_webhook_assets",
-                node_odm_url=node_odm_endpoint,
+                "finalize_scaleodm_task",
+                scaleodm_url=scaleodm_endpoint,
                 dtm_project_id=str(project.id),
-                odm_task_id=project_odm_uuid,
+                odm_task_uuid=project_odm_uuid,
                 odm_status_code=40,
                 _job_id=f"odm-assets:project:{project.id}",
                 _queue_name="default_queue",
             )
             log.warning(
-                "Reconciling project-level completed ODM task (missed webhook): "
+                "Reconciling project-level completed ScaleODM task (missed webhook): "
                 "project={} odm_uuid={}",
                 project.id,
                 project_odm_uuid,
@@ -223,7 +227,7 @@ async def reconcile_project_level_odm(
                 uuid=project_odm_uuid,
                 name=f"Project {project.id}",
                 status_code=20,
-                status_label="Downloading assets (missed webhook)",
+                status_label="Finalizing assets (missed webhook)",
                 images_count=odm_info.get("imagesCount"),
                 progress=odm_info.get("progress"),
                 date_created=odm_info.get("dateCreated"),
@@ -322,7 +326,7 @@ async def reconcile_project_level_odm(
         ]
         return result
 
-    # NodeODM responded but doesn't know this task (not found).
+    # ScaleODM responded but doesn't know this task (not found).
     # Apply the same age guard as task-level reconciliation.
     async with db.cursor(row_factory=dict_row) as cur:
         await cur.execute(
@@ -343,7 +347,7 @@ async def reconcile_project_level_odm(
         try:
             await update_processing_status(db, project.id, ImageProcessingStatus.FAILED)
             log.warning(
-                "Reconciled project-level lost ODM task: project={} odm_uuid={} not found on NodeODM",
+                "Reconciled project-level lost ODM task: project={} odm_uuid={} not found on ScaleODM",
                 project.id,
                 project_odm_uuid,
             )
@@ -377,7 +381,7 @@ async def reconcile_project_level_odm(
         uuid=project_odm_uuid,
         name=f"Project {project.id}",
         status_code=20,
-        status_label="Running (awaiting NodeODM registration)",
+        status_label="Running (awaiting ScaleODM registration)",
     )
     return {
         "running": 1,
@@ -695,7 +699,7 @@ async def process_drone_images(
     odm_url: Optional[str] = None,
     **_kwargs: Any,
 ) -> Dict[str, Any]:
-    """Process drone images using ODM.
+    """Submit a per-task ScaleODM run.
 
     NOTE: **_kwargs absorbs extra keys (e.g. ``_carrier``) that OpenTelemetry's
     now-removed ArqInstrumentor injected into job payloads stored in Redis.
@@ -755,25 +759,15 @@ async def process_drone_images(
 
             await conn.commit()
 
-            # Initialize the processor with the database connection
-            node_odm_endpoint = odm_url or settings.ODM_ENDPOINT
-            log.info(f"Using NodeODM endpoint: {node_odm_endpoint}")
-            processor = DroneImageProcessor(
-                node_odm_url=node_odm_endpoint,
-                project_id=project_id,
-                task_id=task_id,
-                user_id=user_id,
-                db=conn,
-                task_ids=None,
-            )
+            scaleodm_endpoint = odm_url or settings.ODM_ENDPOINT
+            log.info(f"Using ScaleODM endpoint: {scaleodm_endpoint}")
 
-            # Define processing options
             options = [
                 {"name": "dsm", "value": True},
                 {"name": "orthophoto-resolution", "value": 5},
             ]
 
-            # Use public URL when processing on an external NodeODM, internal otherwise
+            # Use public URL when processing on an external ScaleODM, internal otherwise.
             if odm_url:
                 from urllib.parse import quote
 
@@ -782,35 +776,48 @@ async def process_drone_images(
             else:
                 webhook_url = f"{settings.BACKEND_URL_INTERNAL}/api/projects/odm/webhook/{project_id}/{task_id}/"
 
-            result = await processor.process_images_from_s3(
-                settings.S3_BUCKET_NAME,
+            read_s3_path = f"s3://{settings.S3_BUCKET_NAME}/projects/{project_id}/{task_id}/images/"
+            write_s3_path = (
+                f"s3://{settings.S3_BUCKET_NAME}/projects/{project_id}/{task_id}/odm/"
+            )
+
+            odm_uuid = await submit_scaleodm_task(
+                scaleodm_url=scaleodm_endpoint,
+                read_s3_path=read_s3_path,
+                write_s3_path=write_s3_path,
                 name=f"DTM-Task-{task_id}",
                 options=options,
                 webhook=webhook_url,
+                processing_mode="standard",
+                s3_scan_depth=0,
+                exclude_paths=["*/thumbs/*"],
+                s3_endpoint=settings.SCALEODM_S3_ENDPOINT,
             )
 
             await update_task_field(
-                conn,
-                project_id,
-                task_id,
-                "odm_task_uuid",
-                str(result.uuid),
+                conn, project_id, task_id, "odm_task_uuid", odm_uuid
             )
             await conn.commit()
-            log.info(f"Stored ODM task UUID {result.uuid} for task {task_id}")
+            log.info(f"Stored ScaleODM task UUID {odm_uuid} for task {task_id}")
 
             return {
                 "job_id": job_id,
                 "project_id": str(project_id),
                 "task_id": str(task_id),
                 "status": "processing_started",
-                "result": result,
+                "odm_task_uuid": odm_uuid,
             }
 
     except Exception as e:
         failure_message = str(e).strip() or e.__class__.__name__
-        if isinstance(e, NodeResponseError) and "Not enough images" in failure_message:
-            failure_message = "Not enough images for ODM processing. At least 3 task images are required."
+        if (
+            isinstance(e, ScaleOdmSubmitError)
+            and "Not enough images" in failure_message
+        ):
+            failure_message = (
+                "Not enough images for ODM processing. "
+                "At least 3 task images are required."
+            )
 
         try:
             pool = ctx["db_pool"]
@@ -887,17 +894,6 @@ async def process_all_drone_images(
     try:
         pool = ctx["db_pool"]
         async with pool.connection() as conn:
-            # Initialize the processor
-            processor = DroneImageProcessor(
-                node_odm_url=settings.ODM_ENDPOINT,
-                project_id=project_id,
-                task_id=None,
-                user_id=user_id,
-                task_ids=tasks,
-                db=conn,
-            )
-
-            # Define processing options
             options = [
                 {"name": "dsm", "value": True},
                 {"name": "orthophoto-resolution", "value": 5},
@@ -905,16 +901,27 @@ async def process_all_drone_images(
             webhook_url = (
                 f"{settings.PUBLIC_BASE_URL}/api/projects/odm/webhook/{project_id}/"
             )
-            result = await processor.process_images_for_all_tasks(
-                settings.S3_BUCKET_NAME,
-                name_prefix=f"DTM-Task-{project_id}",
+
+            # Project-wide submission: scan under projects/{pid}/ just deep
+            # enough to include {tid}/images/file. Bounded depth is important
+            # because generated derivatives live below that, e.g.
+            # {tid}/images/thumbs/file, and must not become ODM inputs.
+            read_s3_path = f"s3://{settings.S3_BUCKET_NAME}/projects/{project_id}/"
+            write_s3_path = f"s3://{settings.S3_BUCKET_NAME}/projects/{project_id}/odm/"
+
+            odm_uuid = await submit_scaleodm_task(
+                scaleodm_url=settings.ODM_ENDPOINT,
+                read_s3_path=read_s3_path,
+                write_s3_path=write_s3_path,
+                name=f"DTM-Project-{project_id}",
                 options=options,
                 webhook=webhook_url,
+                processing_mode="standard",
+                s3_scan_depth=2,
+                use_default_excludes=True,
+                exclude_paths=["*/thumbs/*"],
+                s3_endpoint=settings.SCALEODM_S3_ENDPOINT,
             )
-            if result is None or not getattr(result, "uuid", None):
-                raise RuntimeError(
-                    "ODM did not return a valid task object after submission"
-                )
 
             # Persist ODM metadata for reconciliation/recovery, then mark PROCESSING.
             # Overwrite on every new run so retries never reconcile against stale metadata.
@@ -928,14 +935,14 @@ async def process_all_drone_images(
                 WHERE id = %(project_id)s;
                 """,
                 {
-                    "odm_uuid": str(result.uuid),
+                    "odm_uuid": odm_uuid,
                     "odm_endpoint": settings.ODM_ENDPOINT,
                     "status": ImageProcessingStatus.PROCESSING.name,
                     "project_id": project_id,
                 },
             )
             await conn.commit()
-            log.info(f"Stored ODM task UUID {result.uuid} for project {project_id}")
+            log.info(f"Stored ScaleODM task UUID {odm_uuid} for project {project_id}")
             return
 
     except Exception as e:

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -435,7 +435,7 @@ async def process_imagery(
     user_data: Annotated[AuthUser, Depends(login_required)],
     db: Annotated[Connection, Depends(database.get_db)],
     redis_pool: ArqRedis = Depends(get_redis_pool),
-    odm_url: Optional[str] = Query(None, description="Custom NodeODM server URL"),
+    odm_url: Optional[str] = Query(None, description="Custom ScaleODM server URL"),
 ):
     """Start a queued task to process drone imagery."""
     pending_transfer_count = await ImageClassifier.get_task_pending_transfer_count(
@@ -474,8 +474,10 @@ async def process_all_imagery(
 ):
     """API endpoint to process all tasks associated with a project.
 
-    If a GCP file has been saved for this project (via POST /gcp/save/),
-    it will be automatically included during ODM processing.
+    Submits a single ScaleODM run with ``processingMode=standard`` and a
+    project-wide ``s3ScanDepth`` so all per-task ``images/`` subdirs roll
+    up into one ODM run. If a GCP file has been saved for this project
+    (via POST /gcp/save/), it will be automatically included.
     """
     user_id = user_data.id
 
@@ -557,14 +559,14 @@ async def odm_webhook_for_processing_whole_project(
         raise HTTPException(status_code=400, detail="Invalid webhook payload")
 
     if status["code"] in {30, 40}:
-        # Use the endpoint persisted when processing started so downloads
+        # Use the endpoint persisted when processing started so finalize jobs
         # target the correct server even if config has changed since.
-        node_odm_url = await _get_project_odm_endpoint(db, dtm_project_id)
+        scaleodm_url = await _get_project_odm_endpoint(db, dtm_project_id)
         await redis_pool.enqueue_job(
-            "process_odm_webhook_assets",
-            node_odm_url=node_odm_url,
+            "finalize_scaleodm_task",
+            scaleodm_url=scaleodm_url,
             dtm_project_id=str(dtm_project_id),
-            odm_task_id=odm_task_id,
+            odm_task_uuid=odm_task_id,
             odm_status_code=status["code"],
             _job_id=f"odm-assets:project:{dtm_project_id}",
             _queue_name="default_queue",
@@ -583,19 +585,19 @@ async def odm_webhook_for_processing_a_single_task(
     dtm_project_id: uuid.UUID,
     dtm_task_id: uuid.UUID,
     redis_pool: Annotated[ArqRedis, Depends(get_redis_pool)],
-    odm_url: Optional[str] = Query(None, description="Custom NodeODM server URL"),
+    odm_url: Optional[str] = Query(None, description="Custom ScaleODM server URL"),
 ):
     payload = await request.json()
     odm_task_id = payload.get("uuid")
     status = payload.get("status")
-    node_odm_endpoint = odm_url or settings.ODM_ENDPOINT
+    scaleodm_endpoint = odm_url or settings.ODM_ENDPOINT
     log.info(
         "ODM webhook (single task): project={} task={} odm_task={} status={} odm_url={}",
         dtm_project_id,
         dtm_task_id,
         odm_task_id,
         status,
-        node_odm_endpoint,
+        scaleodm_endpoint,
     )
 
     if not odm_task_id or not status:
@@ -612,10 +614,10 @@ async def odm_webhook_for_processing_a_single_task(
 
     if status["code"] == 40:
         await redis_pool.enqueue_job(
-            "process_odm_webhook_assets",
-            node_odm_url=node_odm_endpoint,
+            "finalize_scaleodm_task",
+            scaleodm_url=scaleodm_endpoint,
             dtm_project_id=str(dtm_project_id),
-            odm_task_id=odm_task_id,
+            odm_task_uuid=odm_task_id,
             state_name=state_value.name,
             message="Task completed.",
             dtm_task_id=str(dtm_task_id),
@@ -625,21 +627,14 @@ async def odm_webhook_for_processing_a_single_task(
         )
 
     elif status["code"] == 30 and state_value != State.IMAGE_PROCESSING_FAILED:
-        # Use system-level update since webhook may be called from batch processor
-        await task_logic.update_task_state_system(
-            db,
-            dtm_project_id,
-            dtm_task_id,
-            "Image processing failed.",
-            state_value,
-            State.IMAGE_PROCESSING_FAILED,
-            timestamp(),
-        )
+        # Finalize handler records the failure and clears the ScaleODM row.
+        # We don't pre-flip state here so the finalize job can pull the real
+        # errorMessage from ScaleODM and write a more descriptive comment.
         await redis_pool.enqueue_job(
-            "process_odm_webhook_assets",
-            node_odm_url=node_odm_endpoint,
+            "finalize_scaleodm_task",
+            scaleodm_url=scaleodm_endpoint,
             dtm_project_id=str(dtm_project_id),
-            odm_task_id=odm_task_id,
+            odm_task_uuid=odm_task_id,
             state_name=state_value.name,
             message="Image processing failed.",
             dtm_task_id=str(dtm_task_id),
@@ -1194,11 +1189,11 @@ async def get_odm_queue_info(
 ):
     """Get the ODM processing queue info for this project.
 
-    Queries our DB for tasks that have been submitted to NodeODM
+    Queries our DB for tasks that have been submitted to ScaleODM
     (have an odm_task_uuid), then fetches each task's real status
-    from NodeODM via /task/{uuid}/info.
+    from ScaleODM via /task/{uuid}/info.
 
-    If a task is stuck as IMAGE_PROCESSING_STARTED in our DB but NodeODM
+    If a task is stuck as IMAGE_PROCESSING_STARTED in our DB but ScaleODM
     reports it as failed/completed/canceled (or doesn't know about it),
     we reconcile the state automatically.
     """
@@ -1221,8 +1216,8 @@ async def get_odm_queue_info(
         return urlunparse((parsed.scheme, parsed.netloc, path, "", odm_query, ""))
 
     # Minimum age (seconds) a task must be in STARTED state before
-    # "not found on NodeODM" is treated as a definitive loss.  Prevents
-    # false failure when a task was just submitted and NodeODM hasn't
+    # "not found on ScaleODM" is treated as a definitive loss.  Prevents
+    # false failure when a task was just submitted and ScaleODM hasn't
     # registered it yet.
     NOT_FOUND_AGE_THRESHOLD_SEC = 1800  # 30 minutes
 
@@ -1277,9 +1272,9 @@ async def get_odm_queue_info(
             groups=project_odm_info.get("groups", []),
         )
 
-    # Fetch real status from NodeODM for each task via /task/{uuid}/info
+    # Fetch real status from ScaleODM for each task via /task/{uuid}/info
     # We use a sentinel to distinguish "fetch failed" (timeout, network error)
-    # from "task genuinely not found on NodeODM" (got a 200 response but no
+    # from "task genuinely not found on ScaleODM" (got a 200 response but no
     # valid status, or an error JSON like {"error": "uuid not found"}).
     _FETCH_ERROR = object()
     odm_info_by_uuid: dict[str, dict | object] = {}
@@ -1300,7 +1295,7 @@ async def get_odm_queue_info(
                                 await resp.json()
                             )
                         log.warning(
-                            "NodeODM /task/{}/info returned status {}",
+                            "ScaleODM /task/{}/info returned status {}",
                             odm_uuid,
                             resp.status,
                         )
@@ -1308,7 +1303,7 @@ async def get_odm_queue_info(
                         return odm_uuid, _FETCH_ERROR
                 except Exception as e:
                     log.warning(
-                        "Failed to fetch NodeODM task info for {}: {}", odm_uuid, e
+                        "Failed to fetch ScaleODM task info for {}: {}", odm_uuid, e
                     )
                     return odm_uuid, _FETCH_ERROR
 
@@ -1319,7 +1314,7 @@ async def get_odm_queue_info(
                 if info is not None:
                     odm_info_by_uuid[odm_uuid] = info
     except aiohttp.ClientError as e:
-        log.warning("Failed to reach NodeODM at {}: {}", odm_url, e)
+        log.warning("Failed to reach ScaleODM at {}: {}", odm_url, e)
         raise HTTPException(
             status_code=503,
             detail="Unable to connect to the processing server.",
@@ -1362,25 +1357,25 @@ async def get_odm_queue_info(
                 task_index=task_index,
             )
 
-            # Reconcile: DB says STARTED but NodeODM says otherwise
+            # Reconcile: DB says STARTED but ScaleODM says otherwise
             if db_state == "IMAGE_PROCESSING_STARTED" and status_code in (30, 40, 50):
                 if status_code == 40:
-                    # Completed on NodeODM but webhook was missed.
-                    # Trigger the same asset-download pipeline the webhook uses.
+                    # Completed on ScaleODM but webhook was missed.
+                    # Trigger the same finalize pipeline the webhook uses.
                     await redis_pool.enqueue_job(
-                        "process_odm_webhook_assets",
-                        node_odm_url=odm_url,
+                        "finalize_scaleodm_task",
+                        scaleodm_url=odm_url,
                         dtm_project_id=str(project.id),
-                        odm_task_id=odm_uuid,
+                        odm_task_uuid=odm_uuid,
                         state_name=State.IMAGE_PROCESSING_STARTED.name,
-                        message="Reconciled: processing completed on NodeODM (missed webhook).",
+                        message="Reconciled: processing completed on ScaleODM (missed webhook).",
                         dtm_task_id=str(dtm_task_id),
                         odm_status_code=40,
                         _job_id=f"odm-assets:task:{dtm_task_id}",
                         _queue_name="default_queue",
                     )
                     reconciled.append(
-                        f"Task {task_index} ({dtm_task_id}): STARTED -> downloading assets (missed webhook)"
+                        f"Task {task_index} ({dtm_task_id}): STARTED -> finalizing (missed webhook)"
                     )
                     log.warning(
                         "Reconciling completed task (missed webhook): project={} dtm_task={} odm_uuid={}",
@@ -1395,7 +1390,7 @@ async def get_odm_queue_info(
                             db,
                             project.id,
                             dtm_task_id,
-                            f"Reconciled: NodeODM reports {status_label}",
+                            f"Reconciled: ScaleODM reports {status_label}",
                             State.IMAGE_PROCESSING_STARTED,
                             State.IMAGE_PROCESSING_FAILED,
                             timestamp(),
@@ -1413,7 +1408,7 @@ async def get_odm_queue_info(
                     except Exception as e:
                         log.error("Failed to reconcile task {}: {}", dtm_task_id, e)
         elif fetch_failed:
-            # Could not reach NodeODM for this task (timeout, network error).
+            # Could not reach ScaleODM for this task (timeout, network error).
             # Do NOT reconcile - the task may still be running. Show it as
             # "in progress" based on the DB state so the UI doesn't flip to failed.
             if db_state == "IMAGE_PROCESSING_STARTED":
@@ -1441,10 +1436,10 @@ async def get_odm_queue_info(
                 task_index=task_index,
             )
         else:
-            # NodeODM returned a valid response but doesn't know this task
+            # ScaleODM returned a valid response but doesn't know this task
             # (deleted/expired). Only treat as a definitive loss if the task
             # has been in STARTED state long enough; otherwise it may simply
-            # not have been registered on NodeODM yet.
+            # not have been registered on ScaleODM yet.
             state_entered_at = db_task.get("state_entered_at")
             if db_state == "IMAGE_PROCESSING_STARTED":
                 age_ok = True
@@ -1458,7 +1453,7 @@ async def get_odm_queue_info(
                 if not age_ok:
                     # Too young to declare lost - keep showing as running.
                     status_code = 20
-                    status_label = "Running (awaiting NodeODM registration)"
+                    status_label = "Running (awaiting ScaleODM registration)"
                     log.debug(
                         "Skipping not-found reconciliation for task {} "
                         "(only {}s in STARTED, threshold {}s)",
@@ -1467,7 +1462,7 @@ async def get_odm_queue_info(
                         NOT_FOUND_AGE_THRESHOLD_SEC,
                     )
                 else:
-                    # Old enough - mark as failed since NodeODM lost it.
+                    # Old enough - mark as failed since ScaleODM lost it.
                     status_code = 30
                     status_label = "Failed (lost)"
                     try:
@@ -1475,16 +1470,16 @@ async def get_odm_queue_info(
                             db,
                             project.id,
                             dtm_task_id,
-                            "Reconciled: task not found on NodeODM",
+                            "Reconciled: task not found on ScaleODM",
                             State.IMAGE_PROCESSING_STARTED,
                             State.IMAGE_PROCESSING_FAILED,
                             timestamp(),
                         )
                         reconciled.append(
-                            f"Task {task_index} ({dtm_task_id}): STARTED -> FAILED (not found on NodeODM)"
+                            f"Task {task_index} ({dtm_task_id}): STARTED -> FAILED (not found on ScaleODM)"
                         )
                         log.warning(
-                            "Reconciled lost task: project={} dtm_task={} odm_uuid={} not found on NodeODM",
+                            "Reconciled lost task: project={} dtm_task={} odm_uuid={} not found on ScaleODM",
                             project.id,
                             dtm_task_id,
                             odm_uuid,

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
   "aiohttp==3.11.11",
   "aiosmtplib==3.0.1",
   "python-slugify==8.0.4",
-  "pyodm==1.5.11",
   "asgiref==3.8.1",
   "bcrypt==4.2.1",
   "Scrapy==2.14.1",

--- a/src/backend/tests/test_project_processing.py
+++ b/src/backend/tests/test_project_processing.py
@@ -1,12 +1,9 @@
-import os
+import json
 import uuid
-from pathlib import Path
 
 import pytest
-from pyodm.exceptions import NodeResponseError
 
 from app import utils as app_utils
-
 from app.images import image_processing
 from app.models.enums import ImageProcessingStatus, State
 from app.projects import project_logic
@@ -48,89 +45,163 @@ class _FakePool:
         return _FakePoolConnection(self.conn)
 
 
-class _FakeZipFile:
-    def __init__(self, *args, **kwargs):
-        self._members = ["odm_orthophoto/odm_orthophoto.tif", "odm_report/report.pdf"]
+# ── submit_scaleodm_task ──────────────────────────────────────────────────────
 
-    def __enter__(self):
+
+class _FakeScaleOdmResponse:
+    def __init__(self, *, status: int, payload: dict | str):
+        self.status = status
+        self._payload = payload
+
+    async def text(self) -> str:
+        return (
+            self._payload
+            if isinstance(self._payload, str)
+            else json.dumps(self._payload)
+        )
+
+    async def __aenter__(self):
         return self
 
-    def __exit__(self, exc_type, exc, tb):
+    async def __aexit__(self, exc_type, exc, tb):
         return False
 
-    def namelist(self):
-        return self._members
 
-    def extract(self, member, path):
-        full_path = os.path.join(path, member)
-        os.makedirs(os.path.dirname(full_path), exist_ok=True)
-        with open(full_path, "wb") as f:
-            f.write(b"fake")
-        return full_path
+class _FakeScaleOdmSession:
+    """Captures POST /task/new calls and returns a configured response."""
+
+    def __init__(self, *, response: _FakeScaleOdmResponse):
+        self._response = response
+        self.posts: list[tuple[str, dict]] = []
+
+    def post(self, url, json=None, **kwargs):
+        self.posts.append((url, json or {}))
+        return self._response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
 
 
 @pytest.mark.asyncio
-async def test_process_drone_images_starts_then_calls_odm(monkeypatch):
+async def test_submit_scaleodm_task_posts_expected_body(monkeypatch):
+    response = _FakeScaleOdmResponse(status=200, payload={"uuid": "odm-pipeline-abc"})
+    captured = {"session": None}
+
+    def make_session(*args, **kwargs):
+        captured["session"] = _FakeScaleOdmSession(response=response)
+        return captured["session"]
+
+    monkeypatch.setattr(image_processing.aiohttp, "ClientSession", make_session)
+
+    odm_uuid = await image_processing.submit_scaleodm_task(
+        scaleodm_url="http://scaleodm:31100/",
+        read_s3_path="s3://bucket/projects/p/t/images/",
+        write_s3_path="s3://bucket/projects/p/t/odm/",
+        name="DTM-Task-t",
+        options=[{"name": "dsm", "value": True}],
+        webhook="http://backend/webhook/",
+        processing_mode="standard",
+        s3_scan_depth=1,
+        exclude_paths=["*/thumbs/*"],
+        s3_endpoint="http://s3-internal",
+    )
+
+    assert odm_uuid == "odm-pipeline-abc"
+    session = captured["session"]
+    assert len(session.posts) == 1
+    url, body = session.posts[0]
+    assert url == "http://scaleodm:31100/task/new"
+    assert body["readS3Path"] == "s3://bucket/projects/p/t/images/"
+    assert body["writeS3Path"] == "s3://bucket/projects/p/t/odm/"
+    assert body["name"] == "DTM-Task-t"
+    assert body["webhook"] == "http://backend/webhook/"
+    assert body["processingMode"] == "standard"
+    assert body["s3ScanDepth"] == 1
+    assert body["useDefaultExcludes"] is True
+    assert body["s3Endpoint"] == "http://s3-internal"
+    assert body["excludePaths"] == json.dumps(["*/thumbs/*"])
+    assert body["options"] == json.dumps([{"name": "dsm", "value": True}])
+
+
+@pytest.mark.asyncio
+async def test_submit_scaleodm_task_raises_with_server_error_message(monkeypatch):
+    response = _FakeScaleOdmResponse(status=400, payload={"error": "Not enough images"})
+
+    def make_session(*args, **kwargs):
+        return _FakeScaleOdmSession(response=response)
+
+    monkeypatch.setattr(image_processing.aiohttp, "ClientSession", make_session)
+
+    with pytest.raises(image_processing.ScaleOdmSubmitError) as exc_info:
+        await image_processing.submit_scaleodm_task(
+            scaleodm_url="http://scaleodm:31100",
+            read_s3_path="s3://bucket/projects/p/t/images/",
+            write_s3_path="s3://bucket/projects/p/t/odm/",
+            name="DTM-Task-t",
+            options=[],
+            webhook="http://backend/webhook/",
+        )
+
+    assert "Not enough images" in str(exc_info.value)
+    assert exc_info.value.status == 400
+
+
+# ── process_drone_images (per-task) ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_process_drone_images_submits_standard_mode(monkeypatch):
     project_id = uuid.uuid4()
     task_id = uuid.uuid4()
     conn = _FakeConn()
     ctx = {"job_id": "job-1", "db_pool": _FakePool(conn)}
     state_calls = []
+    submit_calls = []
 
     async def fake_update_task_state_system(
-        db,
-        project_id_arg,
-        task_id_arg,
-        comment,
-        initial_state,
-        final_state,
-        updated_at,
+        db, project_id_arg, task_id_arg, comment, initial_state, final_state, updated_at
     ):
-        state_calls.append(
-            {
-                "project_id": project_id_arg,
-                "task_id": task_id_arg,
-                "comment": comment,
-                "initial_state": initial_state,
-                "final_state": final_state,
-            }
-        )
+        state_calls.append({"initial_state": initial_state, "final_state": final_state})
         return {"project_id": project_id_arg, "task_id": task_id_arg}
 
-    class _FakeOdmResult:
-        uuid = "fake-odm-uuid"
-
-    class FakeProcessor:
-        def __init__(self, **kwargs):
-            self.kwargs = kwargs
-
-        async def process_images_from_s3(self, bucket_name, name, options, webhook):
-            return _FakeOdmResult()
+    async def fake_submit_scaleodm_task(**kwargs):
+        submit_calls.append(kwargs)
+        return "fake-odm-uuid"
 
     async def fake_update_task_field(*args, **kwargs):
         return None
 
-    monkeypatch.setattr(project_logic, "DroneImageProcessor", FakeProcessor)
+    monkeypatch.setattr(
+        project_logic, "submit_scaleodm_task", fake_submit_scaleodm_task
+    )
     monkeypatch.setattr(project_logic, "update_task_field", fake_update_task_field)
 
     from app.tasks import task_logic
 
     monkeypatch.setattr(
-        task_logic,
-        "update_task_state_system",
-        fake_update_task_state_system,
+        task_logic, "update_task_state_system", fake_update_task_state_system
     )
 
     result = await project_logic.process_drone_images(
-        ctx,
-        project_id,
-        task_id,
-        "user-123",
+        ctx, project_id, task_id, "user-123"
     )
 
     assert result["status"] == "processing_started"
+    assert result["odm_task_uuid"] == "fake-odm-uuid"
+    assert len(submit_calls) == 1
+    submitted = submit_calls[0]
+    assert submitted["processing_mode"] == "standard"
+    assert submitted["s3_scan_depth"] == 0
+    assert submitted["exclude_paths"] == ["*/thumbs/*"]
+    assert submitted["read_s3_path"].endswith(
+        f"/projects/{project_id}/{task_id}/images/"
+    )
+    assert submitted["write_s3_path"].endswith(f"/projects/{project_id}/{task_id}/odm/")
+    assert submitted["name"] == f"DTM-Task-{task_id}"
     assert state_calls[0]["final_state"] == State.IMAGE_PROCESSING_STARTED
-    assert conn.commit_calls >= 2
 
 
 @pytest.mark.asyncio
@@ -141,17 +212,8 @@ async def test_process_drone_images_marks_task_failed_when_odm_rejects(monkeypat
     ctx = {"job_id": "job-2", "db_pool": _FakePool(conn)}
     state_calls = []
 
-    async def fake_move_task_images_to_folder(db, project_id_arg, task_id_arg):
-        return {"moved_count": 0, "failed_count": 0}
-
     async def fake_update_task_state_system(
-        db,
-        project_id_arg,
-        task_id_arg,
-        comment,
-        initial_state,
-        final_state,
-        updated_at,
+        db, project_id_arg, task_id_arg, comment, initial_state, final_state, updated_at
     ):
         state_calls.append(
             {
@@ -162,30 +224,19 @@ async def test_process_drone_images_marks_task_failed_when_odm_rejects(monkeypat
         )
         return {"project_id": project_id_arg, "task_id": task_id_arg}
 
-    class FailingProcessor:
-        def __init__(self, **kwargs):
-            self.kwargs = kwargs
+    async def failing_submit(**kwargs):
+        raise image_processing.ScaleOdmSubmitError("Not enough images", status=400)
 
-        async def process_images_from_s3(self, bucket_name, name, options, webhook):
-            raise NodeResponseError("Not enough images")
-
-    monkeypatch.setattr(project_logic, "DroneImageProcessor", FailingProcessor)
+    monkeypatch.setattr(project_logic, "submit_scaleodm_task", failing_submit)
 
     from app.tasks import task_logic
 
     monkeypatch.setattr(
-        task_logic,
-        "update_task_state_system",
-        fake_update_task_state_system,
+        task_logic, "update_task_state_system", fake_update_task_state_system
     )
 
-    with pytest.raises(NodeResponseError):
-        await project_logic.process_drone_images(
-            ctx,
-            project_id,
-            task_id,
-            "user-123",
-        )
+    with pytest.raises(image_processing.ScaleOdmSubmitError):
+        await project_logic.process_drone_images(ctx, project_id, task_id, "user-123")
 
     assert state_calls[0]["final_state"] == State.IMAGE_PROCESSING_STARTED
     assert state_calls[1]["final_state"] == State.IMAGE_PROCESSING_FAILED
@@ -197,76 +248,40 @@ async def test_process_drone_images_marks_task_failed_when_odm_rejects(monkeypat
 
 @pytest.mark.asyncio
 async def test_process_drone_images_retries_from_failed_state(monkeypatch):
-    """Retry a task whose previous processing attempt failed.
-
-    The first transition (READY_FOR_PROCESSING -> STARTED) should return None
-    because the task is in IMAGE_PROCESSING_FAILED, then the fallback
-    (IMAGE_PROCESSING_FAILED -> STARTED) should succeed.
-    """
     project_id = uuid.uuid4()
     task_id = uuid.uuid4()
     conn = _FakeConn()
     ctx = {"job_id": "job-3", "db_pool": _FakePool(conn)}
     state_calls = []
 
-    async def fake_move_task_images_to_folder(db, project_id_arg, task_id_arg):
-        return {"moved_count": 0, "failed_count": 0}
-
     async def fake_update_task_state_system(
-        db,
-        project_id_arg,
-        task_id_arg,
-        comment,
-        initial_state,
-        final_state,
-        updated_at,
+        db, project_id_arg, task_id_arg, comment, initial_state, final_state, updated_at
     ):
-        state_calls.append(
-            {
-                "comment": comment,
-                "initial_state": initial_state,
-                "final_state": final_state,
-            }
-        )
-        # Simulate: task is currently IMAGE_PROCESSING_FAILED.
-        # READY_FOR_PROCESSING -> STARTED fails; IMAGE_PROCESSING_FAILED -> STARTED succeeds.
+        state_calls.append({"initial_state": initial_state, "final_state": final_state})
         if initial_state == State.READY_FOR_PROCESSING:
             return None
         return {"project_id": project_id_arg, "task_id": task_id_arg}
 
-    class _FakeOdmResult:
-        uuid = "fake-odm-uuid"
-
-    class FakeProcessor:
-        def __init__(self, **kwargs):
-            self.kwargs = kwargs
-
-        async def process_images_from_s3(self, bucket_name, name, options, webhook):
-            return _FakeOdmResult()
+    async def fake_submit(**kwargs):
+        return "fake-odm-uuid"
 
     async def fake_update_task_field(*args, **kwargs):
         return None
 
-    monkeypatch.setattr(project_logic, "DroneImageProcessor", FakeProcessor)
+    monkeypatch.setattr(project_logic, "submit_scaleodm_task", fake_submit)
     monkeypatch.setattr(project_logic, "update_task_field", fake_update_task_field)
 
     from app.tasks import task_logic
 
     monkeypatch.setattr(
-        task_logic,
-        "update_task_state_system",
-        fake_update_task_state_system,
+        task_logic, "update_task_state_system", fake_update_task_state_system
     )
 
     result = await project_logic.process_drone_images(
-        ctx,
-        project_id,
-        task_id,
-        "user-123",
+        ctx, project_id, task_id, "user-123"
     )
 
     assert result["status"] == "processing_started"
-    # First attempt (READY_FOR_PROCESSING) returned None, second (IMAGE_PROCESSING_FAILED) succeeded
     assert state_calls[0]["initial_state"] == State.READY_FOR_PROCESSING
     assert state_calls[1]["initial_state"] == State.IMAGE_PROCESSING_FAILED
     assert state_calls[1]["final_state"] == State.IMAGE_PROCESSING_STARTED
@@ -280,25 +295,10 @@ async def test_process_drone_images_reruns_from_finished_state(monkeypatch):
     ctx = {"job_id": "job-4", "db_pool": _FakePool(conn)}
     state_calls = []
 
-    async def fake_move_task_images_to_folder(db, project_id_arg, task_id_arg):
-        return {"moved_count": 0, "failed_count": 0}
-
     async def fake_update_task_state_system(
-        db,
-        project_id_arg,
-        task_id_arg,
-        comment,
-        initial_state,
-        final_state,
-        updated_at,
+        db, project_id_arg, task_id_arg, comment, initial_state, final_state, updated_at
     ):
-        state_calls.append(
-            {
-                "comment": comment,
-                "initial_state": initial_state,
-                "final_state": final_state,
-            }
-        )
+        state_calls.append({"initial_state": initial_state, "final_state": final_state})
         if initial_state in (
             State.READY_FOR_PROCESSING,
             State.IMAGE_PROCESSING_FAILED,
@@ -306,76 +306,398 @@ async def test_process_drone_images_reruns_from_finished_state(monkeypatch):
             return None
         return {"project_id": project_id_arg, "task_id": task_id_arg}
 
-    class _FakeOdmResult:
-        uuid = "fake-odm-uuid"
-
-    class FakeProcessor:
-        def __init__(self, **kwargs):
-            self.kwargs = kwargs
-
-        async def process_images_from_s3(self, bucket_name, name, options, webhook):
-            return _FakeOdmResult()
+    async def fake_submit(**kwargs):
+        return "fake-odm-uuid"
 
     async def fake_update_task_field(*args, **kwargs):
         return None
 
-    monkeypatch.setattr(project_logic, "DroneImageProcessor", FakeProcessor)
+    monkeypatch.setattr(project_logic, "submit_scaleodm_task", fake_submit)
     monkeypatch.setattr(project_logic, "update_task_field", fake_update_task_field)
 
     from app.tasks import task_logic
 
     monkeypatch.setattr(
-        task_logic,
-        "update_task_state_system",
-        fake_update_task_state_system,
+        task_logic, "update_task_state_system", fake_update_task_state_system
     )
 
     result = await project_logic.process_drone_images(
-        ctx,
-        project_id,
-        task_id,
-        "user-123",
+        ctx, project_id, task_id, "user-123"
     )
 
     assert result["status"] == "processing_started"
-    assert state_calls[0]["initial_state"] == State.READY_FOR_PROCESSING
-    assert state_calls[1]["initial_state"] == State.IMAGE_PROCESSING_FAILED
     assert state_calls[2]["initial_state"] == State.IMAGE_PROCESSING_FINISHED
     assert state_calls[2]["final_state"] == State.IMAGE_PROCESSING_STARTED
 
 
 @pytest.mark.asyncio
 async def test_process_drone_images_raises_when_state_invalid(monkeypatch):
-    """If task is in none of the allowed processing states, raise immediately."""
     project_id = uuid.uuid4()
     task_id = uuid.uuid4()
     conn = _FakeConn()
     ctx = {"job_id": "job-5", "db_pool": _FakePool(conn)}
 
-    async def fake_move_task_images_to_folder(db, project_id_arg, task_id_arg):
-        return {"moved_count": 0, "failed_count": 0}
-
-    async def fake_update_task_state_system(
-        db, project_id_arg, task_id_arg, comment, initial_state, final_state, updated_at
-    ):
-        # Both transitions fail - task is in an unexpected state
+    async def fake_update_task_state_system(*args, **kwargs):
         return None
 
     from app.tasks import task_logic
 
     monkeypatch.setattr(
-        task_logic,
-        "update_task_state_system",
-        fake_update_task_state_system,
+        task_logic, "update_task_state_system", fake_update_task_state_system
     )
 
     with pytest.raises(RuntimeError, match="not in a valid state"):
-        await project_logic.process_drone_images(
+        await project_logic.process_drone_images(ctx, project_id, task_id, "user-123")
+
+
+@pytest.mark.asyncio
+async def test_process_drone_images_propagates_scaleodm_s3_endpoint(monkeypatch):
+    project_id = uuid.uuid4()
+    task_id = uuid.uuid4()
+    conn = _FakeConn()
+    ctx = {"job_id": "job-s3-endpoint", "db_pool": _FakePool(conn)}
+    submit_calls = []
+
+    async def fake_update_task_state_system(*args, **kwargs):
+        return {"ok": True}
+
+    async def fake_submit(**kwargs):
+        submit_calls.append(kwargs)
+        return "fake-odm-uuid"
+
+    async def fake_update_task_field(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(project_logic, "submit_scaleodm_task", fake_submit)
+    monkeypatch.setattr(project_logic, "update_task_field", fake_update_task_field)
+    monkeypatch.setattr(
+        project_logic.settings, "SCALEODM_S3_ENDPOINT", "http://minio.svc:9000"
+    )
+
+    from app.tasks import task_logic
+
+    monkeypatch.setattr(
+        task_logic, "update_task_state_system", fake_update_task_state_system
+    )
+
+    await project_logic.process_drone_images(ctx, project_id, task_id, "user-123")
+
+    assert submit_calls[0]["s3_endpoint"] == "http://minio.svc:9000"
+
+
+# ── process_all_drone_images (project-wide) ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_process_all_drone_images_uses_project_wide_scan_depth(monkeypatch):
+    project_id = uuid.uuid4()
+    conn = _FakeConn()
+    ctx = {"job_id": "proj-1", "db_pool": _FakePool(conn)}
+    submit_calls = []
+
+    async def fake_submit(**kwargs):
+        submit_calls.append(kwargs)
+        return "fake-project-odm-uuid"
+
+    monkeypatch.setattr(project_logic, "submit_scaleodm_task", fake_submit)
+
+    await project_logic.process_all_drone_images(
+        ctx, project_id, [uuid.uuid4()], "user-123"
+    )
+
+    assert len(submit_calls) == 1
+    submitted = submit_calls[0]
+    assert submitted["processing_mode"] == "standard"
+    assert submitted["s3_scan_depth"] == 2
+    assert submitted["use_default_excludes"] is True
+    assert submitted["exclude_paths"] == ["*/thumbs/*"]
+    assert submitted["read_s3_path"].endswith(f"/projects/{project_id}/")
+    assert submitted["write_s3_path"].endswith(f"/projects/{project_id}/odm/")
+    assert submitted["name"] == f"DTM-Project-{project_id}"
+
+
+# ── finalize_scaleodm_task ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_finalize_scaleodm_task_completes_task_and_removes_odm_row(monkeypatch):
+    project_id = uuid.uuid4()
+    task_id = uuid.uuid4()
+    conn = _FakeConn()
+    ctx = {"job_id": "fin-1", "job_try": 1, "db_pool": _FakePool(conn), "redis": None}
+    state_calls = []
+    field_calls = []
+    remove_calls = []
+
+    async def fake_update_task_state_system(**kwargs):
+        state_calls.append(kwargs)
+        return {"ok": True}
+
+    async def fake_update_task_field(db, pid, tid, column, value):
+        field_calls.append({"column": column, "value": value})
+
+    async def fake_get_task_state(db, pid, tid):
+        return {"state": State.IMAGE_PROCESSING_STARTED.name}
+
+    def fake_reproject(pid, tid):
+        # just verify it's invoked with the right ids
+        assert pid == project_id
+        assert tid == task_id
+
+    async def fake_remove(*, scaleodm_url, odm_task_uuid):
+        remove_calls.append({"url": scaleodm_url, "uuid": odm_task_uuid})
+
+    monkeypatch.setattr(arq_tasks, "reproject_orthophoto_in_place", fake_reproject)
+    monkeypatch.setattr(arq_tasks, "remove_scaleodm_task", fake_remove)
+    monkeypatch.setattr(
+        arq_tasks.task_logic, "update_task_state_system", fake_update_task_state_system
+    )
+    monkeypatch.setattr(arq_tasks.task_logic, "get_task_state", fake_get_task_state)
+    monkeypatch.setattr(
+        arq_tasks.project_logic, "update_task_field", fake_update_task_field
+    )
+
+    result = await arq_tasks.finalize_scaleodm_task(
+        ctx,
+        scaleodm_url="http://scaleodm",
+        dtm_project_id=str(project_id),
+        odm_task_uuid="odm-uuid-1",
+        odm_status_code=40,
+        state_name=State.IMAGE_PROCESSING_STARTED.name,
+        message="Task completed.",
+        dtm_task_id=str(task_id),
+    )
+
+    assert result["status"] == "completed"
+    assert state_calls[0]["final_state"] == State.IMAGE_PROCESSING_FINISHED
+    assert field_calls == [
+        {"column": "assets_url", "value": f"projects/{project_id}/{task_id}/odm/"}
+    ]
+    assert remove_calls == [{"url": "http://scaleodm", "uuid": "odm-uuid-1"}]
+
+
+@pytest.mark.asyncio
+async def test_finalize_scaleodm_task_skips_when_state_already_changed(monkeypatch):
+    project_id = uuid.uuid4()
+    task_id = uuid.uuid4()
+    conn = _FakeConn()
+    ctx = {"job_id": "fin-2", "job_try": 1, "db_pool": _FakePool(conn), "redis": None}
+    reproject_calls = []
+
+    async def fake_get_task_state(db, pid, tid):
+        # Different from expected: someone else already finalized.
+        return {"state": State.IMAGE_PROCESSING_FINISHED.name}
+
+    def fake_reproject(*args, **kwargs):
+        reproject_calls.append(args)
+
+    monkeypatch.setattr(arq_tasks, "reproject_orthophoto_in_place", fake_reproject)
+    monkeypatch.setattr(arq_tasks.task_logic, "get_task_state", fake_get_task_state)
+
+    result = await arq_tasks.finalize_scaleodm_task(
+        ctx,
+        scaleodm_url="http://scaleodm",
+        dtm_project_id=str(project_id),
+        odm_task_uuid="odm-uuid-2",
+        odm_status_code=40,
+        state_name=State.IMAGE_PROCESSING_STARTED.name,
+        message="Task completed.",
+        dtm_task_id=str(task_id),
+    )
+
+    assert result["status"] == "skipped"
+    assert reproject_calls == []
+
+
+@pytest.mark.asyncio
+async def test_finalize_scaleodm_task_pulls_error_message_on_status_30(monkeypatch):
+    project_id = uuid.uuid4()
+    task_id = uuid.uuid4()
+    conn = _FakeConn()
+    ctx = {"job_id": "fin-3", "job_try": 1, "db_pool": _FakePool(conn), "redis": None}
+    state_calls = []
+    remove_calls = []
+
+    async def fake_get_task_state(db, pid, tid):
+        return {"state": State.IMAGE_PROCESSING_STARTED.name}
+
+    async def fake_update_task_state_system(**kwargs):
+        state_calls.append(kwargs)
+        return {"ok": True}
+
+    async def fake_fetch_info(*, scaleodm_url, odm_task_uuid):
+        return {"errorMessage": "ODM exited with code 1"}
+
+    async def fake_remove(*, scaleodm_url, odm_task_uuid):
+        remove_calls.append(odm_task_uuid)
+
+    monkeypatch.setattr(arq_tasks, "fetch_scaleodm_task_info", fake_fetch_info)
+    monkeypatch.setattr(arq_tasks, "remove_scaleodm_task", fake_remove)
+    monkeypatch.setattr(arq_tasks.task_logic, "get_task_state", fake_get_task_state)
+    monkeypatch.setattr(
+        arq_tasks.task_logic, "update_task_state_system", fake_update_task_state_system
+    )
+
+    result = await arq_tasks.finalize_scaleodm_task(
+        ctx,
+        scaleodm_url="http://scaleodm",
+        dtm_project_id=str(project_id),
+        odm_task_uuid="odm-uuid-3",
+        odm_status_code=30,
+        state_name=State.IMAGE_PROCESSING_STARTED.name,
+        message="Image processing failed.",
+        dtm_task_id=str(task_id),
+    )
+
+    assert result["status"] == "failed"
+    assert state_calls
+    assert state_calls[0]["final_state"] == State.IMAGE_PROCESSING_FAILED
+    assert "ODM exited with code 1" in state_calls[0]["comment"]
+    assert remove_calls == ["odm-uuid-3"]
+
+
+@pytest.mark.asyncio
+async def test_finalize_scaleodm_task_marks_failed_on_final_transient_try(monkeypatch):
+    project_id = uuid.uuid4()
+    task_id = uuid.uuid4()
+    conn = _FakeConn()
+    ctx = {
+        "job_id": "fin-retry",
+        "job_try": arq_tasks.WorkerSettings.max_tries,
+        "db_pool": _FakePool(conn),
+        "redis": None,
+    }
+    state_calls = []
+
+    async def fake_get_task_state(db, pid, tid):
+        return {"state": State.IMAGE_PROCESSING_STARTED.name}
+
+    async def fake_update_task_state_system(**kwargs):
+        state_calls.append(kwargs)
+        return {"ok": True}
+
+    def fake_reproject(*args, **kwargs):
+        raise image_processing.OrthophotoPostProcessingError("network error")
+
+    async def fake_remove(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(arq_tasks, "reproject_orthophoto_in_place", fake_reproject)
+    monkeypatch.setattr(arq_tasks, "remove_scaleodm_task", fake_remove)
+    monkeypatch.setattr(arq_tasks.task_logic, "get_task_state", fake_get_task_state)
+    monkeypatch.setattr(
+        arq_tasks.task_logic, "update_task_state_system", fake_update_task_state_system
+    )
+
+    with pytest.raises(image_processing.OrthophotoPostProcessingError):
+        await arq_tasks.finalize_scaleodm_task(
             ctx,
-            project_id,
-            task_id,
-            "user-123",
+            scaleodm_url="http://scaleodm",
+            dtm_project_id=str(project_id),
+            odm_task_uuid="odm-uuid-final",
+            odm_status_code=40,
+            state_name=State.IMAGE_PROCESSING_STARTED.name,
+            message="Task completed.",
+            dtm_task_id=str(task_id),
         )
+
+    assert state_calls
+    assert state_calls[0]["final_state"] == State.IMAGE_PROCESSING_FAILED
+    assert "network error" in state_calls[0]["comment"]
+
+
+@pytest.mark.asyncio
+async def test_finalize_scaleodm_task_project_level_completion(monkeypatch):
+    project_id = uuid.uuid4()
+    conn = _FakeConn()
+    ctx = {
+        "job_id": "fin-proj",
+        "job_try": 1,
+        "db_pool": _FakePool(conn),
+        "redis": None,
+    }
+    processing_status_calls = []
+
+    async def fake_update_processing_status(db, pid, status):
+        processing_status_calls.append({"project_id": pid, "status": status})
+
+    def fake_reproject(*args, **kwargs):
+        return None
+
+    async def fake_remove(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(arq_tasks, "reproject_orthophoto_in_place", fake_reproject)
+    monkeypatch.setattr(arq_tasks, "remove_scaleodm_task", fake_remove)
+    monkeypatch.setattr(
+        arq_tasks.project_logic,
+        "update_processing_status",
+        fake_update_processing_status,
+    )
+
+    result = await arq_tasks.finalize_scaleodm_task(
+        ctx,
+        scaleodm_url="http://scaleodm",
+        dtm_project_id=str(project_id),
+        odm_task_uuid="odm-uuid-proj",
+        odm_status_code=40,
+        state_name=None,
+        message="Task completed.",
+        dtm_task_id=None,
+    )
+
+    assert result["status"] == "completed"
+    assert processing_status_calls
+    assert processing_status_calls[0]["status"] == ImageProcessingStatus.SUCCESS
+    assert processing_status_calls[0]["project_id"] == project_id
+
+
+@pytest.mark.asyncio
+async def test_finalize_scaleodm_task_project_level_failure(monkeypatch):
+    project_id = uuid.uuid4()
+    conn = _FakeConn()
+    ctx = {
+        "job_id": "fin-proj-fail",
+        "job_try": 1,
+        "db_pool": _FakePool(conn),
+        "redis": None,
+    }
+    processing_status_calls = []
+
+    async def fake_update_processing_status(db, pid, status):
+        processing_status_calls.append({"project_id": pid, "status": status})
+
+    async def fake_fetch_info(*, scaleodm_url, odm_task_uuid):
+        return None
+
+    async def fake_remove(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(arq_tasks, "fetch_scaleodm_task_info", fake_fetch_info)
+    monkeypatch.setattr(arq_tasks, "remove_scaleodm_task", fake_remove)
+    monkeypatch.setattr(
+        arq_tasks.project_logic,
+        "update_processing_status",
+        fake_update_processing_status,
+    )
+
+    result = await arq_tasks.finalize_scaleodm_task(
+        ctx,
+        scaleodm_url="http://scaleodm",
+        dtm_project_id=str(project_id),
+        odm_task_uuid="odm-uuid-proj-fail",
+        odm_status_code=30,
+        state_name=None,
+        message="Image processing failed.",
+        dtm_task_id=None,
+    )
+
+    assert result["status"] == "failed"
+    assert processing_status_calls
+    assert processing_status_calls[0]["status"] == ImageProcessingStatus.FAILED
+
+
+# ── move_task_images_for_processing (unchanged behaviour, kept for coverage) ──
 
 
 @pytest.mark.asyncio
@@ -407,8 +729,6 @@ async def test_move_task_images_for_processing_commits_on_success(monkeypatch):
         "moved_count": 4,
         "failed_count": 0,
     }
-    # Per-image commits happen inside move_task_images_to_folder (mocked here).
-    # The caller no longer does a bulk commit.
     assert conn.commit_calls == 0
     assert conn.rollback_calls == 0
 
@@ -442,137 +762,11 @@ async def test_move_task_images_for_processing_rolls_back_on_failure_count(monke
             ctx, str(project_id), str(task_id)
         )
 
-    # Per-image commits happen inside the (mocked) move function.
-    # The error handler commits the IMAGE_PROCESSING_FAILED state transition.
     assert conn.commit_calls == 1
     assert conn.rollback_calls == 0
 
 
-@pytest.mark.asyncio
-async def test_move_task_images_for_processing_handles_transfer_failure_state_update_error(
-    monkeypatch,
-):
-    project_id = uuid.uuid4()
-    task_id = uuid.uuid4()
-    conn = _FakeConn()
-    ctx = {"job_id": "move-job-3", "db_pool": _FakePool(conn)}
-
-    async def fake_move_task_images_to_folder(*_args, **_kwargs):
-        return {"moved_count": 0, "failed_count": 1}
-
-    async def fake_update_task_state_system(*_args, **_kwargs):
-        raise RuntimeError("cannot persist state")
-
-    monkeypatch.setattr(
-        arq_tasks.ImageClassifier,
-        "move_task_images_to_folder",
-        fake_move_task_images_to_folder,
-    )
-    monkeypatch.setattr(
-        arq_tasks.task_logic,
-        "update_task_state_system",
-        fake_update_task_state_system,
-    )
-
-    with pytest.raises(RuntimeError, match=r"Failed to move 1 of 1 image\(s\)"):
-        await arq_tasks.move_task_images_for_processing(
-            ctx, str(project_id), str(task_id)
-        )
-
-    # No images moved successfully, so no per-image commits should have happened.
-    # The error handler's commit also fails (update_task_state_system raises).
-    assert conn.commit_calls == 0
-    assert conn.rollback_calls == 1
-
-
-@pytest.mark.asyncio
-async def test_process_assets_from_odm_does_not_mark_single_task_project_complete(
-    monkeypatch, tmp_path
-):
-    project_id = uuid.uuid4()
-    task_id = uuid.uuid4()
-    conn = _FakeConn()
-    update_processing_calls = []
-
-    assets_zip = tmp_path / "assets.zip"
-    assets_zip.write_bytes(b"zip")
-    ortho_dir = tmp_path / "odm_orthophoto"
-    ortho_dir.mkdir()
-    (ortho_dir / "odm_orthophoto.tif").write_bytes(b"ortho")
-
-    class FakeTask:
-        def download_zip(self, output_path):
-            return str(assets_zip)
-
-        def remove(self):
-            return None
-
-    class FakeNode:
-        def get_task(self, odm_task_id):
-            return FakeTask()
-
-    async def fake_get_db_connection_pool():
-        return _FakePool(conn)
-
-    async def fake_update_task_state_system(**kwargs):
-        return {
-            "project_id": kwargs.get("project_id"),
-            "task_id": kwargs.get("task_id"),
-        }
-
-    async def fake_update_task_field(*args, **kwargs):
-        return None
-
-    async def fake_update_processing_status(db, project_id_arg, status):
-        update_processing_calls.append((project_id_arg, status))
-
-    monkeypatch.setattr(image_processing.Node, "from_url", lambda _url: FakeNode())
-    monkeypatch.setattr(
-        image_processing.database,
-        "get_db_connection_pool",
-        fake_get_db_connection_pool,
-    )
-    monkeypatch.setattr(
-        image_processing.task_logic,
-        "update_task_state_system",
-        fake_update_task_state_system,
-    )
-    monkeypatch.setattr(
-        image_processing.project_logic,
-        "update_task_field",
-        fake_update_task_field,
-    )
-    monkeypatch.setattr(
-        image_processing.project_logic,
-        "update_processing_status",
-        fake_update_processing_status,
-    )
-    monkeypatch.setattr(
-        image_processing, "add_file_to_bucket", lambda *args, **kwargs: None
-    )
-    monkeypatch.setattr(
-        image_processing,
-        "delete_objects_by_prefix",
-        lambda *args, **kwargs: 0,
-    )
-    monkeypatch.setattr(
-        image_processing,
-        "reproject_to_web_mercator",
-        lambda *args, **kwargs: None,
-    )
-    monkeypatch.setattr(image_processing.zipfile, "ZipFile", _FakeZipFile)
-
-    await image_processing.process_assets_from_odm(
-        node_odm_url="http://odm",
-        dtm_project_id=project_id,
-        odm_task_id="odm-task-id",
-        state=State.IMAGE_PROCESSING_STARTED,
-        message="Task completed.",
-        dtm_task_id=task_id,
-        odm_status_code=40,
-    )
-
-    assert update_processing_calls == []
+# ── sanitization helpers (unchanged) ──────────────────────────────────────────
 
 
 def test_sanitize_sensitive_text_redacts_token_query_values():
@@ -587,70 +781,13 @@ def test_sanitize_sensitive_text_redacts_token_query_values():
     assert "foo=bar" in sanitized
 
 
-@pytest.mark.asyncio
-async def test_process_drone_images_persists_failure_comment(monkeypatch):
-    """Verify the failure comment reaches update_task_state_system (which
-    sanitizes sensitive values at the DB boundary)."""
-    project_id = uuid.uuid4()
-    task_id = uuid.uuid4()
-    conn = _FakeConn()
-    ctx = {"job_id": "job-redact-1", "db_pool": _FakePool(conn)}
-    state_calls = []
-
-    async def fake_update_task_state_system(
-        db,
-        project_id_arg,
-        task_id_arg,
-        comment,
-        initial_state,
-        final_state,
-        updated_at,
-    ):
-        state_calls.append(
-            {
-                "comment": comment,
-                "initial_state": initial_state,
-                "final_state": final_state,
-            }
-        )
-        return {"project_id": project_id_arg, "task_id": task_id_arg}
-
-    class FailingProcessor:
-        def __init__(self, **kwargs):
-            self.kwargs = kwargs
-
-        async def process_images_from_s3(self, bucket_name, name, options, webhook):
-            raise RuntimeError(
-                "Failed request: https://odm.drone.hotosm.org/info?token=abc123&foo=bar"
-            )
-
-    monkeypatch.setattr(project_logic, "DroneImageProcessor", FailingProcessor)
-
-    from app.tasks import task_logic
-
-    monkeypatch.setattr(
-        task_logic,
-        "update_task_state_system",
-        fake_update_task_state_system,
-    )
-
-    with pytest.raises(RuntimeError):
-        await project_logic.process_drone_images(
-            ctx,
-            project_id,
-            task_id,
-            "user-123",
-        )
-
-    assert state_calls[1]["final_state"] == State.IMAGE_PROCESSING_FAILED
-    assert "Failed request" in state_calls[1]["comment"]
-
-
 def test_update_task_state_system_sanitizes_comment():
-    """Sensitive values in comments are redacted at the DB boundary."""
     from app.utils import sanitize_sensitive_text
 
-    raw = "Image processing failed: https://odm.drone.hotosm.org/info?token=abc123&foo=bar"
+    raw = (
+        "Image processing failed: "
+        "https://odm.drone.hotosm.org/info?token=abc123&foo=bar"
+    )
     sanitized = sanitize_sensitive_text(raw)
     assert "token=abc123" not in sanitized
     assert "token=%5BREDACTED%5D" in sanitized
@@ -658,323 +795,35 @@ def test_update_task_state_system_sanitizes_comment():
 
 
 @pytest.mark.asyncio
-async def test_process_odm_webhook_assets_retries_transient_errors(monkeypatch):
+async def test_process_drone_images_persists_failure_comment(monkeypatch):
+    """Failure comment should reach update_task_state_system."""
     project_id = uuid.uuid4()
     task_id = uuid.uuid4()
     conn = _FakeConn()
-    ctx = {
-        "job_id": "webhook-retry-1",
-        "job_try": 1,
-        "db_pool": _FakePool(conn),
-        "redis": None,
-    }
-
-    async def fake_process_assets_from_odm(**kwargs):
-        raise image_processing.OdmAssetTransientError(
-            "network error https://odm.drone.hotosm.org/info?token=abc123"
-        )
-
-    monkeypatch.setattr(
-        arq_tasks, "process_assets_from_odm", fake_process_assets_from_odm
-    )
-
-    with pytest.raises(image_processing.OdmAssetTransientError):
-        await arq_tasks.process_odm_webhook_assets(
-            ctx,
-            node_odm_url="https://odm.drone.hotosm.org/?token=abc123",
-            dtm_project_id=str(project_id),
-            odm_task_id="odm-task-1",
-            state_name=State.IMAGE_PROCESSING_STARTED.name,
-            message="Task completed.",
-            dtm_task_id=str(task_id),
-            odm_status_code=40,
-        )
-
-
-@pytest.mark.asyncio
-async def test_process_odm_webhook_assets_marks_failed_on_final_transient_try(
-    monkeypatch,
-):
-    project_id = uuid.uuid4()
-    task_id = uuid.uuid4()
-    conn = _FakeConn()
-    ctx = {
-        "job_id": "webhook-retry-2",
-        "job_try": arq_tasks.WorkerSettings.max_tries,
-        "db_pool": _FakePool(conn),
-        "redis": None,
-    }
+    ctx = {"job_id": "job-redact-1", "db_pool": _FakePool(conn)}
     state_calls = []
 
-    async def fake_process_assets_from_odm(**kwargs):
-        raise image_processing.OdmAssetTransientError(
-            "network error https://odm.drone.hotosm.org/info?token=abc123"
+    async def fake_update_task_state_system(
+        db, project_id_arg, task_id_arg, comment, initial_state, final_state, updated_at
+    ):
+        state_calls.append({"comment": comment, "final_state": final_state})
+        return {"project_id": project_id_arg, "task_id": task_id_arg}
+
+    async def failing_submit(**kwargs):
+        raise RuntimeError(
+            "Failed request: https://odm.drone.hotosm.org/info?token=abc123&foo=bar"
         )
 
-    async def fake_update_task_state_system(**kwargs):
-        state_calls.append(kwargs)
-        return {"ok": True}
+    monkeypatch.setattr(project_logic, "submit_scaleodm_task", failing_submit)
+
+    from app.tasks import task_logic
 
     monkeypatch.setattr(
-        arq_tasks, "process_assets_from_odm", fake_process_assets_from_odm
-    )
-    monkeypatch.setattr(
-        arq_tasks.task_logic,
-        "update_task_state_system",
-        fake_update_task_state_system,
+        task_logic, "update_task_state_system", fake_update_task_state_system
     )
 
-    with pytest.raises(image_processing.OdmAssetTransientError):
-        await arq_tasks.process_odm_webhook_assets(
-            ctx,
-            node_odm_url="https://odm.drone.hotosm.org/?token=abc123",
-            dtm_project_id=str(project_id),
-            odm_task_id="odm-task-2",
-            state_name=State.IMAGE_PROCESSING_STARTED.name,
-            message="Task completed.",
-            dtm_task_id=str(task_id),
-            odm_status_code=40,
-        )
+    with pytest.raises(RuntimeError):
+        await project_logic.process_drone_images(ctx, project_id, task_id, "user-123")
 
-    assert state_calls
-    assert state_calls[0]["final_state"] == State.IMAGE_PROCESSING_FAILED
-    # Comment sanitization now happens inside update_task_state_system,
-    # which is monkeypatched here - verify the error message is passed through.
-    assert "network error" in state_calls[0]["comment"]
-
-
-@pytest.mark.asyncio
-async def test_process_odm_webhook_assets_terminal_error_marks_failed_without_raise(
-    monkeypatch,
-):
-    project_id = uuid.uuid4()
-    task_id = uuid.uuid4()
-    conn = _FakeConn()
-    ctx = {
-        "job_id": "webhook-retry-3",
-        "job_try": 1,
-        "db_pool": _FakePool(conn),
-        "redis": None,
-    }
-    state_calls = []
-
-    async def fake_process_assets_from_odm(**kwargs):
-        raise image_processing.OdmAssetTerminalError(
-            "invalid archive https://odm.drone.hotosm.org/info?token=abc123"
-        )
-
-    async def fake_update_task_state_system(**kwargs):
-        state_calls.append(kwargs)
-        return {"ok": True}
-
-    monkeypatch.setattr(
-        arq_tasks, "process_assets_from_odm", fake_process_assets_from_odm
-    )
-    monkeypatch.setattr(
-        arq_tasks.task_logic,
-        "update_task_state_system",
-        fake_update_task_state_system,
-    )
-
-    result = await arq_tasks.process_odm_webhook_assets(
-        ctx,
-        node_odm_url="https://odm.drone.hotosm.org/?token=abc123",
-        dtm_project_id=str(project_id),
-        odm_task_id="odm-task-3",
-        state_name=State.IMAGE_PROCESSING_STARTED.name,
-        message="Task completed.",
-        dtm_task_id=str(task_id),
-        odm_status_code=40,
-    )
-
-    assert result["status"] == "failed"
-    assert state_calls
-    assert state_calls[0]["final_state"] == State.IMAGE_PROCESSING_FAILED
-    # Comment sanitization now happens inside update_task_state_system,
-    # which is monkeypatched here - verify the error message is passed through.
-    assert "invalid archive" in state_calls[0]["comment"]
-
-
-def test_is_thumbnail_object_key_detects_task_thumbs():
-    assert image_processing.DroneImageProcessor._is_thumbnail_object_key(
-        "projects/p/t/images/thumbs/photo_1.jpg"
-    )
-    assert image_processing.DroneImageProcessor._is_thumbnail_object_key(
-        "projects/p/t/images/thumb_photo_1.jpg"
-    )
-    assert not image_processing.DroneImageProcessor._is_thumbnail_object_key(
-        "projects/p/t/images/photo_1.jpg"
-    )
-
-
-def test_list_images_excludes_thumbnail_files(tmp_path):
-    images_dir = tmp_path / "images"
-    thumbs_dir = images_dir / "thumbs"
-    thumbs_dir.mkdir(parents=True)
-
-    full_image = images_dir / "photo_1.jpg"
-    full_image.write_bytes(b"real-image")
-
-    thumb_in_dir = thumbs_dir / "photo_1.jpg"
-    thumb_in_dir.write_bytes(b"thumb")
-
-    thumb_prefix = images_dir / "thumb_photo_2.jpg"
-    thumb_prefix.write_bytes(b"thumb")
-
-    processor = object.__new__(image_processing.DroneImageProcessor)
-    listed = processor.list_images(str(tmp_path))
-    listed_paths = {Path(p) for p in listed}
-
-    assert full_image in listed_paths
-    assert thumb_in_dir not in listed_paths
-    assert thumb_prefix not in listed_paths
-
-
-def test_s3_presigned_urls_exclude_thumbnails(monkeypatch):
-    """End-to-end: presigned URL generation for ODM skips thumbnail objects."""
-
-    class FakeS3Object:
-        def __init__(self, name):
-            self.object_name = name
-
-    fake_objects = [
-        FakeS3Object("projects/p1/t1/images/DJI_0001.JPG"),
-        FakeS3Object("projects/p1/t1/images/DJI_0002.JPG"),
-        FakeS3Object("projects/p1/t1/images/thumbs/DJI_0001.JPG"),
-        FakeS3Object("projects/p1/t1/images/thumbs/DJI_0002.JPG"),
-        FakeS3Object("projects/p1/t1/images/thumb_DJI_0003.JPG"),
-        FakeS3Object("projects/p1/t1/images/geo.txt"),
-    ]
-
-    monkeypatch.setattr(
-        image_processing, "list_objects_from_bucket", lambda *a, **k: fake_objects
-    )
-
-    signed_urls = []
-
-    def fake_presign(bucket, key, expiry, internal=False):
-        signed_urls.append(key)
-        return f"https://s3/{key}"
-
-    monkeypatch.setattr(image_processing, "generate_presigned_get_url", fake_presign)
-
-    processor = object.__new__(image_processing.DroneImageProcessor)
-    processor.project_id = "p1"
-
-    # Call the internal download method just far enough to collect URLs.
-    # We can't await the full download, but we can test URL filtering
-    # by inspecting what generate_presigned_get_url receives.
-    import asyncio
-
-    async def run():
-        prefix = "projects/p1/t1/images"
-        objects = image_processing.list_objects_from_bucket("bucket", prefix)
-        accepted = (".jpg", ".jpeg", ".png", ".txt", ".laz")
-        return [
-            image_processing.generate_presigned_get_url(
-                "bucket", obj.object_name, 12, internal=True
-            )
-            for obj in objects
-            if obj.object_name.lower().endswith(accepted)
-            and not processor._is_thumbnail_object_key(obj.object_name)
-        ]
-
-    asyncio.get_event_loop().run_until_complete(run())
-
-    # Should include the two full images + geo.txt, but NOT the thumbnails
-    assert len(signed_urls) == 3
-    assert any("DJI_0001.JPG" in u and "thumbs" not in u for u in signed_urls)
-    assert any("DJI_0002.JPG" in u and "thumbs" not in u for u in signed_urls)
-    assert any("geo.txt" in u for u in signed_urls)
-    assert not any("thumbs/" in u for u in signed_urls)
-    assert not any("thumb_" in u for u in signed_urls)
-
-
-@pytest.mark.asyncio
-async def test_project_level_terminal_error_marks_project_failed(monkeypatch):
-    """When dtm_task_id is None (project-level), terminal errors must set
-    image_processing_status = FAILED on the project."""
-    project_id = uuid.uuid4()
-    conn = _FakeConn()
-    ctx = {
-        "job_id": "webhook-proj-terminal",
-        "job_try": 1,
-        "db_pool": _FakePool(conn),
-        "redis": None,
-    }
-    processing_status_calls = []
-
-    async def fake_update_processing_status(db, pid, status):
-        processing_status_calls.append({"project_id": pid, "status": status})
-
-    async def fake_process_assets_from_odm(**kwargs):
-        raise image_processing.OdmAssetTerminalError("corrupt archive")
-
-    monkeypatch.setattr(
-        arq_tasks, "process_assets_from_odm", fake_process_assets_from_odm
-    )
-    monkeypatch.setattr(
-        arq_tasks.project_logic,
-        "update_processing_status",
-        fake_update_processing_status,
-    )
-
-    result = await arq_tasks.process_odm_webhook_assets(
-        ctx,
-        node_odm_url="https://odm.example.com",
-        dtm_project_id=str(project_id),
-        odm_task_id="odm-task-proj",
-        state_name=None,
-        message="Task completed.",
-        dtm_task_id=None,  # Project-level
-        odm_status_code=40,
-    )
-
-    assert result["status"] == "failed"
-    assert processing_status_calls
-    assert processing_status_calls[0]["status"] == ImageProcessingStatus.FAILED
-    assert processing_status_calls[0]["project_id"] == project_id
-
-
-@pytest.mark.asyncio
-async def test_project_level_exhausted_retries_marks_project_failed(monkeypatch):
-    """When dtm_task_id is None and retries exhausted, project status must be FAILED."""
-    project_id = uuid.uuid4()
-    conn = _FakeConn()
-    ctx = {
-        "job_id": "webhook-proj-exhausted",
-        "job_try": arq_tasks.WorkerSettings.max_tries,
-        "db_pool": _FakePool(conn),
-        "redis": None,
-    }
-    processing_status_calls = []
-
-    async def fake_update_processing_status(db, pid, status):
-        processing_status_calls.append({"project_id": pid, "status": status})
-
-    async def fake_process_assets_from_odm(**kwargs):
-        raise image_processing.OdmAssetTransientError("timeout")
-
-    monkeypatch.setattr(
-        arq_tasks, "process_assets_from_odm", fake_process_assets_from_odm
-    )
-    monkeypatch.setattr(
-        arq_tasks.project_logic,
-        "update_processing_status",
-        fake_update_processing_status,
-    )
-
-    with pytest.raises(image_processing.OdmAssetTransientError):
-        await arq_tasks.process_odm_webhook_assets(
-            ctx,
-            node_odm_url="https://odm.example.com",
-            dtm_project_id=str(project_id),
-            odm_task_id="odm-task-proj-2",
-            state_name=None,
-            message="Task completed.",
-            dtm_task_id=None,  # Project-level
-            odm_status_code=40,
-        )
-
-    assert processing_status_calls
-    assert processing_status_calls[0]["status"] == ImageProcessingStatus.FAILED
+    assert state_calls[1]["final_state"] == State.IMAGE_PROCESSING_FAILED
+    assert "Failed request" in state_calls[1]["comment"]

--- a/src/backend/tests/test_projects_routes.py
+++ b/src/backend/tests/test_projects_routes.py
@@ -652,13 +652,13 @@ async def test_odm_queue_info_enqueues_missed_webhook_processing(
     assert len(fake_redis.jobs) == 1
 
     job_args, job_kwargs = fake_redis.jobs[0]
-    assert job_args == ("process_odm_webhook_assets",)
+    assert job_args == ("finalize_scaleodm_task",)
     assert job_kwargs == {
-        "node_odm_url": project_routes.settings.ODM_ENDPOINT,
+        "scaleodm_url": project_routes.settings.ODM_ENDPOINT,
         "dtm_project_id": project_id,
-        "odm_task_id": odm_task_uuid,
+        "odm_task_uuid": odm_task_uuid,
         "state_name": "IMAGE_PROCESSING_STARTED",
-        "message": "Reconciled: processing completed on NodeODM (missed webhook).",
+        "message": "Reconciled: processing completed on ScaleODM (missed webhook).",
         "dtm_task_id": task_id,
         "odm_status_code": 40,
         "_job_id": f"odm-assets:task:{task_id}",

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -784,7 +784,6 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pyexiftool" },
     { name = "pyjwt" },
-    { name = "pyodm" },
     { name = "python-multipart" },
     { name = "python-slugify" },
     { name = "redis" },
@@ -860,7 +859,6 @@ requires-dist = [
     { name = "pydantic-settings", specifier = "==2.4.0" },
     { name = "pyexiftool", specifier = "==0.5.6" },
     { name = "pyjwt", specifier = "==2.8.0" },
-    { name = "pyodm", specifier = "==1.5.11" },
     { name = "python-multipart", specifier = "==0.0.9" },
     { name = "python-slugify", specifier = "==8.0.4" },
     { name = "redis", specifier = "==5.2.1" },
@@ -2917,20 +2915,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyodm"
-version = "1.5.11"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "requests" },
-    { name = "requests-toolbelt" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/52/99/53e514b55916ef91c2b6f8f611c0e03465caa9e5a17c742056b543f0c8ee/pyodm-1.5.11.tar.gz", hash = "sha256:bb97710171bfaee92e145bd97b1ac77db8beef580b89d6585a622ff6fb424c53", size = 13713, upload-time = "2023-12-18T16:53:58.859Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/d8/186ee7b2a95f7b8e50f2068e152f5b3a58d838fea90eabde0785c79f32c5/pyodm-1.5.11-py3-none-any.whl", hash = "sha256:c0b9a4358db12f2a84a4d13533b9a3ea4c63419d6518420ba7a2ab32842294b8", size = 14105, upload-time = "2023-12-18T16:53:57.115Z" },
-]
-
-[[package]]
 name = "pyopenssl"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3226,18 +3210,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
-]
-
-[[package]]
-name = "requests-toolbelt"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
 ]
 
 [[package]]

--- a/src/frontend/src/components/DroneOperatorTask/DescriptionSection/DroneImageProcessingWorkflow/index.tsx
+++ b/src/frontend/src/components/DroneOperatorTask/DescriptionSection/DroneImageProcessingWorkflow/index.tsx
@@ -47,7 +47,7 @@ export const UploadImageryDialog = ({ isOpen, onClose, projectId }: IUploadImage
     },
   });
 
-  // Hold Ctrl to reveal the ingest button (same pattern as NodeODM server prompt)
+  // Hold Ctrl to reveal the ingest button (same pattern as ScaleODM server prompt)
   useEffect(() => {
     if (!isOpen) return;
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/src/frontend/src/components/IndividualProject/ModalContent/ProcessingStatusDialog.tsx
+++ b/src/frontend/src/components/IndividualProject/ModalContent/ProcessingStatusDialog.tsx
@@ -635,7 +635,7 @@ const ProcessingStatusDialog = () => {
                                 }
                                 if (e.ctrlKey || e.metaKey) {
                                   const odmUrl = window.prompt(
-                                    "Enter a NodeODM server URL for processing\n(e.g. https://odm.example.com/?token=YOUR_TOKEN)",
+                                    "Enter a ScaleODM server URL for processing\n(e.g. https://scaleodm.example.com/)",
                                   );
                                   if (odmUrl !== null) {
                                     handleProcessSingle(task.task_id, odmUrl || undefined);

--- a/tasks/start
+++ b/tasks/start
@@ -27,10 +27,58 @@ default:
 # Start Drone-TM (dev mode, local build)
 [no-cd]
 all:
-  #!/usr/bin/env sh
+  #!/usr/bin/env bash
 
   cd {{justfile_directory()}}
+
+  # Auto-detect Docker gateway IP for ScaleODM Talos worker pods.
+  #
+  # ScaleODM runs inside a local Talos k8s cluster (itself Docker containers).
+  # Workflow pods need to reach DroneTM's S3 (RustFS), which is published on
+  # the Docker host at port 9000. The reachable address from inside those pods
+  # is the Docker network's gateway IP — not localhost.
+  #
+  # We only auto-detect when SCALEODM_S3_ENDPOINT is unset/empty, so an
+  # explicit value in .env always wins.
+  if [ -z "${SCALEODM_S3_ENDPOINT}" ]; then
+    worker=$(docker ps --format '{{{{.Names}}' 2>/dev/null \
+      | grep -m1 'scaleodm.*worker' || true)
+    if [ -n "$worker" ]; then
+      net=$(docker inspect "$worker" \
+        --format '{{{{range $name,$_ := .NetworkSettings.Networks}}{{{{println $name}}{{{{end}}' \
+        2>/dev/null | head -n1 | tr -d '[:space:]')
+      gw=$(docker network inspect "$net" \
+        --format '{{{{(index .IPAM.Config 0).Gateway}}' \
+        2>/dev/null | tr -d '[:space:]' || true)
+      if [ -n "$gw" ]; then
+        export SCALEODM_S3_ENDPOINT="http://${gw}:9000"
+        just _echo-blue "ScaleODM: auto-set SCALEODM_S3_ENDPOINT=${SCALEODM_S3_ENDPOINT} (worker: ${worker})"
+        # Persist to .env so later docker compose invocations (restart, etc.) also use it.
+        if grep -q '^SCALEODM_S3_ENDPOINT=' .env 2>/dev/null; then
+          sed -i "s|^SCALEODM_S3_ENDPOINT=.*|SCALEODM_S3_ENDPOINT=${SCALEODM_S3_ENDPOINT}|" .env
+        elif [ -f .env ]; then
+          printf 'SCALEODM_S3_ENDPOINT=%s\n' "${SCALEODM_S3_ENDPOINT}" >> .env
+        fi
+      else
+        just _echo-yellow "ScaleODM worker '${worker}' found but could not determine gateway IP."
+        just _echo-yellow "Set SCALEODM_S3_ENDPOINT manually in .env for processing to work."
+      fi
+    fi
+  fi
+
   {{docker}} compose up -d
+
+  # Soft probe: end-to-end imagery processing requires ScaleODM on the host.
+  # The compose stack ships a NodeODM placeholder, but it can't complete a
+  # ScaleODM-flow run (no S3 writer). See docs/dev/setup.md.
+  scaleodm_url="${SCALEODM_PROBE_URL:-http://localhost:31100/info}"
+  if command -v curl >/dev/null 2>&1; then
+    if ! curl -fsS --max-time 2 "$scaleodm_url" >/dev/null 2>&1; then
+      just _echo-yellow "Warning: ScaleODM not reachable at ${scaleodm_url}."
+      just _echo-yellow "         End-to-end imagery processing won't work until you start it."
+      just _echo-yellow "         See docs/dev/setup.md ('End-to-end imagery processing')."
+    fi
+  fi
 
 # Prompt the user to select a release tag and export GIT_BRANCH.
 # Exits if the working tree is dirty or no tags are found.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [x] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR

- Previously we had a pretty horrible, error prone, bandwidth intensive approach for processing: trigger processing --> pull all images from S3 onto DroneTM worker --> package all up as a zip --> send to NodeODM remote instance --> wait and poll for completion status --> receive a webhook from NodeODM --> download the assets from remote NodeODM instance into DroneTM worker --> upload the assets to S3.
- Replaced with a much simpler: trigger processing --> ScaleODM downloads from S3 on the processing node --> processing complete --> ScaleODM uploads direct to S3 from processing node --> DroneTM is notified or polls that the job is done and can access the S3 assets immediately.

Hoping this solves the very flaky processing we currently have to contend with 🤞 

> [!NOTE]
> This will require a coordinated ODM_ENDPOINT variable update via the k8s-infra repo deployment.

## AI Tool Usage

- [ ] No AI tools were used
- [x] AI tools were used (complete below)

**If AI-assisted:**

- Tool(s) used: Opus 4.6
- What was generated: Double checked the integration surface against the ScaleODM API docs & code + first draft of PR.
- What you reviewed and changed: Reviewed, refined, tested everything locally - seems to work well!

## Review notes

- I have been testing ScaleODM deployed in the cluster using cURL:

```bash
kubectl -n odm run scaleodm-submit \
  --rm -it \
  --restart=Never \
  --image=curlimages/curl \
  --command -- sh -c '
    API="http://scaleodm.odm.svc.cluster.local:31100"
    PREFIX="s3://dronetm-prod/projects/005889ef-67e5-4132-935c-ce50aca81952/d00e3b91-0581-429b-916d-6d1a01008a7e"

    echo "==> Checking heartbeat at ${API}/__heartbeat__"
    curl -sv --max-time 10 "${API}/__heartbeat__" || echo "Heartbeat FAILED (exit $?)"

    echo ""
    echo "==> Submitting job to ${API}/task/new"
    PAYLOAD=$(cat <<EOF
{"name":"dronetm-prod-curl-test","readS3Path":"${PREFIX}/images/","writeS3Path":"${PREFIX}/","s3Region":"us-east-1","options":"[{\"name\":\"fast-orthophoto\",\"value\":true}]"}
EOF
)
    echo "    Payload: ${PAYLOAD}"
    response=$(curl -sS --max-time 60 \
      -X POST "${API}/task/new" \
      -H "Content-Type: application/json" \
      -d "${PAYLOAD}")
    echo "    Response: ${response}"
    uuid=$(printf "%s" "${response}" | sed -n "s/.*\"uuid\":\"\([^\"]*\)\".*/\1/p")
    echo "    Task UUID: ${uuid}"
  '
```

The workflow completes & assets are uploaded.

There are also instructions for how to standup a ScaleODM instance locally for testing this, plus Justfile command for assisting with connecting up the networking correctly (it's a bit of a pain, as ScaleODM uses a containerised k8s controlplane + worker, so we need to use a hacky IP based fix to ensure the DroneTM worker can access the ScaleODM API deployed in k8s).

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/hotosm/drone-tm/blob/dev/CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](https://docs.hotosm.org/code-of-conduct)
- [x] PR is focused and small
- [x] Tests are included or updated
- [x] I understand all code in this PR and can answer questions about it
- [x] No secrets, credentials, or sensitive data are included
- [x] Commit messages are descriptive
- [x] Related docs and screenshots are updated

## [optional] What gif best describes this PR or how it makes you feel?
