### PR TITLE
fix(backend): replace remaining hardcoded /tmp paths with tempfile

### DIFF
--- a/src/backend/app/gcp/gcp_routes.py
+++ b/src/backend/app/gcp/gcp_routes.py
@@ -1,3 +1,4 @@
+import tempfile
 import uuid
 from typing import Annotated, List
 
@@ -57,12 +58,12 @@ async def save_gcp_file(
     The file is stored at `projects/{project_id}/gcp.txt` in S3
     and will be automatically included when final processing is triggered.
     """
-    gcp_file_path = f"/tmp/{uuid.uuid4()}"
-    with open(gcp_file_path, "wb") as f:
-        f.write(await gcp_file.read())
+    with tempfile.NamedTemporaryFile(suffix=".txt") as gcp_file_tmp:
+        gcp_file_tmp.write(await gcp_file.read())
+        gcp_file_tmp.flush()
 
-    s3_path = f"projects/{project.id}/gcp.txt"
-    add_file_to_bucket(settings.S3_BUCKET_NAME, gcp_file_path, s3_path)
+        s3_path = f"projects/{project.id}/gcp.txt"
+        add_file_to_bucket(settings.S3_BUCKET_NAME, gcp_file_tmp.name, s3_path)
     log.info(f"GCP file saved for project {project.id} by user {user_data.id}")
 
     return {"message": "GCP file saved successfully", "project_id": str(project.id)}

--- a/src/backend/app/jaxa/upload_dem.py
+++ b/src/backend/app/jaxa/upload_dem.py
@@ -8,6 +8,7 @@ bridging that CrawlerRunner required.
 import io
 import asyncio
 import os
+import tempfile
 from pathlib import Path
 
 from loguru import logger as log
@@ -188,7 +189,7 @@ async def download_and_upload_dem(
     )
 
     # Use project-specific directory to avoid conflicts in k8s
-    project_dir = Path(f"/tmp/tif_processing/{project_id}")
+    project_dir = Path(tempfile.gettempdir()) / "tif_processing" / str(project_id)
     project_dir.mkdir(parents=True, exist_ok=True)
     tif_file_path = str(project_dir / "merged.tif")
 

--- a/src/backend/app/projects/classification_routes.py
+++ b/src/backend/app/projects/classification_routes.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from datetime import datetime
 from typing import Annotated, Literal, Optional
 from uuid import UUID
@@ -931,7 +932,10 @@ async def download_reflight_plan(
         )
 
     flightplan_config = get_flightplan_output_config(flight_drone_type)
-    file_path = f"/tmp/reflight_{task_id}{flightplan_config['suffix']}"
+    file_path = os.path.join(
+        tempfile.gettempdir(),
+        f"reflight_{task_id}{flightplan_config['suffix']}",
+    )
 
     with open(file_path, "wb") as f:
         f.write(result["kmz_bytes"])

--- a/src/backend/app/projects/project_logic.py
+++ b/src/backend/app/projects/project_logic.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 import shutil
+import tempfile
 import uuid
 from datetime import datetime, timezone
 from io import BytesIO
@@ -675,7 +676,7 @@ async def process_task_metrics(db, tasks_data, project):
         }
 
         if project.is_terrain_follow:
-            dem_path = f"/tmp/{uuid.uuid4()}/dem.tif"
+            dem_path = os.path.join(tempfile.gettempdir(), str(uuid.uuid4()), "dem.tif")
             points = create_waypoint(**waypoint_params)
             try:
                 get_file_from_bucket(
@@ -683,7 +684,9 @@ async def process_task_metrics(db, tasks_data, project):
                     f"projects/{project.id}/dem.tif",
                     dem_path,
                 )
-                outfile_with_elevation = "/tmp/output_file_with_elevation.geojson"
+                outfile_with_elevation = os.path.join(
+                    tempfile.gettempdir(), "output_file_with_elevation.geojson"
+                )
                 add_elevation_from_dem(dem_path, points, outfile_with_elevation)
                 with open(outfile_with_elevation) as inpointsfile:
                     points_with_elevation = inpointsfile.read()
@@ -1451,11 +1454,10 @@ async def process_waypoints_and_waylines(
     count_data = {"waypoints": 0, "waylines": 0}
 
     if is_terrain_follow and dem:
-        temp_dir = f"/tmp/{uuid.uuid4()}"
+        temp_dir = tempfile.mkdtemp()
         dem_path = os.path.join(temp_dir, "dem.tif")
 
         try:
-            os.makedirs(temp_dir, exist_ok=True)
             # Read DEM content into memory and write to the file
             file_content = await dem.read()
             with open(dem_path, "wb") as file:

--- a/src/backend/app/waypoints/waypoint_routes.py
+++ b/src/backend/app/waypoints/waypoint_routes.py
@@ -276,7 +276,8 @@ async def generate_wmpl_kmz(
                 detail="DEM file should be in GeoTIFF format",
             )
 
-        dem_path = f"/tmp/{dem.filename}"
+        fd, dem_path = tempfile.mkstemp(suffix=".tif", prefix="dem_")
+        os.close(fd)
         with open(dem_path, "wb") as buffer:
             shutil.copyfileobj(dem.file, buffer)
 
@@ -312,7 +313,7 @@ async def generate_wmpl_kmz(
             gsd=gsd,
             flight_mode=flight_mode,
             dem=dem_path if dem else None,
-            outfile=f"/tmp/{uuid.uuid4()}",
+            outfile=os.path.join(tempfile.gettempdir(), str(uuid.uuid4())),
             take_off_point=take_off_point,
             drone_type=drone_type,
         )
@@ -329,7 +330,7 @@ async def generate_kmz_with_placemarks(
     task_id: uuid.UUID, data: waypoint_schemas.PlacemarksFeature
 ):
     try:
-        outfile = f"/tmp/{task_id}_flight_plan.kmz"
+        outfile = os.path.join(tempfile.gettempdir(), f"{task_id}_flight_plan.kmz")
 
         kmz_file = create_wpml(data.model_dump(), outfile)
         if not os.path.exists(kmz_file):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🧑‍💻 Refactor

## Related Issue

Follow-up to #775.

## Describe this PR

When #775 was closed, most of the `/tmp` work had already landed on `dev`, but a handful of hardcoded `/tmp/` paths were still left in the backend. @spwoodcock welcomed a smaller follow-up, so this clears the remaining ones.

Each path now resolves through the `tempfile` module instead of assuming a POSIX `/tmp`, matching the idioms already used elsewhere in the repo:

- `gcp/gcp_routes.py` - GCP upload now goes through a `tempfile.NamedTemporaryFile` (same pattern as `images/image_logic.py`). As a side effect the scratch file is also cleaned up after the S3 upload instead of being left behind.
- `jaxa/upload_dem.py` - DEM processing dir moved to `tempfile.gettempdir()`, keeping the existing per-project subdirectory so the k8s conflict-avoidance comment still holds.
- `projects/classification_routes.py` - reflight plan path via `tempfile.gettempdir()`; existing `background_tasks` cleanup is unchanged.
- `projects/project_logic.py` - three paths across the two terrain-follow blocks. `process_waypoints_and_waylines` now uses `tempfile.mkdtemp()` (which makes the redundant `os.makedirs` unnecessary); `process_task_metrics` keeps its existing behaviour, just portable.
- `waypoints/waypoint_routes.py` - the `generate_wmpl_kmz` and `generate_kmz_with_placemarks` endpoints. The uploaded DEM now lands in a `tempfile.mkstemp` file (matching the existing terrain-follow handler above it in the same file) rather than `f"/tmp/{dem.filename}"`, which also removes a path built straight from a user-supplied filename.

The `drone-flightplan` output writers (`dji.py`, `litchi.py`, etc.) still carry `/tmp/` *default* arguments, but those belong to the vendored package and are better handled in a dedicated upstream PR, so they are intentionally out of scope here.

## AI Tool Usage

- [ ] No AI tools were used
- [x] AI tools were used (complete below)

**If AI-assisted:**

- Tool(s) used: Claude Code
- What was generated: the initial edits replacing the hardcoded paths and this description draft.
- What you reviewed and changed: I located each remaining `/tmp` path, chose the matching tempfile idiom per call site, kept `process_task_metrics` behaviour-preserving rather than "fixing" a long-dormant code path I could not verify, confirmed the imports, and ran py_compile + ruff locally. I understand and stand behind every line.

## Alternative Approaches Considered

For the GCP upload I considered a like-for-like `mkstemp` swap, but the upload there never deleted its scratch file, so `NamedTemporaryFile` as a context manager is both portable and tidier. For `jaxa/upload_dem.py` I kept the stable per-project subdirectory rather than switching to a random `mkdtemp`, to preserve the documented k8s conflict-avoidance intent.

## Review Guide

Behaviour is unchanged except for the two noted side effects (GCP scratch file is now cleaned up; the DEM upload filename is no longer used to build a path). `python -m py_compile` and `ruff check` pass on the five touched files.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/hotosm/drone-tm/blob/dev/CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](https://docs.hotosm.org/code-of-conduct)
- [x] PR is focused and small
- [x] I understand all code in this PR and can answer questions about it
- [x] No secrets, credentials, or sensitive data are included
- [x] Commit messages are descriptive
