### PR TITLE
fix(transfer-util): field reliability fixes (controller guidance, USB permission)

### DIFF
--- a/src/transfer-util/android/app/src/main/kotlin/org/hotosm/dronetm_transfer/MtpTransferPlugin.kt
+++ b/src/transfer-util/android/app/src/main/kotlin/org/hotosm/dronetm_transfer/MtpTransferPlugin.kt
@@ -86,7 +86,10 @@ class MtpTransferPlugin : MethodChannel.MethodCallHandler {
             addAction(UsbManager.ACTION_USB_DEVICE_DETACHED)
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            activity.registerReceiver(usbReceiver, filter, Context.RECEIVER_NOT_EXPORTED)
+            // EXPORTED: on Android 14+ the USB permission result can be
+            // delivered as an external broadcast, so a NOT_EXPORTED receiver
+            // may never fire and the permission step would hang.
+            activity.registerReceiver(usbReceiver, filter, Context.RECEIVER_EXPORTED)
         } else {
             activity.registerReceiver(usbReceiver, filter)
         }

--- a/src/transfer-util/lib/services/mtp_transfer.dart
+++ b/src/transfer-util/lib/services/mtp_transfer.dart
@@ -21,8 +21,9 @@ class MtpTransferStrategy implements TransferStrategy {
 
   bool _opened = false;
 
-  /// How long to wait for the user to respond to the USB permission dialog.
-  static const _permissionTimeout = Duration(seconds: 90);
+  /// How long to wait for the user to respond to the USB permission dialog
+  /// before giving up so they can retry rather than stare at a spinner.
+  static const _permissionTimeout = Duration(seconds: 45);
 
   @override
   TransferMethod get method => TransferMethod.mtp;
@@ -49,9 +50,11 @@ class MtpTransferStrategy implements TransferStrategy {
       throw const TransferException(
         code: 'NO_DEVICE',
         message:
-            'No controller detected. Connect the DJI RC to your phone with a '
-            'USB cable and make sure the cable supports data (not just '
-            'charging).',
+            'No controller detected over USB. This transfers to a controller '
+            'that has its own screen (e.g. DJI RC 2) — connect it with a data '
+            'USB cable (charge-only cables won\'t work).\n\n'
+            'Using an RC-N2 that holds this phone? Then DJI Fly already runs on '
+            'this phone, so the mission is here — no transfer needed.',
         canFallbackToSaf: true,
       );
     }


### PR DESCRIPTION
## Reliability fixes for the transfer-util app

Two small, field-focused fixes on top of #823 (which restored the `lib/` layer + drone model selector). Targets `feat/file-transfer-util` so it can ride along with #793.

### 1. Clearer "no controller" guidance + shorter USB-permission timeout
- The `NO_DEVICE` message now explains this transfers to a **separate screen controller (e.g. DJI RC 2)** and tells RC-N2 users (phone-mounted) that the mission is already on their phone — no transfer needed. This avoids confusion in the field when no MTP device appears.
- USB permission wait dropped **90s → 45s** so a missed/denied permission prompt fails fast and the user can retry instead of staring at a spinner.

### 2. `RECEIVER_EXPORTED` for the USB permission receiver (Android 14+)
- On Android 14+ the USB permission result can be delivered as an external broadcast; a `RECEIVER_NOT_EXPORTED` receiver may never fire, hanging the connect step. Switched to `RECEIVER_EXPORTED`.

### Verification
`flutter analyze` clean and `flutter test` passing (Flutter 3.44.1 / Dart 3.12.1). A debug APK build is in progress for on-device testing.

> Still unverified on hardware — the two real unknowns remain (a) RC 2 vs RC-N2 controller type, and (b) whether MTP can write into `Android/data/dji.go.v5` on the controller.
