### PR TITLE
chore: remove the pyupgrade commit hook (because we don't feel confident we can rely on it to target the right version, and ruff can replace its functionality if we need it)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -107,12 +107,6 @@ repos:
         files: src/backend/pyproject.toml
         args: [--project, src/backend]
 
-  # Upgrade: upgrade Python syntax
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.2
-    hooks:
-      - id: pyupgrade
-
   # # Lint: code cognitive complexity
   # - repo: https://github.com/rohaquinlop/complexipy-pre-commit
   #   rev: v5.1.0


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [x] ❓ Other: tooling cleanup

## Related Issue

See discussion in [803](https://github.com/hotosm/drone-tm/pull/803#discussion_r3184487930)

## Describe this PR

Removes the pyupgrade commit hook.

## AI Tool Usage

- [x] No AI tools were used
- [ ] AI tools were used (complete below)

**If AI-assisted:**

- Tool(s) used:
- What was generated:
- What you reviewed and changed:

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/hotosm/drone-tm/blob/dev/CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](https://docs.hotosm.org/code-of-conduct)
- [x] PR is focused and small
- [ ] Tests are included or updated
- [ ] I understand all code in this PR and can answer questions about it
- [x] No secrets, credentials, or sensitive data are included
- [x] Commit messages are descriptive
- [ ] Related docs and screenshots are updated