### PR TITLE
feat(transfer-util): restore missing Flutter lib/ Dart sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,8 @@ src/backend/frontend_html
 *.json
 !**/package.json
 !**/tsconfig.json
+
+# The Python "lib/" packaging ignore above also swallows the Flutter transfer
+# util's Dart sources. Re-include them (anchored so it only affects this app).
+!/src/transfer-util/lib/
+!/src/transfer-util/lib/**

--- a/src/transfer-util/lib/main.dart
+++ b/src/transfer-util/lib/main.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'screens/home_screen.dart';
+import 'state/transfer_controller.dart';
+import 'theme.dart';
+
+void main() {
+  runApp(const DroneTMTransferApp());
+}
+
+/// Root widget. Owns the single [TransferController] for the whole app.
+class DroneTMTransferApp extends StatelessWidget {
+  const DroneTMTransferApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider<TransferController>(
+      // Build the controller and start listening for launch intents / events
+      // after the first frame, so a missing plugin can never block startup.
+      create: (_) => TransferController()..init(),
+      child: MaterialApp(
+        title: 'DroneTM Transfer',
+        debugShowCheckedModeBanner: false,
+        theme: AppTheme.light(),
+        darkTheme: AppTheme.dark(),
+        home: const HomeScreen(),
+      ),
+    );
+  }
+}

--- a/src/transfer-util/lib/models/drone_model.dart
+++ b/src/transfer-util/lib/models/drone_model.dart
@@ -1,0 +1,71 @@
+/// Drone/controller families this app knows about.
+enum DroneFamily { dji, potensic }
+
+/// A selectable drone model and how (or whether) this app can transfer to its
+/// controller.
+///
+/// The capability split mirrors the frontend's WebUSB transfer logic
+/// (`src/frontend/src/utils/adb.ts`):
+///
+/// - **DJI** writes the mission KMZ to *external* app storage
+///   (`Android/data/dji.go.v5/files/waypoint/<uuid>/<uuid>.kmz`), which is
+///   reachable over MTP/SAF — so this app can do it directly.
+/// - **Potensic** writes a SQLite database into the *private* app storage
+///   (`run-as com.ipotensic.potensicpro … databases/test.db`), which is only
+///   reachable via an ADB shell. MTP/SAF cannot touch private storage, so this
+///   app cannot perform the Potensic transfer; the DroneTM web USB transfer
+///   (which speaks ADB) must be used instead.
+class DroneModel {
+  const DroneModel({
+    required this.id,
+    required this.name,
+    required this.family,
+    required this.onDeviceTransfer,
+  });
+
+  /// Stable id, matching the frontend's drone model values.
+  final String id;
+
+  /// Display name.
+  final String name;
+
+  final DroneFamily family;
+
+  /// Whether this app's MTP/SAF transport can deliver to this controller.
+  /// `false` means the user must use the web/ADB method.
+  final bool onDeviceTransfer;
+
+  bool get isDji => family == DroneFamily.dji;
+}
+
+/// The models offered in the selector. Kept to exactly what's needed in the
+/// field: the two DJI Minis and the Potensic Atom 2.
+class DroneModels {
+  DroneModels._();
+
+  static const djiMini4Pro = DroneModel(
+    id: 'DJI_MINI_4_PRO',
+    name: 'DJI Mini 4 Pro',
+    family: DroneFamily.dji,
+    onDeviceTransfer: true,
+  );
+
+  static const djiMini5Pro = DroneModel(
+    id: 'DJI_MINI_5_PRO',
+    name: 'DJI Mini 5 Pro',
+    family: DroneFamily.dji,
+    onDeviceTransfer: true,
+  );
+
+  static const potensicAtom2 = DroneModel(
+    id: 'POTENSIC_ATOM_2',
+    name: 'Potensic Atom 2',
+    family: DroneFamily.potensic,
+    onDeviceTransfer: false,
+  );
+
+  static const all = <DroneModel>[djiMini4Pro, djiMini5Pro, potensicAtom2];
+
+  /// Sensible default (matches the frontend's default drone model).
+  static const fallback = djiMini4Pro;
+}

--- a/src/transfer-util/lib/models/kmz_file.dart
+++ b/src/transfer-util/lib/models/kmz_file.dart
@@ -1,0 +1,42 @@
+import 'dart:typed_data';
+
+/// A KMZ waypoint file that the user wants to push onto the controller.
+///
+/// The bytes are held in memory because every transfer strategy ultimately
+/// hands a `Uint8List` to the native side. KMZ mission files are small (a few
+/// KB to low MB), so this is cheap and avoids juggling file paths/URIs across
+/// the platform boundary.
+class KmzFile {
+  const KmzFile({
+    required this.name,
+    required this.bytes,
+  });
+
+  /// Original file name, e.g. `7f3c....kmz`.
+  final String name;
+
+  /// Raw file contents.
+  final Uint8List bytes;
+
+  int get sizeBytes => bytes.length;
+
+  /// DroneTM names exported missions `<uuid>.kmz`, so the file name (minus the
+  /// extension) is usually the mission UUID. We use this to auto-select the
+  /// matching slot on the controller when one exists.
+  String? get inferredUuid {
+    final dot = name.toLowerCase().lastIndexOf('.kmz');
+    if (dot <= 0) return null;
+    final base = name.substring(0, dot).trim();
+    return base.isEmpty ? null : base;
+  }
+
+  bool get looksLikeKmz => name.toLowerCase().endsWith('.kmz');
+
+  String get humanSize {
+    if (sizeBytes < 1024) return '$sizeBytes B';
+    if (sizeBytes < 1024 * 1024) {
+      return '${(sizeBytes / 1024).toStringAsFixed(1)} KB';
+    }
+    return '${(sizeBytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+  }
+}

--- a/src/transfer-util/lib/models/mission.dart
+++ b/src/transfer-util/lib/models/mission.dart
@@ -1,0 +1,49 @@
+/// A waypoint mission "slot" that already exists on the DJI controller.
+///
+/// DJI Fly stores every mission in its sandboxed directory as
+/// `Android/data/dji.go.v5/files/waypoint/<uuid>/<uuid>.kmz`. We can only ever
+/// *replace* the `.kmz` inside a slot that DJI Fly has already created – we
+/// cannot create new slots, because DJI also tracks them in an internal
+/// database. That constraint is why the UI lists existing slots rather than
+/// letting the user type a name.
+class Mission {
+  const Mission({
+    required this.uuid,
+    required this.dateModified,
+    this.handle,
+  });
+
+  /// The directory name, which is the mission UUID used by DroneTM/DJI.
+  final String uuid;
+
+  /// Last-modified time of the slot directory (best-effort, used for sorting).
+  final DateTime dateModified;
+
+  /// MTP object handle, when discovered via the MTP strategy. Not needed for
+  /// transfer (which addresses missions by [uuid]) but kept for debugging.
+  final int? handle;
+
+  /// Builds a [Mission] from the platform-channel map. Both the MTP and SAF
+  /// Kotlin plugins return `{ uuid: String, dateModified: Long(ms), handle? }`.
+  factory Mission.fromPlatform(Map<dynamic, dynamic> map) {
+    final rawDate = map['dateModified'];
+    final millis = rawDate is int ? rawDate : 0;
+    return Mission(
+      uuid: (map['uuid'] as String?)?.trim() ?? '',
+      dateModified: DateTime.fromMillisecondsSinceEpoch(millis),
+      handle: map['handle'] is int ? map['handle'] as int : null,
+    );
+  }
+
+  bool get isValid => uuid.isNotEmpty;
+
+  @override
+  bool operator ==(Object other) =>
+      other is Mission && other.uuid == uuid && other.handle == handle;
+
+  @override
+  int get hashCode => Object.hash(uuid, handle);
+
+  @override
+  String toString() => 'Mission($uuid, modified: $dateModified)';
+}

--- a/src/transfer-util/lib/models/usb_device.dart
+++ b/src/transfer-util/lib/models/usb_device.dart
@@ -1,0 +1,30 @@
+/// A USB device reported by the native MTP plugin's `getConnectedDevices`.
+class UsbDeviceInfo {
+  const UsbDeviceInfo({
+    required this.name,
+    required this.vendorId,
+    required this.productId,
+    required this.hasPermission,
+    required this.isDji,
+  });
+
+  final String name;
+  final int vendorId;
+  final int productId;
+  final bool hasPermission;
+  final bool isDji;
+
+  factory UsbDeviceInfo.fromPlatform(Map<dynamic, dynamic> map) {
+    return UsbDeviceInfo(
+      name: (map['name'] as String?) ?? 'USB Device',
+      vendorId: (map['vendorId'] as int?) ?? 0,
+      productId: (map['productId'] as int?) ?? 0,
+      hasPermission: (map['hasPermission'] as bool?) ?? false,
+      isDji: (map['isDji'] as bool?) ?? false,
+    );
+  }
+
+  @override
+  String toString() =>
+      'UsbDeviceInfo($name, vid: $vendorId, dji: $isDji, perm: $hasPermission)';
+}

--- a/src/transfer-util/lib/platform/mtp_channel.dart
+++ b/src/transfer-util/lib/platform/mtp_channel.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/services.dart';
+
+import '../models/kmz_file.dart';
+import '../models/mission.dart';
+import '../models/usb_device.dart';
+
+/// Kinds of asynchronous events pushed from the native MTP plugin over the
+/// `org.hotosm.drone_tm/mtp_events` EventChannel. Mirrors the `type` strings
+/// emitted by `MtpTransferPlugin.sendEvent(...)`.
+enum MtpEventType {
+  usbPermissionGranted,
+  usbPermissionDenied,
+  deviceAttached,
+  deviceDisconnected,
+  fileReceived,
+  transferComplete,
+  unknown,
+}
+
+/// A decoded event from the native side.
+class MtpEvent {
+  const MtpEvent(this.type, this.data);
+
+  final MtpEventType type;
+  final Map<dynamic, dynamic> data;
+
+  /// URI string for [MtpEventType.fileReceived].
+  String? get uri => data['uri'] as String?;
+
+  /// Device name for [MtpEventType.usbPermissionGranted].
+  String? get deviceName => data['deviceName'] as String?;
+
+  factory MtpEvent.fromMap(Map<dynamic, dynamic> map) {
+    final type = switch (map['type'] as String?) {
+      'usb_permission_granted' => MtpEventType.usbPermissionGranted,
+      'usb_permission_denied' => MtpEventType.usbPermissionDenied,
+      'device_attached' => MtpEventType.deviceAttached,
+      'device_disconnected' => MtpEventType.deviceDisconnected,
+      'file_received' => MtpEventType.fileReceived,
+      'transfer_complete' => MtpEventType.transferComplete,
+      _ => MtpEventType.unknown,
+    };
+    return MtpEvent(type, map);
+  }
+}
+
+/// Result of `getInitialIntent` / a `file_received` event: how the app was
+/// launched and the file URI it was asked to transfer.
+class IncomingFile {
+  const IncomingFile({required this.uri, this.action = 'view'});
+
+  final String uri;
+  final String action; // 'share' | 'deeplink' | 'view'
+
+  factory IncomingFile.fromMap(Map<dynamic, dynamic> map) => IncomingFile(
+        uri: (map['uri'] as String?) ?? '',
+        action: (map['action'] as String?) ?? 'view',
+      );
+
+  bool get isValid => uri.isNotEmpty;
+}
+
+/// Thin, typed wrapper around the native MTP method + event channels.
+///
+/// This class does no orchestration; it only translates between Dart types and
+/// the platform message maps. The connection/permission state machine lives in
+/// `MtpTransferStrategy`.
+class MtpChannel {
+  MtpChannel()
+      : _method = const MethodChannel('org.hotosm.drone_tm/mtp'),
+        _events = const EventChannel('org.hotosm.drone_tm/mtp_events');
+
+  final MethodChannel _method;
+  final EventChannel _events;
+
+  Stream<MtpEvent>? _eventStream;
+
+  /// Broadcast stream of native events. Lazily started and shared so multiple
+  /// listeners (controller + transient awaiters) can subscribe.
+  Stream<MtpEvent> get events => _eventStream ??= _events
+      .receiveBroadcastStream()
+      .map((dynamic e) => MtpEvent.fromMap(e as Map<dynamic, dynamic>))
+      .asBroadcastStream();
+
+  Future<List<UsbDeviceInfo>> getConnectedDevices() async {
+    final raw = await _method.invokeListMethod<dynamic>('getConnectedDevices');
+    if (raw == null) return const [];
+    return raw
+        .whereType<Map<dynamic, dynamic>>()
+        .map(UsbDeviceInfo.fromPlatform)
+        .toList(growable: false);
+  }
+
+  /// Requests USB permission. Returns `true` if permission was *already*
+  /// granted; `false` means the system dialog was shown and the outcome will
+  /// arrive as a [MtpEventType.usbPermissionGranted] / `usbPermissionDenied`
+  /// event.
+  Future<bool> requestPermission({String? deviceName}) async {
+    final granted = await _method.invokeMethod<bool>(
+      'requestPermission',
+      {'deviceName': deviceName},
+    );
+    return granted ?? false;
+  }
+
+  /// Opens the MTP session. Must be called before [listMissions]/[transferKmz].
+  /// Returns the device descriptor map on success; throws [PlatformException]
+  /// otherwise.
+  Future<Map<dynamic, dynamic>> openDevice({String? deviceName}) async {
+    final info = await _method.invokeMapMethod<dynamic, dynamic>(
+      'openDevice',
+      {'deviceName': deviceName},
+    );
+    return info ?? const {};
+  }
+
+  Future<List<Mission>> listMissions() async {
+    final raw = await _method.invokeListMethod<dynamic>('listMissions');
+    if (raw == null) return const [];
+    return raw
+        .whereType<Map<dynamic, dynamic>>()
+        .map(Mission.fromPlatform)
+        .where((m) => m.isValid)
+        .toList(growable: false);
+  }
+
+  Future<bool> transferKmz({
+    required String uuid,
+    required Uint8List kmzData,
+  }) async {
+    final ok = await _method.invokeMethod<bool>('transferKmz', {
+      'uuid': uuid,
+      'kmzData': kmzData,
+    });
+    return ok ?? false;
+  }
+
+  Future<void> closeDevice() => _method.invokeMethod<void>('closeDevice');
+
+  Future<bool> isConnected() async {
+    final status =
+        await _method.invokeMapMethod<dynamic, dynamic>('getDeviceStatus');
+    return (status?['isConnected'] as bool?) ?? false;
+  }
+
+  /// Reads a `content://` (or `file://`) URI on the native side and returns it
+  /// as an in-memory [KmzFile].
+  Future<KmzFile> readContentUri(String uri) async {
+    final map = await _method.invokeMapMethod<dynamic, dynamic>(
+      'readContentUri',
+      {'uri': uri},
+    );
+    if (map == null) {
+      throw PlatformException(code: 'READ_FAILED', message: 'Empty file read');
+    }
+    final bytes = map['bytes'];
+    return KmzFile(
+      name: (map['name'] as String?) ?? 'mission.kmz',
+      bytes: bytes is Uint8List ? bytes : Uint8List(0),
+    );
+  }
+
+  /// Returns the file the app was cold-launched with (share/deeplink/open), or
+  /// `null` for a normal launch. Native guarantees this fires at most once.
+  Future<IncomingFile?> getInitialIntent() async {
+    final map =
+        await _method.invokeMapMethod<dynamic, dynamic>('getInitialIntent');
+    if (map == null) return null;
+    final incoming = IncomingFile.fromMap(map);
+    return incoming.isValid ? incoming : null;
+  }
+}

--- a/src/transfer-util/lib/platform/saf_channel.dart
+++ b/src/transfer-util/lib/platform/saf_channel.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/services.dart';
+
+import '../models/mission.dart';
+
+/// Thin, typed wrapper around the native SAF (Storage Access Framework)
+/// fallback plugin on `org.hotosm.drone_tm/saf`.
+///
+/// SAF is the fallback for phones where the direct MTP API is unavailable or
+/// flaky. Unlike the old dronetm-mobile app, the native side persists the
+/// directory permission, so the user only has to navigate the picker once.
+class SafChannel {
+  SafChannel() : _method = const MethodChannel('org.hotosm.drone_tm/saf');
+
+  final MethodChannel _method;
+
+  /// Whether a previously-granted waypoint directory permission is still valid.
+  Future<bool> hasPersistedUri() async {
+    final ok = await _method.invokeMethod<bool>('hasPersistedUri');
+    return ok ?? false;
+  }
+
+  /// Launches the system directory picker. Returns `true` once the user has
+  /// selected a directory and the permission has been persisted; `false` if
+  /// they cancelled.
+  Future<bool> openDirectoryPicker() async {
+    final ok = await _method.invokeMethod<bool>('openDirectoryPicker');
+    return ok ?? false;
+  }
+
+  Future<List<Mission>> listMissions() async {
+    final raw = await _method.invokeListMethod<dynamic>('listMissions');
+    if (raw == null) return const [];
+    return raw
+        .whereType<Map<dynamic, dynamic>>()
+        .map(Mission.fromPlatform)
+        .where((m) => m.isValid)
+        .toList(growable: false);
+  }
+
+  Future<bool> transferKmz({
+    required String uuid,
+    required Uint8List kmzData,
+  }) async {
+    final ok = await _method.invokeMethod<bool>('transferKmz', {
+      'uuid': uuid,
+      'kmzData': kmzData,
+    });
+    return ok ?? false;
+  }
+
+  Future<void> clearPersistedUri() =>
+      _method.invokeMethod<void>('clearPersistedUri');
+}

--- a/src/transfer-util/lib/screens/home_screen.dart
+++ b/src/transfer-util/lib/screens/home_screen.dart
@@ -1,0 +1,770 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/transfer_strategy.dart';
+import '../state/transfer_controller.dart';
+import '../widgets/mission_selector.dart';
+
+/// The single screen the whole app lives on. It renders one "step" per
+/// [TransferPhase], keeping the flow flat and obvious rather than spread across
+/// routes the user has to navigate.
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = context.watch<TransferController>();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('DroneTM Transfer'),
+        actions: [
+          IconButton(
+            tooltip: 'How it works',
+            onPressed: () => _showHelp(context),
+            icon: const Icon(Icons.help_outline),
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: AnimatedSwitcher(
+          duration: const Duration(milliseconds: 250),
+          child: SingleChildScrollView(
+            key: ValueKey(controller.phase),
+            padding: const EdgeInsets.fromLTRB(20, 12, 20, 32),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 560),
+              child: _PhaseView(controller: controller),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _showHelp(BuildContext context) {
+    showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      isScrollControlled: true,
+      builder: (_) => const _HelpSheet(),
+    );
+  }
+}
+
+class _PhaseView extends StatelessWidget {
+  const _PhaseView({required this.controller});
+
+  final TransferController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (controller.phase) {
+      TransferPhase.awaitingFile => _AwaitingFileStep(controller: controller),
+      TransferPhase.connecting => _BusyStep(
+          label: controller.status.isEmpty ? 'Connecting…' : controller.status,
+        ),
+      TransferPhase.needsFolder => _NeedsFolderStep(controller: controller),
+      TransferPhase.ready => _ReadyStep(controller: controller),
+      TransferPhase.transferring => _BusyStep(
+          label:
+              controller.status.isEmpty ? 'Transferring…' : controller.status,
+          showFile: true,
+          controller: controller,
+        ),
+      TransferPhase.done => _DoneStep(controller: controller),
+      TransferPhase.failed => _FailedStep(controller: controller),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Step 1: choose / receive a file
+// ---------------------------------------------------------------------------
+
+class _AwaitingFileStep extends StatelessWidget {
+  const _AwaitingFileStep({required this.controller});
+
+  final TransferController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const SizedBox(height: 24),
+        Center(
+          child: Container(
+            width: 96,
+            height: 96,
+            decoration: BoxDecoration(
+              color: scheme.primaryContainer,
+              shape: BoxShape.circle,
+            ),
+            child: Icon(Icons.upload_file,
+                size: 44, color: scheme.onPrimaryContainer),
+          ),
+        ),
+        const SizedBox(height: 24),
+        Text(
+          'Send a mission to your controller',
+          textAlign: TextAlign.center,
+          style: theme.textTheme.headlineSmall
+              ?.copyWith(fontWeight: FontWeight.w700),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Pick the waypoint file (.kmz) you generated in DroneTM or QField, '
+          'then we\'ll copy it straight onto the DJI controller over the cable.',
+          textAlign: TextAlign.center,
+          style: theme.textTheme.bodyMedium
+              ?.copyWith(color: scheme.onSurfaceVariant),
+        ),
+        const SizedBox(height: 28),
+        FilledButton.icon(
+          onPressed: controller.pickFile,
+          icon: const Icon(Icons.folder_open),
+          label: const Text('Choose a .kmz file'),
+        ),
+        const SizedBox(height: 16),
+        _HintRow(
+          icon: Icons.ios_share,
+          text:
+              'Tip: you can also Share a .kmz from QField or your browser to '
+              '"DroneTM Transfer" and it will open here automatically.',
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Busy step (connecting / transferring)
+// ---------------------------------------------------------------------------
+
+class _BusyStep extends StatelessWidget {
+  const _BusyStep({
+    required this.label,
+    this.showFile = false,
+    this.controller,
+  });
+
+  final String label;
+  final bool showFile;
+  final TransferController? controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (showFile && controller?.file != null) ...[
+          _FileCard(controller: controller!),
+          const SizedBox(height: 24),
+        ] else
+          const SizedBox(height: 48),
+        const Center(child: CircularProgressIndicator()),
+        const SizedBox(height: 20),
+        Text(
+          label,
+          textAlign: TextAlign.center,
+          style: theme.textTheme.titleMedium,
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SAF folder access step
+// ---------------------------------------------------------------------------
+
+class _NeedsFolderStep extends StatelessWidget {
+  const _NeedsFolderStep({required this.controller});
+
+  final TransferController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _FileCard(controller: controller),
+        const SizedBox(height: 16),
+        _SectionCard(
+          icon: Icons.folder_special,
+          title: 'Grant folder access (one time)',
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Android needs you to point to the controller\'s waypoint '
+                'folder once. After that it\'s remembered.',
+                style: theme.textTheme.bodyMedium,
+              ),
+              const SizedBox(height: 12),
+              const _PathSteps(),
+            ],
+          ),
+        ),
+        const SizedBox(height: 20),
+        FilledButton.icon(
+          onPressed: controller.chooseFolder,
+          icon: const Icon(Icons.drive_folder_upload),
+          label: const Text('Choose folder'),
+        ),
+        if (controller.method == TransferMethod.saf) ...[
+          const SizedBox(height: 8),
+          OutlinedButton.icon(
+            onPressed: () => controller.useMethod(TransferMethod.mtp),
+            icon: const Icon(Icons.usb),
+            label: const Text('Try direct USB instead'),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Ready: pick a slot and send
+// ---------------------------------------------------------------------------
+
+class _ReadyStep extends StatelessWidget {
+  const _ReadyStep({required this.controller});
+
+  final TransferController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final hasMissions = controller.missions.isNotEmpty;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _FileCard(controller: controller),
+        const SizedBox(height: 16),
+        _MethodToggle(controller: controller),
+        const SizedBox(height: 20),
+        if (!hasMissions)
+          _SectionCard(
+            icon: Icons.info_outline,
+            title: 'No mission slots found',
+            tone: _CardTone.warning,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'The controller has no waypoint missions yet. DJI only lets '
+                  'us replace an existing mission, so create one first:',
+                  style: theme.textTheme.bodyMedium,
+                ),
+                const SizedBox(height: 10),
+                const _OrderedSteps(steps: [
+                  'On the controller, open DJI Fly.',
+                  'Create any waypoint mission (a single point is fine).',
+                  'Come back here and tap Refresh.',
+                ]),
+              ],
+            ),
+          )
+        else ...[
+          Text(
+            'Choose the slot to send into',
+            style:
+                theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+          ),
+          const SizedBox(height: 12),
+          MissionSelector(
+            missions: controller.missions,
+            selected: controller.selectedMission,
+            onSelected: controller.selectMission,
+            highlightUuid: controller.file?.inferredUuid,
+          ),
+        ],
+        const SizedBox(height: 20),
+        if (hasMissions)
+          FilledButton.icon(
+            onPressed: controller.selectedMission == null
+                ? null
+                : controller.startTransfer,
+            icon: const Icon(Icons.send),
+            label: const Text('Send to controller'),
+          )
+        else
+          FilledButton.icon(
+            onPressed: controller.connectAndList,
+            icon: const Icon(Icons.refresh),
+            label: const Text('Refresh'),
+          ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Done
+// ---------------------------------------------------------------------------
+
+class _DoneStep extends StatelessWidget {
+  const _DoneStep({required this.controller});
+
+  final TransferController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final uuid = controller.selectedMission?.uuid ?? '';
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const SizedBox(height: 28),
+        Center(
+          child: Container(
+            width: 96,
+            height: 96,
+            decoration: BoxDecoration(
+              color: scheme.tertiaryContainer,
+              shape: BoxShape.circle,
+            ),
+            child: Icon(Icons.check_rounded,
+                size: 52, color: scheme.onTertiaryContainer),
+          ),
+        ),
+        const SizedBox(height: 24),
+        Text(
+          'Mission sent',
+          textAlign: TextAlign.center,
+          style: theme.textTheme.headlineSmall
+              ?.copyWith(fontWeight: FontWeight.w700),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'The waypoint file was copied onto the controller'
+          '${uuid.isEmpty ? '' : ' (slot ${_short(uuid)})'}.',
+          textAlign: TextAlign.center,
+          style: theme.textTheme.bodyMedium
+              ?.copyWith(color: scheme.onSurfaceVariant),
+        ),
+        const SizedBox(height: 16),
+        _SectionCard(
+          icon: Icons.flight_takeoff,
+          title: 'On the controller',
+          tone: _CardTone.success,
+          child: Text(
+            'Open DJI Fly and select that mission — your updated waypoints are '
+            'ready to fly.',
+            style: theme.textTheme.bodyMedium,
+          ),
+        ),
+        const SizedBox(height: 24),
+        FilledButton.icon(
+          onPressed: controller.reset,
+          icon: const Icon(Icons.add),
+          label: const Text('Send another'),
+        ),
+      ],
+    );
+  }
+
+  String _short(String uuid) => uuid.length > 12
+      ? '${uuid.substring(0, 8)}…'
+      : uuid;
+}
+
+// ---------------------------------------------------------------------------
+// Failed
+// ---------------------------------------------------------------------------
+
+class _FailedStep extends StatelessWidget {
+  const _FailedStep({required this.controller});
+
+  final TransferController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final error = controller.error;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (controller.file != null) ...[
+          _FileCard(controller: controller),
+          const SizedBox(height: 16),
+        ],
+        _SectionCard(
+          icon: error?.requiresDjiSetup == true
+              ? Icons.flight
+              : Icons.error_outline,
+          title: error?.requiresDjiSetup == true
+              ? 'One step on the controller'
+              : 'Transfer didn\'t complete',
+          tone: _CardTone.error,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                error?.message ?? 'Something went wrong. Please try again.',
+                style: theme.textTheme.bodyMedium,
+              ),
+              if (error?.technical != null) ...[
+                const SizedBox(height: 8),
+                Theme(
+                  data: theme.copyWith(dividerColor: Colors.transparent),
+                  child: ExpansionTile(
+                    tilePadding: EdgeInsets.zero,
+                    childrenPadding: EdgeInsets.zero,
+                    title: Text('Technical details',
+                        style: theme.textTheme.bodySmall
+                            ?.copyWith(color: scheme.onSurfaceVariant)),
+                    children: [
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: Text(
+                          '${error?.code}: ${error?.technical}',
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            fontFamily: 'monospace',
+                            color: scheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+        const SizedBox(height: 20),
+        FilledButton.icon(
+          onPressed: controller.retry,
+          icon: const Icon(Icons.refresh),
+          label: const Text('Try again'),
+        ),
+        if (error?.canFallbackToSaf == true &&
+            controller.method == TransferMethod.mtp) ...[
+          const SizedBox(height: 8),
+          OutlinedButton.icon(
+            onPressed: controller.fallbackToSaf,
+            icon: const Icon(Icons.folder),
+            label: const Text('Use file access instead'),
+          ),
+        ],
+        const SizedBox(height: 4),
+        TextButton(
+          onPressed: controller.reset,
+          child: const Text('Start over'),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared widgets
+// ---------------------------------------------------------------------------
+
+class _FileCard extends StatelessWidget {
+  const _FileCard({required this.controller});
+
+  final TransferController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final file = controller.file;
+    if (file == null) return const SizedBox.shrink();
+
+    final isKmz = file.looksLikeKmz;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(14),
+        child: Row(
+          children: [
+            CircleAvatar(
+              backgroundColor: scheme.secondaryContainer,
+              child: Icon(Icons.description, color: scheme.onSecondaryContainer),
+            ),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    file.name,
+                    style: theme.textTheme.titleSmall
+                        ?.copyWith(fontWeight: FontWeight.w600),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    isKmz
+                        ? file.humanSize
+                        : '${file.humanSize} • not a .kmz file',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: isKmz ? scheme.onSurfaceVariant : scheme.error,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            TextButton(
+              onPressed: controller.pickFile,
+              child: const Text('Change'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MethodToggle extends StatelessWidget {
+  const _MethodToggle({required this.controller});
+
+  final TransferController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return SegmentedButton<TransferMethod>(
+      segments: const [
+        ButtonSegment(
+          value: TransferMethod.mtp,
+          icon: Icon(Icons.usb),
+          label: Text('Direct USB'),
+        ),
+        ButtonSegment(
+          value: TransferMethod.saf,
+          icon: Icon(Icons.folder),
+          label: Text('File access'),
+        ),
+      ],
+      selected: {controller.method},
+      onSelectionChanged: (s) => controller.useMethod(s.first),
+      showSelectedIcon: false,
+    );
+  }
+}
+
+enum _CardTone { neutral, success, warning, error }
+
+class _SectionCard extends StatelessWidget {
+  const _SectionCard({
+    required this.icon,
+    required this.title,
+    required this.child,
+    this.tone = _CardTone.neutral,
+  });
+
+  final IconData icon;
+  final String title;
+  final Widget child;
+  final _CardTone tone;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final (bg, fg) = switch (tone) {
+      _CardTone.success => (scheme.tertiaryContainer, scheme.onTertiaryContainer),
+      _CardTone.warning =>
+        (scheme.secondaryContainer, scheme.onSecondaryContainer),
+      _CardTone.error => (scheme.errorContainer, scheme.onErrorContainer),
+      _CardTone.neutral =>
+        (scheme.surfaceContainerHighest, scheme.onSurface),
+    };
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(icon, color: fg, size: 20),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  title,
+                  style: Theme.of(context)
+                      .textTheme
+                      .titleSmall
+                      ?.copyWith(color: fg, fontWeight: FontWeight.w700),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          DefaultTextStyle.merge(
+            style: TextStyle(color: fg),
+            child: child,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HintRow extends StatelessWidget {
+  const _HintRow({required this.icon, required this.text});
+
+  final IconData icon;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(icon, size: 18, color: scheme.onSurfaceVariant),
+        const SizedBox(width: 10),
+        Expanded(
+          child: Text(
+            text,
+            style: Theme.of(context)
+                .textTheme
+                .bodySmall
+                ?.copyWith(color: scheme.onSurfaceVariant),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// The DJI path rendered as discrete folder chips, so users know exactly what
+/// to tap in the SAF picker.
+class _PathSteps extends StatelessWidget {
+  const _PathSteps();
+
+  static const _segments = [
+    'Android',
+    'data',
+    'dji.go.v5',
+    'files',
+    'waypoint',
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Wrap(
+      spacing: 6,
+      runSpacing: 6,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        for (var i = 0; i < _segments.length; i++) ...[
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+            decoration: BoxDecoration(
+              color: scheme.surface,
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: scheme.outlineVariant),
+            ),
+            child: Text(_segments[i],
+                style: const TextStyle(
+                    fontFamily: 'monospace', fontSize: 12.5)),
+          ),
+          if (i < _segments.length - 1)
+            Icon(Icons.chevron_right, size: 16, color: scheme.onSurfaceVariant),
+        ],
+      ],
+    );
+  }
+}
+
+class _OrderedSteps extends StatelessWidget {
+  const _OrderedSteps({required this.steps});
+
+  final List<String> steps;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (var i = 0; i < steps.length; i++)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 6),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('${i + 1}.',
+                    style: theme.textTheme.bodyMedium
+                        ?.copyWith(fontWeight: FontWeight.w700)),
+                const SizedBox(width: 8),
+                Expanded(
+                    child: Text(steps[i], style: theme.textTheme.bodyMedium)),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _HelpSheet extends StatelessWidget {
+  const _HelpSheet();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 0, 20, 32),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('How it works',
+              style: theme.textTheme.titleLarge
+                  ?.copyWith(fontWeight: FontWeight.w700)),
+          const SizedBox(height: 16),
+          const _OrderedSteps(steps: [
+            'Generate a waypoint mission (.kmz) in DroneTM or QField.',
+            'Connect your phone to the DJI controller with a USB data cable.',
+            'Open this app (or Share the .kmz to it) and pick the file.',
+            'Choose the mission slot on the controller and send.',
+          ]),
+          const SizedBox(height: 16),
+          Text('Why two methods?',
+              style: theme.textTheme.titleMedium
+                  ?.copyWith(fontWeight: FontWeight.w600)),
+          const SizedBox(height: 8),
+          Text(
+            'Direct USB talks to the controller programmatically and needs no '
+            'folder picking — it\'s the default. If your phone can\'t use it, '
+            'switch to File access, which uses Android\'s folder picker once.',
+            style: theme.textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 16),
+          Text('First time? Create a mission in DJI Fly',
+              style: theme.textTheme.titleMedium
+                  ?.copyWith(fontWeight: FontWeight.w600)),
+          const SizedBox(height: 8),
+          Text(
+            'DJI only lets us replace an existing mission file. If no slots '
+            'show up, make any waypoint mission in DJI Fly first, then refresh.',
+            style: theme.textTheme.bodyMedium,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/src/transfer-util/lib/screens/home_screen.dart
+++ b/src/transfer-util/lib/screens/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../services/transfer_strategy.dart';
 import '../state/transfer_controller.dart';
+import '../widgets/drone_model_bar.dart';
 import '../widgets/mission_selector.dart';
 
 /// The single screen the whole app lives on. It renders one "step" per
@@ -27,14 +28,29 @@ class HomeScreen extends StatelessWidget {
         ],
       ),
       body: SafeArea(
-        child: AnimatedSwitcher(
-          duration: const Duration(milliseconds: 250),
-          child: SingleChildScrollView(
-            key: ValueKey(controller.phase),
-            padding: const EdgeInsets.fromLTRB(20, 12, 20, 32),
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 560),
-              child: _PhaseView(controller: controller),
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 560),
+            child: Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 12, 20, 0),
+                  child: DroneModelBar(
+                    selected: controller.model,
+                    onSelected: controller.selectModel,
+                  ),
+                ),
+                Expanded(
+                  child: AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 250),
+                    child: SingleChildScrollView(
+                      key: ValueKey(controller.phase),
+                      padding: const EdgeInsets.fromLTRB(20, 12, 20, 32),
+                      child: _PhaseView(controller: controller),
+                    ),
+                  ),
+                ),
+              ],
             ),
           ),
         ),
@@ -60,6 +76,8 @@ class _PhaseView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return switch (controller.phase) {
+      TransferPhase.unsupportedModel =>
+        _UnsupportedModelStep(controller: controller),
       TransferPhase.awaitingFile => _AwaitingFileStep(controller: controller),
       TransferPhase.connecting => _BusyStep(
           label: controller.status.isEmpty ? 'Connecting…' : controller.status,
@@ -135,6 +153,73 @@ class _AwaitingFileStep extends StatelessWidget {
           text:
               'Tip: you can also Share a .kmz from QField or your browser to '
               '"DroneTM Transfer" and it will open here automatically.',
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Unsupported model (Potensic): guide to the web transfer
+// ---------------------------------------------------------------------------
+
+class _UnsupportedModelStep extends StatelessWidget {
+  const _UnsupportedModelStep({required this.controller});
+
+  final TransferController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const SizedBox(height: 20),
+        Center(
+          child: Container(
+            width: 88,
+            height: 88,
+            decoration: BoxDecoration(
+              color: scheme.secondaryContainer,
+              shape: BoxShape.circle,
+            ),
+            child: Icon(Icons.public,
+                size: 40, color: scheme.onSecondaryContainer),
+          ),
+        ),
+        const SizedBox(height: 20),
+        Text(
+          '${controller.model.name} uses the web transfer',
+          textAlign: TextAlign.center,
+          style: theme.textTheme.headlineSmall
+              ?.copyWith(fontWeight: FontWeight.w700),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Potensic stores missions in its app\'s private database, which can '
+          'only be written over ADB. This app\'s direct USB transfer can\'t '
+          'reach private app storage, so use the DroneTM web app instead.',
+          textAlign: TextAlign.center,
+          style: theme.textTheme.bodyMedium
+              ?.copyWith(color: scheme.onSurfaceVariant),
+        ),
+        const SizedBox(height: 16),
+        _SectionCard(
+          icon: Icons.usb,
+          title: 'Send via the DroneTM web app',
+          child: const _OrderedSteps(steps: [
+            'Open the DroneTM web app in desktop Chrome or Edge.',
+            'Connect the Potensic controller to the computer with a USB cable.',
+            'Use its USB transfer option to send the mission.',
+          ]),
+        ),
+        const SizedBox(height: 16),
+        _HintRow(
+          icon: Icons.flight,
+          text: 'Flying a DJI Mini 4/5 Pro instead? Pick it in the drone '
+              'selector above to transfer right here.',
         ),
       ],
     );

--- a/src/transfer-util/lib/services/mtp_transfer.dart
+++ b/src/transfer-util/lib/services/mtp_transfer.dart
@@ -1,0 +1,234 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+
+import '../models/mission.dart';
+import '../platform/mtp_channel.dart';
+import 'transfer_strategy.dart';
+
+/// Primary strategy: talk to the controller directly with Android's
+/// `android.mtp.MtpDevice` API (wrapped by `MtpTransferPlugin.kt`).
+///
+/// This avoids the SAF directory picker entirely – navigation happens
+/// programmatically on the native side – which is the whole point of the
+/// rewrite. The tricky part handled here is the USB *permission* handshake:
+/// `requestPermission` returns immediately, and the user's choice arrives later
+/// as an event, so [prepare] bridges that into a single awaitable step.
+class MtpTransferStrategy implements TransferStrategy {
+  MtpTransferStrategy(this._channel);
+
+  final MtpChannel _channel;
+
+  bool _opened = false;
+
+  /// How long to wait for the user to respond to the USB permission dialog.
+  static const _permissionTimeout = Duration(seconds: 90);
+
+  @override
+  TransferMethod get method => TransferMethod.mtp;
+
+  @override
+  String get displayName => 'Direct USB';
+
+  @override
+  String get description =>
+      'Talks to the controller directly over the cable. Fastest and needs no '
+      'folder picking. Recommended.';
+
+  /// True when a DJI (or generic MTP) device is currently plugged in. Used by
+  /// the controller to decide whether to default to this strategy.
+  Future<bool> hasDevice() async {
+    final devices = await _channel.getConnectedDevices();
+    return devices.isNotEmpty;
+  }
+
+  @override
+  Future<void> prepare() async {
+    final devices = await _channel.getConnectedDevices();
+    if (devices.isEmpty) {
+      throw const TransferException(
+        code: 'NO_DEVICE',
+        message:
+            'No controller detected. Connect the DJI RC to your phone with a '
+            'USB cable and make sure the cable supports data (not just '
+            'charging).',
+        canFallbackToSaf: true,
+      );
+    }
+
+    // Prefer a recognised DJI device, otherwise the first MTP device.
+    final device = devices.firstWhere(
+      (d) => d.isDji,
+      orElse: () => devices.first,
+    );
+
+    if (!device.hasPermission) {
+      final alreadyGranted =
+          await _channel.requestPermission(deviceName: device.name);
+      if (!alreadyGranted) {
+        final granted = await _awaitPermissionDecision();
+        if (!granted) {
+          throw const TransferException(
+            code: 'NO_PERMISSION',
+            message:
+                'USB access was not granted. Reconnect the controller and tap '
+                '"OK" (optionally "Always allow") when Android asks for '
+                'permission.',
+            canFallbackToSaf: true,
+          );
+        }
+      }
+    }
+
+    try {
+      await _channel.openDevice(deviceName: device.name);
+      _opened = true;
+    } on PlatformException catch (e) {
+      throw _mapError(e);
+    }
+  }
+
+  @override
+  Future<List<Mission>> listMissions() async {
+    try {
+      return await _channel.listMissions();
+    } on PlatformException catch (e) {
+      throw _mapError(e);
+    }
+  }
+
+  @override
+  Future<void> transfer({
+    required String uuid,
+    required Uint8List kmzData,
+  }) async {
+    try {
+      final ok = await _channel.transferKmz(uuid: uuid, kmzData: kmzData);
+      if (!ok) {
+        throw const TransferException(
+          code: 'SEND_FAILED',
+          message:
+              'The controller rejected the transfer. Try again, or switch to '
+              'the file-access fallback.',
+          canFallbackToSaf: true,
+        );
+      }
+    } on PlatformException catch (e) {
+      throw _mapError(e);
+    }
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (!_opened) return;
+    _opened = false;
+    try {
+      await _channel.closeDevice();
+    } on PlatformException {
+      // Best-effort cleanup; ignore.
+    }
+  }
+
+  /// Waits for the `usb_permission_granted` / `usb_permission_denied` event
+  /// that follows a permission dialog. Resolves `true` on grant, `false` on
+  /// denial or timeout.
+  Future<bool> _awaitPermissionDecision() {
+    final completer = Completer<bool>();
+    late final StreamSubscription<MtpEvent> sub;
+
+    void finish(bool granted) {
+      if (completer.isCompleted) return;
+      sub.cancel();
+      completer.complete(granted);
+    }
+
+    sub = _channel.events.listen(
+      (event) {
+        switch (event.type) {
+          case MtpEventType.usbPermissionGranted:
+            finish(true);
+          case MtpEventType.usbPermissionDenied:
+            finish(false);
+          default:
+            break;
+        }
+      },
+      onError: (_) => finish(false),
+    );
+
+    return completer.future.timeout(
+      _permissionTimeout,
+      onTimeout: () {
+        finish(false);
+        return false;
+      },
+    );
+  }
+
+  TransferException _mapError(PlatformException e) {
+    final detail = e.message;
+    return switch (e.code) {
+      'NO_PERMISSION' => TransferException(
+          code: e.code,
+          message:
+              'USB access was not granted. Reconnect the controller and allow '
+              'access when prompted.',
+          canFallbackToSaf: true,
+          technical: detail,
+        ),
+      'OPEN_FAILED' || 'MTP_OPEN_FAILED' => TransferException(
+          code: e.code,
+          message:
+              'Could not open the controller over USB. Unplug and replug the '
+              'cable, then try again. If it keeps failing, use file access.',
+          canFallbackToSaf: true,
+          technical: detail,
+        ),
+      'NOT_CONNECTED' => TransferException(
+          code: e.code,
+          message:
+              'Lost the connection to the controller. Check the cable and '
+              'reconnect.',
+          canFallbackToSaf: true,
+          technical: detail,
+        ),
+      'NO_STORAGE' => TransferException(
+          code: e.code,
+          message:
+              'The controller did not expose any storage. Make sure it is '
+              'powered on and unlocked.',
+          canFallbackToSaf: true,
+          technical: detail,
+        ),
+      'DIR_NOT_FOUND' => TransferException(
+          code: e.code,
+          message:
+              'The DJI waypoint folder was not found. Open DJI Fly on the '
+              'controller and create at least one waypoint mission first.',
+          requiresDjiSetup: true,
+          technical: detail,
+        ),
+      'MISSION_NOT_FOUND' => TransferException(
+          code: e.code,
+          message:
+              'That mission slot is no longer on the controller. Refresh the '
+              'list and pick another.',
+          technical: detail,
+        ),
+      'SEND_INFO_FAILED' || 'SEND_FAILED' => TransferException(
+          code: e.code,
+          message:
+              'The controller rejected the file. Try again, or switch to the '
+              'file-access fallback.',
+          canFallbackToSaf: true,
+          technical: detail,
+        ),
+      _ => TransferException(
+          code: e.code,
+          message: 'USB transfer failed. ${detail ?? ''}'.trim(),
+          canFallbackToSaf: true,
+          technical: detail,
+        ),
+    };
+  }
+}

--- a/src/transfer-util/lib/services/saf_transfer.dart
+++ b/src/transfer-util/lib/services/saf_transfer.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/services.dart';
+
+import '../models/mission.dart';
+import '../platform/saf_channel.dart';
+import 'transfer_strategy.dart';
+
+/// Fallback strategy: Storage Access Framework (SAF).
+///
+/// Used when the direct MTP API is unavailable or fails. The big improvement
+/// over the legacy app is that the granted directory permission is persisted
+/// natively, so the user navigates the folder picker exactly once and every
+/// later transfer is one tap.
+class SafTransferStrategy implements TransferStrategy {
+  SafTransferStrategy(this._channel);
+
+  final SafChannel _channel;
+
+  @override
+  TransferMethod get method => TransferMethod.saf;
+
+  @override
+  String get displayName => 'File access';
+
+  @override
+  String get description =>
+      'Uses Android\'s folder picker. You point it at the controller\'s '
+      'waypoint folder once, then it is remembered.';
+
+  /// Whether the user has already granted (and we still hold) access to the
+  /// waypoint directory.
+  Future<bool> hasAccess() => _channel.hasPersistedUri();
+
+  /// Launches the system folder picker. Returns `true` once a directory is
+  /// chosen and persisted.
+  Future<bool> requestAccess() async {
+    try {
+      return await _channel.openDirectoryPicker();
+    } on PlatformException catch (e) {
+      throw _mapError(e);
+    }
+  }
+
+  @override
+  Future<void> prepare() async {
+    if (await _channel.hasPersistedUri()) return;
+    final granted = await requestAccess();
+    if (!granted) {
+      throw const TransferException(
+        code: 'NO_DIR',
+        message:
+            'Folder access is needed. Tap "Choose folder" and browse to the '
+            'controller\'s DJI waypoint folder '
+            '(Android > data > dji.go.v5 > files > waypoint).',
+      );
+    }
+  }
+
+  @override
+  Future<List<Mission>> listMissions() async {
+    try {
+      return await _channel.listMissions();
+    } on PlatformException catch (e) {
+      throw _mapError(e);
+    }
+  }
+
+  @override
+  Future<void> transfer({
+    required String uuid,
+    required Uint8List kmzData,
+  }) async {
+    try {
+      final ok = await _channel.transferKmz(uuid: uuid, kmzData: kmzData);
+      if (!ok) {
+        throw const TransferException(
+          code: 'WRITE_FAILED',
+          message: 'Could not write the file to the controller. Try again.',
+        );
+      }
+    } on PlatformException catch (e) {
+      throw _mapError(e);
+    }
+  }
+
+  @override
+  Future<void> dispose() async {
+    // Nothing to release; the persisted permission is intentionally kept.
+  }
+
+  /// Forgets the saved directory so the user can re-pick it (e.g. they granted
+  /// the wrong folder).
+  Future<void> resetAccess() => _channel.clearPersistedUri();
+
+  TransferException _mapError(PlatformException e) {
+    final detail = e.message;
+    return switch (e.code) {
+      'NO_DIR' => TransferException(
+          code: e.code,
+          message:
+              'No folder has been chosen yet. Tap "Choose folder" and browse '
+              'to the controller\'s waypoint folder.',
+          technical: detail,
+        ),
+      'MISSION_NOT_FOUND' => TransferException(
+          code: e.code,
+          message:
+              'That mission slot was not found in the chosen folder. Refresh '
+              'and pick another, or re-choose the folder.',
+          technical: detail,
+        ),
+      'INVALID_DIR' || 'PERMISSION_FAILED' => TransferException(
+          code: e.code,
+          message:
+              'That folder can\'t be used. Re-open the picker and select the '
+              'waypoint folder on the controller, not local phone storage.',
+          technical: detail,
+        ),
+      'CREATE_FAILED' || 'WRITE_FAILED' => TransferException(
+          code: e.code,
+          message:
+              'Could not write to the controller. Reconnect it and make sure '
+              'the chosen folder is still accessible.',
+          technical: detail,
+        ),
+      'PICKER_FAILED' => TransferException(
+          code: e.code,
+          message: 'Could not open the folder picker on this device.',
+          technical: detail,
+        ),
+      _ => TransferException(
+          code: e.code,
+          message: 'File access failed. ${detail ?? ''}'.trim(),
+          technical: detail,
+        ),
+    };
+  }
+}

--- a/src/transfer-util/lib/services/transfer_strategy.dart
+++ b/src/transfer-util/lib/services/transfer_strategy.dart
@@ -1,0 +1,66 @@
+import 'dart:typed_data';
+
+import '../models/mission.dart';
+
+/// Which underlying transport a [TransferStrategy] uses.
+enum TransferMethod { mtp, saf }
+
+/// A user-facing failure raised by a [TransferStrategy].
+///
+/// Native code throws `PlatformException`s with terse codes; strategies
+/// translate those into a [TransferException] carrying a sentence the user can
+/// actually act on, plus hints for the controller (whether falling back to SAF
+/// might help, or whether the user must act in DJI Fly first).
+class TransferException implements Exception {
+  const TransferException({
+    required this.code,
+    required this.message,
+    this.canFallbackToSaf = false,
+    this.requiresDjiSetup = false,
+    this.technical,
+  });
+
+  /// Stable machine code (mirrors the native error code where there is one).
+  final String code;
+
+  /// Friendly, actionable sentence shown to the user.
+  final String message;
+
+  /// True when retrying via the SAF strategy could plausibly succeed.
+  final bool canFallbackToSaf;
+
+  /// True when the fix is in DJI Fly (e.g. create a mission slot first).
+  final bool requiresDjiSetup;
+
+  /// Original technical detail, surfaced only in a "details" expander.
+  final String? technical;
+
+  @override
+  String toString() => 'TransferException($code): $message';
+}
+
+/// A way of getting a KMZ file onto the controller. Implementations are the
+/// direct-MTP path (primary) and the SAF path (fallback).
+abstract class TransferStrategy {
+  TransferMethod get method;
+
+  /// Short label, e.g. "Direct USB".
+  String get displayName;
+
+  /// One-line explanation for the strategy picker.
+  String get description;
+
+  /// Establishes a usable session (open device / confirm directory access).
+  /// Throws [TransferException] if it cannot be prepared.
+  Future<void> prepare();
+
+  /// Lists the mission slots already present on the controller.
+  Future<List<Mission>> listMissions();
+
+  /// Writes [kmzData] into the `<uuid>/<uuid>.kmz` slot, replacing any existing
+  /// file. Throws [TransferException] on failure.
+  Future<void> transfer({required String uuid, required Uint8List kmzData});
+
+  /// Releases any held resources (open MTP handle, etc.). Safe to call twice.
+  Future<void> dispose();
+}

--- a/src/transfer-util/lib/state/transfer_controller.dart
+++ b/src/transfer-util/lib/state/transfer_controller.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 
+import '../models/drone_model.dart';
 import '../models/kmz_file.dart';
 import '../models/mission.dart';
 import '../platform/mtp_channel.dart';
@@ -14,6 +15,10 @@ import '../services/transfer_strategy.dart';
 /// The distinct steps the user moves through. The UI renders one "step" widget
 /// per phase, which keeps navigation flat and the flow obvious.
 enum TransferPhase {
+  /// The selected drone model can't be transferred to from this app
+  /// (Potensic): show guidance to use the web method instead.
+  unsupportedModel,
+
   /// No KMZ chosen yet.
   awaitingFile,
 
@@ -57,6 +62,9 @@ class TransferController extends ChangeNotifier {
 
   TransferPhase _phase = TransferPhase.awaitingFile;
   TransferPhase get phase => _phase;
+
+  DroneModel _model = DroneModels.fallback;
+  DroneModel get model => _model;
 
   KmzFile? _file;
   KmzFile? get file => _file;
@@ -162,6 +170,30 @@ class TransferController extends ChangeNotifier {
     }
   }
 
+  // ---- Drone model ------------------------------------------------------
+
+  /// Changes the target drone model. Potensic can't be transferred to from
+  /// this app, so it drops into the [TransferPhase.unsupportedModel] guidance
+  /// step; DJI resumes the normal flow.
+  Future<void> selectModel(DroneModel next) async {
+    if (next.id == _model.id) return;
+    _model = next;
+    _error = null;
+
+    if (!next.onDeviceTransfer) {
+      await _strategy.dispose();
+      _setPhase(TransferPhase.unsupportedModel);
+      return;
+    }
+
+    // DJI: continue where it makes sense.
+    if (_file != null) {
+      await connectAndList();
+    } else {
+      _setPhase(TransferPhase.awaitingFile);
+    }
+  }
+
   // ---- File intake ------------------------------------------------------
 
   /// Opens the system file picker for the user to choose a `.kmz`.
@@ -225,6 +257,10 @@ class TransferController extends ChangeNotifier {
   /// Prepares the active strategy and loads the controller's mission slots.
   Future<void> connectAndList() async {
     if (_file == null) return;
+    if (!_model.onDeviceTransfer) {
+      _setPhase(TransferPhase.unsupportedModel);
+      return;
+    }
     _error = null;
     _setPhase(TransferPhase.connecting);
     _status = isUsb ? 'Opening controller over USB…' : 'Checking folder access…';

--- a/src/transfer-util/lib/state/transfer_controller.dart
+++ b/src/transfer-util/lib/state/transfer_controller.dart
@@ -1,0 +1,349 @@
+import 'dart:async';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart';
+
+import '../models/kmz_file.dart';
+import '../models/mission.dart';
+import '../platform/mtp_channel.dart';
+import '../platform/saf_channel.dart';
+import '../services/mtp_transfer.dart';
+import '../services/saf_transfer.dart';
+import '../services/transfer_strategy.dart';
+
+/// The distinct steps the user moves through. The UI renders one "step" widget
+/// per phase, which keeps navigation flat and the flow obvious.
+enum TransferPhase {
+  /// No KMZ chosen yet.
+  awaitingFile,
+
+  /// Opening the controller / confirming access.
+  connecting,
+
+  /// SAF chosen but the waypoint folder hasn't been granted yet.
+  needsFolder,
+
+  /// Connected; mission slots loaded and ready to transfer.
+  ready,
+
+  /// Writing the file to the controller.
+  transferring,
+
+  /// Transfer finished successfully.
+  done,
+
+  /// Something failed; [error] explains what.
+  failed,
+}
+
+/// Single source of truth for the transfer flow. Screens are thin observers of
+/// this controller; all platform interaction is funnelled through it.
+class TransferController extends ChangeNotifier {
+  TransferController({MtpChannel? mtpChannel, SafChannel? safChannel})
+      : _mtpChannel = mtpChannel ?? MtpChannel(),
+        _safChannel = safChannel ?? SafChannel() {
+    _mtp = MtpTransferStrategy(_mtpChannel);
+    _saf = SafTransferStrategy(_safChannel);
+  }
+
+  final MtpChannel _mtpChannel;
+  final SafChannel _safChannel;
+  late final MtpTransferStrategy _mtp;
+  late final SafTransferStrategy _saf;
+
+  StreamSubscription<MtpEvent>? _eventSub;
+
+  // ---- Observable state -------------------------------------------------
+
+  TransferPhase _phase = TransferPhase.awaitingFile;
+  TransferPhase get phase => _phase;
+
+  KmzFile? _file;
+  KmzFile? get file => _file;
+
+  TransferMethod _method = TransferMethod.mtp;
+  TransferMethod get method => _method;
+
+  List<Mission> _missions = const [];
+  List<Mission> get missions => _missions;
+
+  Mission? _selected;
+  Mission? get selectedMission => _selected;
+
+  TransferException? _error;
+  TransferException? get error => _error;
+
+  /// Human-readable status line shown under the header (device name, etc.).
+  String _status = '';
+  String get status => _status;
+
+  bool _usbDevicePresent = false;
+
+  /// Whether the active strategy is the direct-USB one.
+  bool get isUsb => _method == TransferMethod.mtp;
+
+  TransferStrategy get _strategy => isUsb ? _mtp : _saf;
+
+  // ---- Lifecycle --------------------------------------------------------
+
+  /// Wire up native events and pick up any file the app was launched with.
+  /// All native calls are guarded so a missing plugin (e.g. in tests) never
+  /// blocks the first frame.
+  Future<void> init() async {
+    _eventSub = _mtpChannel.events.listen(
+      _onNativeEvent,
+      onError: (_) {/* no plugin / no listener – ignore */},
+    );
+
+    try {
+      _usbDevicePresent = await _mtp.hasDevice();
+    } catch (_) {
+      _usbDevicePresent = false;
+    }
+    _method =
+        _usbDevicePresent ? TransferMethod.mtp : TransferMethod.saf;
+
+    try {
+      final incoming = await _mtpChannel.getInitialIntent();
+      if (incoming != null) {
+        await _loadFromUri(incoming.uri);
+      }
+    } catch (_) {
+      // No launch intent / no plugin.
+    }
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _eventSub?.cancel();
+    _mtp.dispose();
+    _saf.dispose();
+    super.dispose();
+  }
+
+  // ---- Native events ----------------------------------------------------
+
+  void _onNativeEvent(MtpEvent event) {
+    switch (event.type) {
+      case MtpEventType.fileReceived:
+        final uri = event.uri;
+        if (uri != null && uri.isNotEmpty) _loadFromUri(uri);
+      case MtpEventType.deviceAttached:
+        _usbDevicePresent = true;
+        // If we were stuck waiting for a USB device, retry automatically.
+        if (_file != null &&
+            isUsb &&
+            (_phase == TransferPhase.failed ||
+                _phase == TransferPhase.awaitingFile)) {
+          connectAndList();
+        } else {
+          notifyListeners();
+        }
+      case MtpEventType.deviceDisconnected:
+        _usbDevicePresent = false;
+        if (isUsb &&
+            (_phase == TransferPhase.ready ||
+                _phase == TransferPhase.connecting)) {
+          _fail(const TransferException(
+            code: 'NOT_CONNECTED',
+            message:
+                'The controller was unplugged. Reconnect it and try again.',
+            canFallbackToSaf: true,
+          ));
+        } else {
+          notifyListeners();
+        }
+      case MtpEventType.usbPermissionGranted:
+      case MtpEventType.usbPermissionDenied:
+      case MtpEventType.transferComplete:
+      case MtpEventType.unknown:
+        break;
+    }
+  }
+
+  // ---- File intake ------------------------------------------------------
+
+  /// Opens the system file picker for the user to choose a `.kmz`.
+  Future<void> pickFile() async {
+    try {
+      final result = await FilePicker.pickFiles(withData: true);
+      if (result == null || result.files.isEmpty) return; // cancelled
+      final picked = result.files.first;
+      final bytes = picked.bytes;
+      if (bytes == null) {
+        _fail(const TransferException(
+          code: 'READ_FAILED',
+          message: 'Could not read that file. Try choosing it again.',
+        ));
+        return;
+      }
+      await setFile(KmzFile(name: picked.name, bytes: bytes));
+    } catch (e) {
+      _fail(TransferException(
+        code: 'PICK_FAILED',
+        message: 'Could not open the file picker.',
+        technical: '$e',
+      ));
+    }
+  }
+
+  Future<void> _loadFromUri(String uri) async {
+    try {
+      final kmz = await _mtpChannel.readContentUri(uri);
+      await setFile(kmz);
+    } catch (e) {
+      _fail(TransferException(
+        code: 'READ_FAILED',
+        message: 'Could not read the shared file.',
+        technical: '$e',
+      ));
+    }
+  }
+
+  /// Accepts a KMZ and kicks off the connect → list flow.
+  Future<void> setFile(KmzFile kmz) async {
+    _file = kmz;
+    _error = null;
+    notifyListeners();
+    await connectAndList();
+  }
+
+  // ---- Strategy / connection -------------------------------------------
+
+  /// Switches transport (e.g. falling back to SAF) and reconnects.
+  Future<void> useMethod(TransferMethod next) async {
+    if (next == _method) return;
+    await _strategy.dispose();
+    _method = next;
+    _error = null;
+    await connectAndList();
+  }
+
+  Future<void> fallbackToSaf() => useMethod(TransferMethod.saf);
+
+  /// Prepares the active strategy and loads the controller's mission slots.
+  Future<void> connectAndList() async {
+    if (_file == null) return;
+    _error = null;
+    _setPhase(TransferPhase.connecting);
+    _status = isUsb ? 'Opening controller over USB…' : 'Checking folder access…';
+    notifyListeners();
+
+    try {
+      // For SAF, surface the folder picker step explicitly instead of
+      // launching it from under a spinner.
+      if (!isUsb && !await _saf.hasAccess()) {
+        _setPhase(TransferPhase.needsFolder);
+        return;
+      }
+
+      await _strategy.prepare();
+      _missions = await _strategy.listMissions();
+      _autoSelect();
+      _status = isUsb ? 'Connected over USB' : 'Folder access granted';
+      _setPhase(TransferPhase.ready);
+    } on TransferException catch (e) {
+      if (e.code == 'NO_DIR') {
+        _setPhase(TransferPhase.needsFolder);
+      } else {
+        _fail(e);
+      }
+    } catch (e) {
+      _fail(TransferException(
+        code: 'UNEXPECTED',
+        message: 'Something went wrong while connecting.',
+        canFallbackToSaf: isUsb,
+        technical: '$e',
+      ));
+    }
+  }
+
+  /// Launches the SAF folder picker, then lists missions on success.
+  Future<void> chooseFolder() async {
+    try {
+      final granted = await _saf.requestAccess();
+      if (!granted) return; // user cancelled; stay on needsFolder
+      await connectAndList();
+    } on TransferException catch (e) {
+      _fail(e);
+    }
+  }
+
+  void _autoSelect() {
+    if (_missions.isEmpty) {
+      _selected = null;
+      return;
+    }
+    final inferred = _file?.inferredUuid;
+    _selected = _missions.firstWhere(
+      (m) => inferred != null && m.uuid == inferred,
+      orElse: () => _missions.first, // most-recent (native sorts desc)
+    );
+  }
+
+  void selectMission(Mission mission) {
+    _selected = mission;
+    notifyListeners();
+  }
+
+  // ---- Transfer ---------------------------------------------------------
+
+  Future<void> startTransfer() async {
+    final file = _file;
+    final mission = _selected;
+    if (file == null || mission == null) return;
+
+    _setPhase(TransferPhase.transferring);
+    _status = 'Sending ${file.name}…';
+    notifyListeners();
+
+    try {
+      await _strategy.transfer(uuid: mission.uuid, kmzData: file.bytes);
+      _status = 'Sent to ${mission.uuid}';
+      _setPhase(TransferPhase.done);
+    } on TransferException catch (e) {
+      if (e.code == 'MISSION_NOT_FOUND') {
+        // The slot vanished – refresh and let the user re-pick.
+        await connectAndList();
+      }
+      _fail(e);
+    } catch (e) {
+      _fail(TransferException(
+        code: 'UNEXPECTED',
+        message: 'The transfer failed unexpectedly.',
+        canFallbackToSaf: isUsb,
+        technical: '$e',
+      ));
+    }
+  }
+
+  /// Retries the current step after a failure.
+  Future<void> retry() async {
+    _error = null;
+    await connectAndList();
+  }
+
+  /// Clears the file and returns to the start to send another mission.
+  void reset() {
+    _file = null;
+    _missions = const [];
+    _selected = null;
+    _error = null;
+    _status = '';
+    _setPhase(TransferPhase.awaitingFile);
+  }
+
+  // ---- Helpers ----------------------------------------------------------
+
+  void _setPhase(TransferPhase p) {
+    _phase = p;
+    notifyListeners();
+  }
+
+  void _fail(TransferException e) {
+    _error = e;
+    _phase = TransferPhase.failed;
+    notifyListeners();
+  }
+}

--- a/src/transfer-util/lib/theme.dart
+++ b/src/transfer-util/lib/theme.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+
+/// App theming. Material 3 with a single seed colour so every surface, button
+/// and state colour is derived from one semantic palette – which keeps the UI
+/// coherent in both light and dark mode without hand-picking colours.
+class AppTheme {
+  AppTheme._();
+
+  /// DroneTM "sky" blue – reads as connectivity/transfer.
+  static const Color _seed = Color(0xFF1565C0);
+
+  static ThemeData light() => _build(Brightness.light);
+  static ThemeData dark() => _build(Brightness.dark);
+
+  static ThemeData _build(Brightness brightness) {
+    final scheme = ColorScheme.fromSeed(
+      seedColor: _seed,
+      brightness: brightness,
+    );
+    return ThemeData(
+      useMaterial3: true,
+      colorScheme: scheme,
+      scaffoldBackgroundColor: scheme.surface,
+      appBarTheme: AppBarTheme(
+        centerTitle: false,
+        backgroundColor: scheme.surface,
+        foregroundColor: scheme.onSurface,
+        elevation: 0,
+        scrolledUnderElevation: 2,
+      ),
+      cardTheme: CardThemeData(
+        elevation: 0,
+        clipBehavior: Clip.antiAlias,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+          side: BorderSide(color: scheme.outlineVariant),
+        ),
+      ),
+      filledButtonTheme: FilledButtonThemeData(
+        style: FilledButton.styleFrom(
+          minimumSize: const Size.fromHeight(52),
+          textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(14),
+          ),
+        ),
+      ),
+      outlinedButtonTheme: OutlinedButtonThemeData(
+        style: OutlinedButton.styleFrom(
+          minimumSize: const Size.fromHeight(48),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(14),
+          ),
+        ),
+      ),
+      listTileTheme: const ListTileThemeData(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(Radius.circular(12)),
+        ),
+      ),
+      snackBarTheme: SnackBarThemeData(
+        behavior: SnackBarBehavior.floating,
+        shape:
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      ),
+    );
+  }
+}

--- a/src/transfer-util/lib/widgets/drone_model_bar.dart
+++ b/src/transfer-util/lib/widgets/drone_model_bar.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+
+import '../models/drone_model.dart';
+
+/// Persistent bar at the top of the app showing the selected drone model and
+/// letting the user change it. Tapping opens a bottom sheet of the supported
+/// models.
+class DroneModelBar extends StatelessWidget {
+  const DroneModelBar({
+    super.key,
+    required this.selected,
+    required this.onSelected,
+  });
+
+  final DroneModel selected;
+  final ValueChanged<DroneModel> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+
+    return Material(
+      color: scheme.surfaceContainerHighest,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(14),
+        onTap: () => _openPicker(context),
+        child: Semantics(
+          button: true,
+          label: 'Drone model: ${selected.name}. Tap to change.',
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+            child: Row(
+              children: [
+                Icon(Icons.flight, color: scheme.onSurfaceVariant, size: 20),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Drone model',
+                        style: theme.textTheme.labelSmall
+                            ?.copyWith(color: scheme.onSurfaceVariant),
+                      ),
+                      Text(
+                        selected.name,
+                        style: theme.textTheme.titleSmall
+                            ?.copyWith(fontWeight: FontWeight.w600),
+                      ),
+                    ],
+                  ),
+                ),
+                if (!selected.onDeviceTransfer)
+                  Padding(
+                    padding: const EdgeInsets.only(right: 8),
+                    child: _WebBadge(scheme: scheme),
+                  ),
+                Icon(Icons.expand_more, color: scheme.onSurfaceVariant),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _openPicker(BuildContext context) {
+    final theme = Theme.of(context);
+    showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (sheetCtx) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 4, 20, 12),
+                child: Text(
+                  'Select drone model',
+                  style: theme.textTheme.titleMedium
+                      ?.copyWith(fontWeight: FontWeight.w700),
+                ),
+              ),
+              for (final m in DroneModels.all)
+                ListTile(
+                  leading: Icon(
+                    m.isDji ? Icons.flight : Icons.flight_takeoff,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                  title: Text(m.name),
+                  subtitle: Text(
+                    m.onDeviceTransfer
+                        ? 'Direct USB transfer'
+                        : 'Use the DroneTM web USB transfer',
+                  ),
+                  trailing: m.id == selected.id
+                      ? Icon(Icons.check, color: theme.colorScheme.primary)
+                      : null,
+                  onTap: () {
+                    Navigator.pop(sheetCtx);
+                    if (m.id != selected.id) onSelected(m);
+                  },
+                ),
+              const SizedBox(height: 8),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _WebBadge extends StatelessWidget {
+  const _WebBadge({required this.scheme});
+
+  final ColorScheme scheme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: scheme.secondaryContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        'WEB ONLY',
+        style: TextStyle(
+          fontSize: 10,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0.4,
+          color: scheme.onSecondaryContainer,
+        ),
+      ),
+    );
+  }
+}

--- a/src/transfer-util/lib/widgets/mission_selector.dart
+++ b/src/transfer-util/lib/widgets/mission_selector.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+
+import '../models/mission.dart';
+
+/// A selectable list of the mission slots found on the controller.
+///
+/// Each slot maps to a `<uuid>/` directory created by DJI Fly. Picking one and
+/// transferring *replaces* the `.kmz` inside it, so the copy makes the
+/// "overwrite" nature explicit.
+class MissionSelector extends StatelessWidget {
+  const MissionSelector({
+    super.key,
+    required this.missions,
+    required this.selected,
+    required this.onSelected,
+    this.highlightUuid,
+  });
+
+  final List<Mission> missions;
+  final Mission? selected;
+  final ValueChanged<Mission> onSelected;
+
+  /// UUID inferred from the file name; if a slot matches, it's badged as a
+  /// suggested match.
+  final String? highlightUuid;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        for (final mission in missions)
+          _MissionTile(
+            mission: mission,
+            isSelected: selected?.uuid == mission.uuid,
+            isSuggested:
+                highlightUuid != null && mission.uuid == highlightUuid,
+            onTap: () => onSelected(mission),
+          ),
+        const SizedBox(height: 4),
+        Text(
+          'The selected slot\'s mission file will be replaced.',
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _MissionTile extends StatelessWidget {
+  const _MissionTile({
+    required this.mission,
+    required this.isSelected,
+    required this.isSuggested,
+    required this.onTap,
+  });
+
+  final Mission mission;
+  final bool isSelected;
+  final bool isSuggested;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final shortId = mission.uuid.length > 12
+        ? '${mission.uuid.substring(0, 8)}…${mission.uuid.substring(mission.uuid.length - 4)}'
+        : mission.uuid;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Material(
+        color: isSelected
+            ? scheme.primaryContainer
+            : scheme.surfaceContainerHighest,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+          side: BorderSide(
+            color: isSelected ? scheme.primary : scheme.outlineVariant,
+            width: isSelected ? 2 : 1,
+          ),
+        ),
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(12),
+          child: Semantics(
+            selected: isSelected,
+            button: true,
+            label: 'Mission slot $shortId'
+                '${isSuggested ? ', suggested match' : ''}',
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+              child: Row(
+                children: [
+                  Icon(
+                    isSelected
+                        ? Icons.radio_button_checked
+                        : Icons.radio_button_unchecked,
+                    color: isSelected ? scheme.primary : scheme.outline,
+                  ),
+                  const SizedBox(width: 14),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Flexible(
+                              child: Text(
+                                shortId,
+                                style: theme.textTheme.titleMedium?.copyWith(
+                                  color: isSelected
+                                      ? scheme.onPrimaryContainer
+                                      : scheme.onSurface,
+                                ),
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                            if (isSuggested) ...[
+                              const SizedBox(width: 8),
+                              _Badge(label: 'Match', scheme: scheme),
+                            ],
+                          ],
+                        ),
+                        const SizedBox(height: 2),
+                        Text(
+                          _modified(mission.dateModified),
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: isSelected
+                                ? scheme.onPrimaryContainer.withValues(alpha: 0.8)
+                                : scheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _modified(DateTime t) {
+    if (t.millisecondsSinceEpoch == 0) return 'Existing slot';
+    final d = t.toLocal();
+    String two(int n) => n.toString().padLeft(2, '0');
+    return 'Updated ${d.year}-${two(d.month)}-${two(d.day)} ${two(d.hour)}:${two(d.minute)}';
+  }
+}
+
+class _Badge extends StatelessWidget {
+  const _Badge({required this.label, required this.scheme});
+
+  final String label;
+  final ColorScheme scheme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: scheme.tertiaryContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+          color: scheme.onTertiaryContainer,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## What this PR does

Restores the **Flutter `lib/` Dart sources** for the `transfer-util` app that are missing from #793.

The root `.gitignore` has a Python-packaging rule (`lib/`) that silently matched and excluded `src/transfer-util/lib/`, so the entire Dart app layer never got committed on `feat/file-transfer-util`. As a result the app cannot build (`flutter build apk` has no entry point) and `test/widget_test.dart` (which imports `package:dronetm_transfer/main.dart`) cannot compile.

This PR targets `feat/file-transfer-util` so it can be merged into #793.

## Changes

- **`build`**: anchored `.gitignore` negation (`!/src/transfer-util/lib/`) so the Dart sources are tracked without affecting the Python `lib/` ignore.
- **`feat`**: the `lib/` layer, written against the **existing Kotlin platform channels** (`MtpTransferPlugin.kt`, `SafTransferPlugin.kt`) — channel names, method args, return shapes, event types and error codes all match the native contract exactly:
  - `models/` — `Mission`, `KmzFile` (with uuid inference), `UsbDeviceInfo`
  - `platform/` — typed `MtpChannel` (method + event channel) and `SafChannel`
  - `services/` — `TransferStrategy` interface + friendly `TransferException`, `MtpTransferStrategy` (direct USB, incl. the async USB-permission handshake), `SafTransferStrategy` (persisted-permission fallback)
  - `state/` — `TransferController` orchestration (auto strategy selection, share/deeplink intake, graceful MTP→SAF fallback, auto-retry/disconnect handling)
  - UI — Material 3 `theme`, phase-driven `HomeScreen`, `MissionSelector` widget, `main` entry point

## Behaviour notes

- Honors DJI's constraint: missions can only **replace** an existing `<uuid>.kmz` in a slot DJI Fly already created — empty list shows explicit "create a mission in DJI Fly first" guidance.
- Seamless flow: auto-detects USB to pick the default strategy, auto-selects the slot matching the file name, one-time SAF folder grant, clear per-phase UI with accessible semantics.
- No HTTP strategies (3 & 4 in `plan.md`) — there is no native counterpart, so they're intentionally out of scope here.

## Verification

Run on Flutter `3.44.1` / Dart `3.12.1`:

- `flutter analyze` → **No issues found!**
- `flutter test` → **All tests passed!** (`App launches`)

> Note: not a full `flutter build apk` yet (needs Android licenses accepted in the build env). The `build.sh` Docker path remains the canonical APK build.

Assisted-by: Claude (opencode)
