### PR TITLE
feat(transfer-util): field diagnostics for flightplan transfer

### DIFF
--- a/src/transfer-util/android/app/src/main/AndroidManifest.xml
+++ b/src/transfer-util/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,9 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 
+    <!-- Uploading queued diagnostic reports when connectivity returns -->
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:label="DroneTM Transfer"
         android:name="${applicationName}"
@@ -72,6 +75,17 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+
+        <!-- Shares diagnostic reports out of the app's cache via the share sheet -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
     <queries>

--- a/src/transfer-util/android/app/src/main/kotlin/org/hotosm/dronetm_transfer/DiagnosticsPlugin.kt
+++ b/src/transfer-util/android/app/src/main/kotlin/org/hotosm/dronetm_transfer/DiagnosticsPlugin.kt
@@ -1,0 +1,131 @@
+package org.hotosm.dronetm_transfer
+
+import android.app.Activity
+import android.content.ContentValues
+import android.content.Intent
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import android.util.Log
+import androidx.core.content.FileProvider
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import java.io.File
+
+/**
+ * Native side of diagnostic-report export.
+ *
+ * Writing to Downloads (MediaStore) and sharing via the system share sheet
+ * (FileProvider) are done natively because they need platform APIs. The Dart
+ * layer owns the other two return paths: clipboard (Flutter built-in) and the
+ * offline POST queue (dart:io). [getAppFilesDir] gives Dart a stable directory
+ * to persist that queue in.
+ */
+class DiagnosticsPlugin : MethodChannel.MethodCallHandler {
+
+    companion object {
+        private const val TAG = "Diagnostics"
+        private const val METHOD_CHANNEL = "org.hotosm.drone_tm/diag"
+    }
+
+    private lateinit var activity: Activity
+    private lateinit var methodChannel: MethodChannel
+
+    fun register(activity: Activity, flutterEngine: FlutterEngine) {
+        this.activity = activity
+        methodChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, METHOD_CHANNEL)
+        methodChannel.setMethodCallHandler(this)
+    }
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "getAppFilesDir" -> result.success(activity.filesDir.absolutePath)
+            "saveReportToDownloads" -> {
+                val fileName = call.argument<String>("fileName") ?: "dronetm-report.txt"
+                val content = call.argument<String>("content") ?: ""
+                saveToDownloads(fileName, content, result)
+            }
+            "shareReport" -> {
+                val fileName = call.argument<String>("fileName") ?: "dronetm-report.txt"
+                val content = call.argument<String>("content") ?: ""
+                shareReport(fileName, content, result)
+            }
+            else -> result.notImplemented()
+        }
+    }
+
+    /** Save to the public Downloads/DroneTM folder so it can be pulled off the phone later. */
+    private fun saveToDownloads(fileName: String, content: String, result: MethodChannel.Result) {
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                val resolver = activity.contentResolver
+                val values = ContentValues().apply {
+                    put(MediaStore.Downloads.DISPLAY_NAME, fileName)
+                    put(MediaStore.Downloads.MIME_TYPE, "text/plain")
+                    put(
+                        MediaStore.Downloads.RELATIVE_PATH,
+                        Environment.DIRECTORY_DOWNLOADS + "/DroneTM",
+                    )
+                    put(MediaStore.Downloads.IS_PENDING, 1)
+                }
+                val uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values)
+                    ?: return result.error("SAVE_FAILED", "Could not create a Downloads entry", null)
+                resolver.openOutputStream(uri)?.use { it.write(content.toByteArray()) }
+                values.clear()
+                values.put(MediaStore.Downloads.IS_PENDING, 0)
+                resolver.update(uri, values, null, null)
+                result.success(uri.toString())
+            } else {
+                // Pre-Q: writing to PUBLIC Downloads needs the WRITE_EXTERNAL_STORAGE
+                // runtime permission, which this app never requests — so it would
+                // silently fail. Use the app-specific external Downloads dir
+                // instead: no permission on any API level, and still retrievable
+                // over USB at Android/data/<pkg>/files/Download/DroneTM.
+                val base = activity.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)
+                    ?: activity.filesDir
+                val dir = File(base, "DroneTM")
+                if (!dir.exists()) dir.mkdirs()
+                val file = File(dir, fileName)
+                file.writeText(content)
+                result.success(file.absolutePath)
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "saveToDownloads failed", e)
+            result.error("SAVE_FAILED", "Could not save report: ${e.message}", null)
+        }
+    }
+
+    /** Write the report to a FileProvider-shared cache file and fire the share sheet. */
+    private fun shareReport(fileName: String, content: String, result: MethodChannel.Result) {
+        try {
+            val dir = File(activity.cacheDir, "reports")
+            if (!dir.exists()) dir.mkdirs()
+            val file = File(dir, fileName)
+            file.writeText(content)
+
+            val uri = FileProvider.getUriForFile(
+                activity,
+                "${activity.packageName}.fileprovider",
+                file,
+            )
+            val send = Intent(Intent.ACTION_SEND).apply {
+                type = "text/plain"
+                putExtra(Intent.EXTRA_STREAM, uri)
+                putExtra(Intent.EXTRA_SUBJECT, fileName)
+                // Also attach the text so chat/SMS apps that ignore the stream
+                // still receive the report body.
+                putExtra(Intent.EXTRA_TEXT, content)
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+            val chooser = Intent.createChooser(send, "Share diagnostic report").apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            activity.startActivity(chooser)
+            result.success(true)
+        } catch (e: Exception) {
+            Log.e(TAG, "shareReport failed", e)
+            result.error("SHARE_FAILED", "Could not share report: ${e.message}", null)
+        }
+    }
+}

--- a/src/transfer-util/android/app/src/main/kotlin/org/hotosm/dronetm_transfer/MainActivity.kt
+++ b/src/transfer-util/android/app/src/main/kotlin/org/hotosm/dronetm_transfer/MainActivity.kt
@@ -11,6 +11,7 @@ class MainActivity : FlutterActivity() {
 
     private lateinit var mtpPlugin: MtpTransferPlugin
     private lateinit var safPlugin: SafTransferPlugin
+    private lateinit var diagPlugin: DiagnosticsPlugin
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
@@ -18,6 +19,8 @@ class MainActivity : FlutterActivity() {
         mtpPlugin.register(this, flutterEngine)
         safPlugin = SafTransferPlugin()
         safPlugin.register(this, flutterEngine)
+        diagPlugin = DiagnosticsPlugin()
+        diagPlugin.register(this, flutterEngine)
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/src/transfer-util/android/app/src/main/kotlin/org/hotosm/dronetm_transfer/MtpTransferPlugin.kt
+++ b/src/transfer-util/android/app/src/main/kotlin/org/hotosm/dronetm_transfer/MtpTransferPlugin.kt
@@ -6,6 +6,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.PackageManager
 import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbManager
 import android.mtp.MtpConstants
@@ -15,6 +16,8 @@ import android.os.Build
 import android.os.ParcelFileDescriptor
 import android.util.Log
 import java.io.File
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodCall
@@ -31,6 +34,9 @@ class MtpTransferPlugin : MethodChannel.MethodCallHandler {
         // DJI vendor ID
         private const val DJI_VENDOR_ID = 11427
 
+        // MTP "no parent" / storage-root handle (0xFFFFFFFF as a signed Int).
+        private const val MTP_ROOT_HANDLE = -1
+
         // DJI waypoint path segments
         private val DJI_PATH_SEGMENTS = listOf("Android", "data", "dji.go.v5", "files", "waypoint")
     }
@@ -40,6 +46,10 @@ class MtpTransferPlugin : MethodChannel.MethodCallHandler {
     private lateinit var eventChannel: EventChannel
     private var eventSink: EventChannel.EventSink? = null
     private var currentMtpDevice: MtpDevice? = null
+
+    // Serializes the heavy diagnostic tree walk off the platform thread so it
+    // can never block the UI / trigger an ANR.
+    private val mtpExecutor: ExecutorService = Executors.newSingleThreadExecutor()
 
     private val usbReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
@@ -117,6 +127,9 @@ class MtpTransferPlugin : MethodChannel.MethodCallHandler {
                 result.success(true)
             }
             "getDeviceStatus" -> getDeviceStatus(result)
+            "getEnvironment" -> getEnvironment(result)
+            "dumpUsbDevices" -> dumpUsbDevices(result)
+            "dumpMtpTree" -> dumpMtpTree(call, result)
             "readContentUri" -> {
                 val uri = call.argument<String>("uri") ?: return result.error("INVALID_ARGS", "uri required", null)
                 readContentUri(uri, result)
@@ -262,7 +275,12 @@ class MtpTransferPlugin : MethodChannel.MethodCallHandler {
         try {
             val waypointHandle = navigateToWaypointDir(device)
             if (waypointHandle == null) {
-                result.error("DIR_NOT_FOUND", "DJI waypoint directory not found on device", null)
+                val ctx = describeDjiPath(device)
+                result.error(
+                    "DIR_NOT_FOUND",
+                    "DJI waypoint directory not found (missing: ${ctx["missingSegment"]})",
+                    ctx,
+                )
                 return
             }
 
@@ -335,6 +353,263 @@ class MtpTransferPlugin : MethodChannel.MethodCallHandler {
         result.success(mapOf(
             "isConnected" to (currentMtpDevice != null)
         ))
+    }
+
+    // ---- Diagnostics capture ---------------------------------------------
+    // Read-only inspection of the phone, the USB bus, and the connected MTP
+    // responder. These exist so a field failure produces an actionable report
+    // (which step broke and why) instead of a generic error code.
+
+    /** Phone + app facts that frame every report. */
+    private fun getEnvironment(result: MethodChannel.Result) {
+        val pm = activity.packageManager
+        val hasUsbHost = pm.hasSystemFeature(PackageManager.FEATURE_USB_HOST)
+        val pkg = try {
+            pm.getPackageInfo(activity.packageName, 0)
+        } catch (e: Exception) {
+            null
+        }
+        val build = if (pkg == null) {
+            -1L
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            pkg.longVersionCode
+        } else {
+            @Suppress("DEPRECATION")
+            pkg.versionCode.toLong()
+        }
+        result.success(mapOf(
+            "manufacturer" to Build.MANUFACTURER,
+            "brand" to Build.BRAND,
+            "model" to Build.MODEL,
+            "device" to Build.DEVICE,
+            "androidSdk" to Build.VERSION.SDK_INT,
+            "androidRelease" to Build.VERSION.RELEASE,
+            "hasUsbHostFeature" to hasUsbHost,
+            "appVersion" to (pkg?.versionName ?: "unknown"),
+            "appBuild" to build,
+            "abi" to (Build.SUPPORTED_ABIS.firstOrNull() ?: "unknown"),
+        ))
+    }
+
+    /**
+     * Every USB device the phone currently enumerates, UNFILTERED, with full
+     * interface detail. This is the highest-value diagnostic: if the RC2 shows
+     * up with an unexpected product id or behind a non-class-6 interface, the
+     * normal device filter silently drops it and "no controller detected"
+     * becomes indistinguishable from "nothing plugged in".
+     */
+    private fun dumpUsbDevices(result: MethodChannel.Result) {
+        val usbManager = activity.getSystemService(Context.USB_SERVICE) as UsbManager
+        val devices = usbManager.deviceList.values.map { device ->
+            val interfaces = (0 until device.interfaceCount).map { i ->
+                val iface = device.getInterface(i)
+                mapOf(
+                    "id" to iface.id,
+                    "interfaceClass" to iface.interfaceClass,
+                    "subclass" to iface.interfaceSubclass,
+                    "protocol" to iface.interfaceProtocol,
+                    "endpointCount" to iface.endpointCount,
+                )
+            }
+            val serial = try {
+                device.serialNumber
+            } catch (e: SecurityException) {
+                null
+            }
+            mapOf(
+                "deviceName" to device.deviceName,
+                "vendorId" to device.vendorId,
+                "productId" to device.productId,
+                "deviceClass" to device.deviceClass,
+                "deviceSubclass" to device.deviceSubclass,
+                "deviceProtocol" to device.deviceProtocol,
+                "manufacturerName" to (device.manufacturerName ?: ""),
+                "productName" to (device.productName ?: ""),
+                "serialNumber" to (serial ?: ""),
+                "interfaceCount" to device.interfaceCount,
+                "hasPermission" to usbManager.hasPermission(device),
+                "isDji" to (device.vendorId == DJI_VENDOR_ID),
+                "looksMtp" to isMtpDevice(device),
+                "interfaces" to interfaces,
+            )
+        }
+        result.success(devices)
+    }
+
+    /**
+     * Inspect the connected MTP responder: its identity, storage volumes, the
+     * exact DJI-path traversal result, and a shallow object-tree sample. Needs
+     * an already-opened device (call openDevice first).
+     */
+    private fun dumpMtpTree(call: MethodCall, result: MethodChannel.Result) {
+        val device = currentMtpDevice
+        if (device == null) {
+            result.error("NOT_CONNECTED", "No MTP device connected", null)
+            return
+        }
+        val maxDepth = call.argument<Int>("maxDepth") ?: 2
+        val maxChildren = call.argument<Int>("maxChildren") ?: 40
+        // The tree walk is up to a few hundred synchronous USB round-trips; run
+        // it on the dedicated worker so it never blocks the platform thread, then
+        // post the channel reply back on the main thread (results must be
+        // delivered there).
+        mtpExecutor.execute {
+            try {
+                val payload = buildMtpTree(device, maxDepth, maxChildren)
+                activity.runOnUiThread { result.success(payload) }
+            } catch (e: Exception) {
+                Log.e(TAG, "dumpMtpTree failed", e)
+                activity.runOnUiThread {
+                    result.error("MTP_ERROR", "Tree dump failed: ${e.message}", null)
+                }
+            }
+        }
+    }
+
+    private fun buildMtpTree(device: MtpDevice, maxDepth: Int, maxChildren: Int): Map<String, Any?> {
+        val storageIds = device.storageIds?.toList() ?: emptyList()
+        val storages = storageIds.map { sid ->
+            val info = device.getStorageInfo(sid)
+            mapOf(
+                "id" to sid,
+                "description" to (info?.description ?: ""),
+                "volumeIdentifier" to (info?.volumeIdentifier ?: ""),
+                "freeSpaceBytes" to (info?.freeSpace ?: -1L),
+                "maxCapacityBytes" to (info?.maxCapacity ?: -1L),
+            )
+        }
+        val di = device.deviceInfo
+        val deviceInfo = mapOf(
+            "manufacturer" to (di?.manufacturer ?: ""),
+            "model" to (di?.model ?: ""),
+            "serialNumber" to (di?.serialNumber ?: ""),
+            "version" to (di?.version ?: ""),
+        )
+        val djiPath = describeDjiPath(device)
+        val firstStorage = storageIds.firstOrNull()
+        val tree = if (firstStorage != null) {
+            val budget = intArrayOf(400)
+            walkTree(device, firstStorage, MTP_ROOT_HANDLE, maxDepth, maxChildren, "(root)", budget)
+        } else {
+            null
+        }
+        return mapOf(
+            "storageCount" to storageIds.size,
+            "storages" to storages,
+            "deviceInfo" to deviceInfo,
+            "djiPath" to djiPath,
+            "tree" to tree,
+        )
+    }
+
+    /**
+     * Walk the DJI waypoint path segment by segment and report exactly how far
+     * it got: the deepest segment that resolved, the first missing one, and the
+     * sibling names present where it stopped. When the full path resolves, the
+     * existing UUID slots are returned instead.
+     */
+    private fun describeDjiPath(device: MtpDevice): Map<String, Any?> {
+        val storageId = device.storageIds?.firstOrNull()
+            ?: return mapOf(
+                "reachedDepth" to 0,
+                "deepestSegment" to null,
+                "missingSegment" to DJI_PATH_SEGMENTS.first(),
+                "childrenAtFailure" to emptyList<String>(),
+                "note" to "no storage exposed",
+            )
+        var currentParent = MTP_ROOT_HANDLE
+        var depth = 0
+        var deepest: String? = null
+        for (segment in DJI_PATH_SEGMENTS) {
+            val handle = findChildByName(device, storageId, currentParent, segment)
+            if (handle == null) {
+                return mapOf(
+                    "reachedDepth" to depth,
+                    "deepestSegment" to deepest,
+                    "missingSegment" to segment,
+                    "childrenAtFailure" to childNames(device, storageId, currentParent),
+                )
+            }
+            currentParent = handle
+            deepest = segment
+            depth++
+        }
+        return mapOf(
+            "reachedDepth" to depth,
+            "deepestSegment" to deepest,
+            "missingSegment" to null,
+            "childrenAtFailure" to emptyList<String>(),
+            "waypointSlots" to childNames(device, storageId, currentParent),
+        )
+    }
+
+    /** Names of the immediate children of [parent]. */
+    private fun childNames(device: MtpDevice, storageId: Int, parent: Int): List<String> {
+        val handles = device.getObjectHandles(storageId, 0, parent) ?: return emptyList()
+        val names = mutableListOf<String>()
+        for (handle in handles) {
+            val name = device.getObjectInfo(handle)?.name
+            if (name != null) names.add(name)
+        }
+        return names
+    }
+
+    /**
+     * Bounded recursive sample of the object tree. Depth- and width-limited and
+     * capped by a shared node [budget] so a controller full of media never turns
+     * a diagnostic scan into thousands of slow USB round-trips.
+     */
+    private fun walkTree(
+        device: MtpDevice,
+        storageId: Int,
+        parent: Int,
+        depthRemaining: Int,
+        maxChildren: Int,
+        name: String,
+        budget: IntArray,
+    ): Map<String, Any?> {
+        val node = linkedMapOf<String, Any?>("name" to name, "isDir" to true)
+        if (depthRemaining <= 0) {
+            node["truncated"] = true
+            return node
+        }
+        val handles = device.getObjectHandles(storageId, 0, parent)
+        if (handles == null || handles.isEmpty()) {
+            node["children"] = emptyList<Map<String, Any?>>()
+            return node
+        }
+        val children = mutableListOf<Map<String, Any?>>()
+        var count = 0
+        for (handle in handles) {
+            if (count >= maxChildren) {
+                node["childrenTruncated"] = handles.size - count
+                break
+            }
+            if (budget[0] <= 0) {
+                node["budgetExhausted"] = true
+                break
+            }
+            budget[0]--
+            val info = device.getObjectInfo(handle) ?: continue
+            val childName = info.name ?: "?"
+            if (info.format == MtpConstants.FORMAT_ASSOCIATION) {
+                children.add(
+                    walkTree(device, storageId, handle, depthRemaining - 1, maxChildren, childName, budget),
+                )
+            } else {
+                children.add(mapOf(
+                    "name" to childName,
+                    // 64-bit accessor (API 24+, matches minSdk): getCompressedSize()
+                    // is a 32-bit int that wraps for files >= 2 GiB — exactly the
+                    // large DJI media we want an honest size for.
+                    "sizeBytes" to info.compressedSizeLong,
+                    "format" to info.format,
+                ))
+            }
+            count++
+        }
+        node["children"] = children
+        return node
     }
 
     /**
@@ -426,7 +701,7 @@ class MtpTransferPlugin : MethodChannel.MethodCallHandler {
      */
     private fun navigateToWaypointDir(device: MtpDevice): Int? {
         val storageId = device.storageIds?.firstOrNull() ?: return null
-        var currentParent = 0xFFFFFFFF.toInt() // MTP root handle
+        var currentParent = MTP_ROOT_HANDLE // MTP root handle
 
         for (segment in DJI_PATH_SEGMENTS) {
             val handle = findChildByName(device, storageId, currentParent, segment)

--- a/src/transfer-util/android/app/src/main/res/xml/file_paths.xml
+++ b/src/transfer-util/android/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <!-- Diagnostic reports written by DiagnosticsPlugin.shareReport() -->
+    <cache-path name="reports" path="reports/" />
+</paths>

--- a/src/transfer-util/android/gradle.properties
+++ b/src/transfer-util/android/gradle.properties
@@ -1,2 +1,6 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/src/transfer-util/docs/plans/2026-06-08-mtp-transfer-diagnostics-design.md
+++ b/src/transfer-util/docs/plans/2026-06-08-mtp-transfer-diagnostics-design.md
@@ -1,0 +1,127 @@
+# Field Diagnostics for the DroneTM Transfer App — Design
+
+Date: 2026-06-08
+Status: Accepted (implementation in progress)
+App: `src/transfer-util/` (Flutter, branch `transfer-util-lib`)
+
+## Problem
+
+Flight-plan transfer is DroneTM's #1 field issue. The manual QField + file-manager
+workaround succeeds on only ~1/3 of phones, and the new `MtpTransferPlugin`-based
+transfer app is essentially **untested on real hardware** (a DJI RC2 + Mini 5 Pro is
+now available for testing).
+
+When a transfer fails in the field, the app surfaces a single generic error
+(`NO_DEVICE`, `NO_PERMISSION`, `MTP_OPEN_FAILED`, `DIR_NOT_FOUND`, `SEND_FAILED`, …)
+with **no field-collectable record of why**. Concretely, today we cannot tell apart:
+
+- _no controller plugged in_ vs _the RC2 enumerated with an unexpected PID/interface
+  class and our `getConnectedDevices` filter silently dropped it_ (both look like
+  `NO_DEVICE`);
+- _the user denied USB permission_ vs _the permission broadcast never arrived_ (the
+  Android-14 `RECEIVER_EXPORTED` class of hang — both look like a 45 s timeout →
+  `NO_PERMISSION`);
+- _which path segment_ of `Android/data/dji.go.v5/files/waypoint/<uuid>` was missing
+  when navigation failed (only `Log.d`'d — invisible without `adb`);
+- the controller's MTP identity / storage layout (the `MtpDeviceInfo` we fetch in
+  `openDevice` is currently discarded by the Dart layer).
+
+Without this, "1/3 phones" is unactionable. The fix is **instrumentation**, not a new
+transport: capture the raw USB/MTP facts and the per-step outcome, structure them, and
+make the report exportable **offline** so a field tester can send it back.
+
+## Goals
+
+1. Turn every failed (or successful) transfer attempt into a structured, exportable
+   report that pinpoints the failing step and the underlying device facts.
+2. Provide a one-tap **standalone diagnostic scan** that characterises any phone + RC2
+   combination **without needing a KMZ**.
+3. Work fully offline (rural deployment): capture now, export/send later.
+4. Add **zero new pub dependencies** (the app deliberately stays native-first; avoids a
+   fragile `pub get`). Use Flutter built-ins + native platform channels only.
+
+Non-goals: changing the transfer mechanism, NDK/libusb work, DJI-SDK integration,
+backend report ingestion (the client queues POSTs; the receiver is out of scope here).
+
+## Architecture
+
+Three layers, mirroring the app's existing `native ↔ channel ↔ strategy ↔ controller ↔ UI`.
+
+### 1. Native capture — `MtpTransferPlugin.kt` (method channel `org.hotosm.drone_tm/mtp`)
+
+New read-only inspection methods (co-located with the USB/MTP code that owns
+`UsbManager` and `currentMtpDevice`):
+
+- `getEnvironment()` → `{ manufacturer, model, device, androidSdk, androidRelease,
+hasUsbHostFeature, appVersion, appBuild, abi }`
+- `dumpUsbDevices()` → list of **every** USB device, unfiltered:
+  `{ deviceName, vendorId, productId, deviceClass, deviceSubclass, deviceProtocol,
+manufacturerName, productName, serialNumber?, hasPermission, isDji, looksMtp,
+interfaces: [{ id, interfaceClass, subclass, protocol, endpointCount }] }`
+- `dumpMtpTree({ maxDepth=6, maxChildren=60 })` → requires an open device:
+  `{ storages: [{ id, description, volumeIdentifier, freeSpaceBytes, maxCapacityBytes }],
+deviceInfo: { manufacturer, model, serialNumber, version },
+djiPath: { reachedDepth, deepestSegment, missingSegment, childrenAtFailure: [names] },
+tree: { name, format, isDir, sizeBytes, children: [...] } }` (tree bounded by
+  depth/children; always includes the DJI-path traversal result even when the full
+  walk is truncated).
+
+`navigateToWaypointDir` is refactored to return the traversal context (deepest segment
+reached, the missing segment, and the sibling names present where it stopped) so both
+`dumpMtpTree` and the `DIR_NOT_FOUND` error can report _where_ it broke.
+
+### 2. Native export — `DiagnosticsPlugin.kt` (method channel `org.hotosm.drone_tm/diag`)
+
+- `getAppFilesDir()` → `context.filesDir.absolutePath` (for the Dart POST queue).
+- `saveReportToDownloads({ fileName, content })` → writes via `MediaStore.Downloads`
+  (API 29+) / `WRITE_EXTERNAL_STORAGE` fallback; returns the saved path/URI.
+- `shareReport({ fileName, content })` → writes to cache, fires `ACTION_SEND` with a
+  `FileProvider` content URI (`text/plain`), returns `true` on launch.
+
+Manifest: add `INTERNET`, a `FileProvider` (authority `org.hotosm.drone_tm.fileprovider`)
+and `res/xml/file_paths.xml`.
+
+### 3. Dart — model, service, UI
+
+- `models/diagnostic_report.dart`: `DiagnosticReport` (env, usbDevices, mtpTree, steps,
+  summary, appContext, timestamp) + `DiagnosticStep` (`name, status[ok|fail|timeout|info],
+code?, detail?, durationMs?`). `toJson()` + `toText()` (human-readable) serialisers.
+- `services/diagnostics_service.dart`:
+  - `DiagnosticLog` — an always-on `ChangeNotifier` ring buffer of recent `DiagnosticStep`s,
+    written to from the transfer flow; survives screen navigation.
+  - `runFullScan()` — env → USB dump → (DJI/MTP present?) → permission → open → tree dump
+    → close, recording each step; returns a `DiagnosticReport`.
+  - `buildReport()` — assemble env + last USB dump + last tree + current step log.
+  - export: `share()`, `copyToClipboard()` (built-in `Clipboard`), `saveToDownloads()`,
+    `enqueuePost()` + `flushQueue()` (disk-backed queue under `getAppFilesDir()`, sent via
+    `dart:io HttpClient`; failures stay queued and are retried on next app start / scan).
+- `platform/diag_channel.dart`: typed wrappers for both channels.
+- `screens/diagnostics_screen.dart`: "Run full diagnostic scan" button, live step list
+  (colour-coded), and an Export bottom sheet offering Share / Copy / Save / (queue) Send.
+- Entry point: a `bug_report`/`troubleshoot` `IconButton` on `HomeScreen`'s `AppBar`;
+  `DiagnosticsService` provided alongside `TransferController` in `main.dart`.
+
+### Always-on logging hooks (minimal touches)
+
+- `MtpTransferStrategy`: record `prepare`/`listMissions`/`transfer` start+outcome+duration;
+  `_awaitPermissionDecision` distinguishes **granted / denied / timeout**.
+- `TransferController`: record phase transitions and `_fail` (code + technical).
+- `openDevice` result (`MtpDeviceInfo`) is captured into the log instead of being dropped.
+
+## Report return paths (all selected; offline-first)
+
+Capture writes to disk first; sending is best-effort and deferred:
+
+1. **Share sheet** (native) — primary; send via WhatsApp/Telegram/email when signal returns.
+2. **Copy to clipboard** (built-in) — paste into chat.
+3. **Save to Downloads/DroneTM** (native MediaStore) — retrieve off the phone later.
+4. **Auto-POST when online** — `dart:io HttpClient` to a configurable endpoint; queued on
+   disk and flushed on success. No-op until an endpoint is configured / a receiver exists.
+
+## Verification
+
+- `flutter analyze` clean; `flutter build apk --debug` succeeds.
+- Adversarial multi-dimension review (Kotlin/MTP-API correctness, Dart correctness,
+  manifest/FileProvider, offline queue) before flashing to hardware.
+- Field: install on the test phones, run the scan against the RC2, export a report, and
+  confirm it pinpoints the step/cause on phones where transfer fails.

--- a/src/transfer-util/lib/main.dart
+++ b/src/transfer-util/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'screens/home_screen.dart';
+import 'services/diagnostics_service.dart';
 import 'state/transfer_controller.dart';
 import 'theme.dart';
 
@@ -9,16 +10,25 @@ void main() {
   runApp(const DroneTMTransferApp());
 }
 
-/// Root widget. Owns the single [TransferController] for the whole app.
+/// Root widget. Owns the [TransferController] and the [DiagnosticsService] for
+/// the whole app.
 class DroneTMTransferApp extends StatelessWidget {
   const DroneTMTransferApp({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider<TransferController>(
-      // Build the controller and start listening for launch intents / events
-      // after the first frame, so a missing plugin can never block startup.
-      create: (_) => TransferController()..init(),
+    return MultiProvider(
+      // Both are built and started after the first frame, so a missing plugin
+      // (e.g. in tests) can never block startup.
+      providers: [
+        ChangeNotifierProvider<TransferController>(
+          create: (_) => TransferController()..init(),
+        ),
+        ChangeNotifierProvider<DiagnosticsService>(
+          // init() loads any saved upload endpoint and flushes queued reports.
+          create: (_) => DiagnosticsService()..init(),
+        ),
+      ],
       child: MaterialApp(
         title: 'DroneTM Transfer',
         debugShowCheckedModeBanner: false,

--- a/src/transfer-util/lib/models/diagnostic_report.dart
+++ b/src/transfer-util/lib/models/diagnostic_report.dart
@@ -1,0 +1,237 @@
+/// Structured, exportable record of a transfer attempt or a standalone scan.
+///
+/// The whole point of these types is to turn a field failure into something a
+/// maintainer can act on remotely: which step broke, and the raw USB/MTP facts
+/// underneath it. A report serialises to both JSON (machine) and plain text
+/// (paste into a chat).
+library;
+
+/// Outcome of a single diagnostic step.
+enum DiagStatus { ok, fail, timeout, info, running }
+
+extension DiagStatusGlyph on DiagStatus {
+  String get glyph => switch (this) {
+        DiagStatus.ok => 'OK ',
+        DiagStatus.fail => 'FAIL',
+        DiagStatus.timeout => 'TIME',
+        DiagStatus.info => 'INFO',
+        DiagStatus.running => '... ',
+      };
+
+  String get label => switch (this) {
+        DiagStatus.ok => 'ok',
+        DiagStatus.fail => 'fail',
+        DiagStatus.timeout => 'timeout',
+        DiagStatus.info => 'info',
+        DiagStatus.running => 'running',
+      };
+}
+
+/// One step in a flow (e.g. "open device", "request permission", "send object")
+/// with its outcome and any error/code detail.
+class DiagnosticStep {
+  DiagnosticStep({
+    required this.name,
+    required this.status,
+    this.code,
+    this.detail,
+    this.durationMs,
+    DateTime? at,
+  }) : at = at ?? DateTime.now();
+
+  final String name;
+  final DiagStatus status;
+
+  /// Stable machine code where there is one (mirrors the native error codes).
+  final String? code;
+
+  /// Free-text detail: the native `technical` string, structured context, etc.
+  final String? detail;
+
+  /// Wall-clock duration of the step, when measured.
+  final int? durationMs;
+
+  /// When the step finished (or started, for `running`).
+  final DateTime at;
+
+  DiagnosticStep copyWith({
+    DiagStatus? status,
+    String? code,
+    String? detail,
+    int? durationMs,
+  }) =>
+      DiagnosticStep(
+        name: name,
+        status: status ?? this.status,
+        code: code ?? this.code,
+        detail: detail ?? this.detail,
+        durationMs: durationMs ?? this.durationMs,
+        at: at,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        'status': status.label,
+        if (code != null) 'code': code,
+        if (detail != null) 'detail': detail,
+        if (durationMs != null) 'durationMs': durationMs,
+        'at': at.toIso8601String(),
+      };
+
+  String toLine() {
+    final dur = durationMs != null ? ' (${durationMs}ms)' : '';
+    final codePart = code != null ? ' [$code]' : '';
+    final detailPart = detail != null && detail!.isNotEmpty ? '\n      $detail' : '';
+    return '${status.glyph}  $name$codePart$dur$detailPart';
+  }
+}
+
+/// A full diagnostic report: the phone/app context, the raw USB enumeration,
+/// the MTP responder inspection, and the step-by-step log.
+class DiagnosticReport {
+  DiagnosticReport({
+    required this.kind,
+    required this.environment,
+    required this.usbDevices,
+    required this.mtpTree,
+    required this.steps,
+    required this.summary,
+    DateTime? createdAt,
+  }) : createdAt = createdAt ?? DateTime.now();
+
+  /// 'scan' for a standalone diagnostic scan, 'attempt' for a real transfer.
+  final String kind;
+
+  /// `getEnvironment()` map (phone make/model, Android SDK, USB-host feature…).
+  final Map<String, dynamic> environment;
+
+  /// `dumpUsbDevices()` — every USB device, unfiltered.
+  final List<Map<String, dynamic>> usbDevices;
+
+  /// `dumpMtpTree()` map, or null when no device was opened.
+  final Map<String, dynamic>? mtpTree;
+
+  final List<DiagnosticStep> steps;
+
+  /// One-line verdict computed by the service.
+  final String summary;
+
+  final DateTime createdAt;
+
+  String get fileName {
+    final model = (environment['model'] as String?)?.replaceAll(RegExp(r'\s+'), '-') ?? 'phone';
+    final ts = createdAt
+        .toIso8601String()
+        .replaceAll(':', '')
+        .replaceAll('.', '-')
+        .split('T')
+        .join('_');
+    return 'dronetm-$kind-$model-$ts.txt';
+  }
+
+  Map<String, dynamic> toJson() => {
+        'kind': kind,
+        'createdAt': createdAt.toIso8601String(),
+        'summary': summary,
+        'environment': environment,
+        'usbDevices': usbDevices,
+        'mtpTree': mtpTree,
+        'steps': steps.map((s) => s.toJson()).toList(),
+      };
+
+  /// Human-readable report a tester can paste straight into a chat.
+  String toText() {
+    final b = StringBuffer();
+    b.writeln('=== DroneTM Transfer — diagnostic report ===');
+    b.writeln('kind:    $kind');
+    b.writeln('time:    ${createdAt.toIso8601String()}');
+    b.writeln('verdict: $summary');
+    b.writeln();
+
+    b.writeln('--- Environment ---');
+    _writeEnv(b);
+    b.writeln();
+
+    b.writeln('--- USB devices (${usbDevices.length}) ---');
+    if (usbDevices.isEmpty) {
+      b.writeln('(none enumerated — no OTG/USB-host, a charge-only cable, or the '
+          'controller is not in a USB data mode)');
+    } else {
+      for (final d in usbDevices) {
+        _writeUsbDevice(b, d);
+      }
+    }
+    b.writeln();
+
+    b.writeln('--- MTP responder ---');
+    _writeMtp(b);
+    b.writeln();
+
+    b.writeln('--- Steps ---');
+    if (steps.isEmpty) {
+      b.writeln('(no steps recorded)');
+    } else {
+      for (final s in steps) {
+        b.writeln(s.toLine());
+      }
+    }
+    return b.toString();
+  }
+
+  void _writeEnv(StringBuffer b) {
+    String e(String k) => '${environment[k] ?? '?'}';
+    b.writeln('phone:   ${e('manufacturer')} ${e('model')} (${e('device')})');
+    b.writeln('android: ${e('androidRelease')} (SDK ${e('androidSdk')}), abi ${e('abi')}');
+    b.writeln('usbHost: ${environment['hasUsbHostFeature'] == true ? 'yes' : 'NO (cannot act as USB host!)'}');
+    b.writeln('app:     ${e('appVersion')}+${e('appBuild')}');
+  }
+
+  void _writeUsbDevice(StringBuffer b, Map<String, dynamic> d) {
+    final vid = d['vendorId'];
+    final pid = d['productId'];
+    final tags = <String>[
+      if (d['isDji'] == true) 'DJI',
+      if (d['looksMtp'] == true) 'MTP-class',
+      if (d['hasPermission'] == true) 'permitted' else 'no-perm',
+    ];
+    b.writeln('• ${d['productName'] ?? d['deviceName'] ?? '?'}  '
+        'vid=$vid pid=$pid  '
+        'class=${d['deviceClass']}  [${tags.join(', ')}]');
+    final ifaces = (d['interfaces'] as List?) ?? const [];
+    for (final i in ifaces) {
+      final m = i as Map;
+      b.writeln('    iface#${m['id']}: class=${m['interfaceClass']} '
+          'sub=${m['subclass']} proto=${m['protocol']} eps=${m['endpointCount']}');
+    }
+  }
+
+  void _writeMtp(StringBuffer b) {
+    final tree = mtpTree;
+    if (tree == null) {
+      b.writeln('(device not opened — see steps above for why)');
+      return;
+    }
+    final info = (tree['deviceInfo'] as Map?) ?? const {};
+    b.writeln('device:  ${info['manufacturer'] ?? '?'} ${info['model'] ?? ''} '
+        'serial=${info['serialNumber'] ?? '?'}');
+    final storages = (tree['storages'] as List?) ?? const [];
+    b.writeln('storage: ${tree['storageCount'] ?? storages.length} volume(s)');
+    for (final s in storages) {
+      final m = s as Map;
+      b.writeln('    id=${m['id']} "${m['description']}" '
+          'free=${m['freeSpaceBytes']} cap=${m['maxCapacityBytes']}');
+    }
+    final dji = (tree['djiPath'] as Map?) ?? const {};
+    final missing = dji['missingSegment'];
+    if (missing == null) {
+      final slots = (dji['waypointSlots'] as List?) ?? const [];
+      b.writeln('djiPath: reached waypoint/ — ${slots.length} mission slot(s)');
+      if (slots.isNotEmpty) b.writeln('    slots: ${slots.join(', ')}');
+    } else {
+      final children = (dji['childrenAtFailure'] as List?) ?? const [];
+      b.writeln('djiPath: STOPPED at "${dji['deepestSegment'] ?? '(root)'}" — '
+          'missing "$missing" (depth ${dji['reachedDepth']})');
+      b.writeln('    present here: ${children.isEmpty ? '(empty)' : children.join(', ')}');
+    }
+  }
+}

--- a/src/transfer-util/lib/platform/diag_channel.dart
+++ b/src/transfer-util/lib/platform/diag_channel.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/services.dart';
+
+/// Thin wrapper over the native `org.hotosm.drone_tm/diag` channel for the
+/// report-export paths that need platform APIs: a stable files dir for the POST
+/// queue, saving into Downloads (MediaStore), and the system share sheet
+/// (FileProvider). Clipboard and the HTTP POST itself are done in Dart.
+class DiagChannel {
+  DiagChannel() : _method = const MethodChannel('org.hotosm.drone_tm/diag');
+
+  final MethodChannel _method;
+
+  /// Absolute path to the app's private files dir (for the offline POST queue).
+  Future<String?> getAppFilesDir() =>
+      _method.invokeMethod<String>('getAppFilesDir');
+
+  /// Saves [content] to `Downloads/DroneTM/[fileName]`; returns the saved
+  /// path/URI on success.
+  Future<String?> saveReportToDownloads(String fileName, String content) =>
+      _method.invokeMethod<String>('saveReportToDownloads', {
+        'fileName': fileName,
+        'content': content,
+      });
+
+  /// Writes [content] to a shareable cache file and opens the system share
+  /// sheet. Returns `true` once the chooser is launched.
+  Future<bool> shareReport(String fileName, String content) async {
+    final ok = await _method.invokeMethod<bool>('shareReport', {
+      'fileName': fileName,
+      'content': content,
+    });
+    return ok ?? false;
+  }
+}

--- a/src/transfer-util/lib/platform/mtp_channel.dart
+++ b/src/transfer-util/lib/platform/mtp_channel.dart
@@ -169,4 +169,53 @@ class MtpChannel {
     final incoming = IncomingFile.fromMap(map);
     return incoming.isValid ? incoming : null;
   }
+
+  // ---- Diagnostics capture ----------------------------------------------
+
+  /// Phone + app facts (make/model, Android SDK, USB-host feature, app version).
+  Future<Map<String, dynamic>> getEnvironment() async {
+    final map = await _method.invokeMapMethod<dynamic, dynamic>('getEnvironment');
+    return coerceMap(map);
+  }
+
+  /// Every USB device the phone enumerates, UNFILTERED, with interface detail.
+  Future<List<Map<String, dynamic>>> dumpUsbDevices() async {
+    final raw = await _method.invokeListMethod<dynamic>('dumpUsbDevices');
+    if (raw == null) return const [];
+    return raw
+        .whereType<Map<dynamic, dynamic>>()
+        .map(coerceMap)
+        .toList(growable: false);
+  }
+
+  /// Inspect the open MTP responder: identity, storage, DJI-path traversal, and
+  /// a bounded object-tree sample. Requires [openDevice] to have succeeded.
+  Future<Map<String, dynamic>> dumpMtpTree({
+    int maxDepth = 2,
+    int maxChildren = 40,
+  }) async {
+    final map = await _method.invokeMapMethod<dynamic, dynamic>(
+      'dumpMtpTree',
+      {'maxDepth': maxDepth, 'maxChildren': maxChildren},
+    );
+    return coerceMap(map);
+  }
+}
+
+/// Platform channels hand back `Map<Object?, Object?>` / `List<Object?>` whose
+/// keys are Strings at runtime but not statically. Deep-convert so the result
+/// is a clean `Map<String, dynamic>` that `jsonEncode` and typed access accept.
+Map<String, dynamic> coerceMap(Map<dynamic, dynamic>? map) {
+  if (map == null) return <String, dynamic>{};
+  return map.map((key, value) => MapEntry('$key', _coerceValue(value)));
+}
+
+dynamic _coerceValue(dynamic value) {
+  if (value is Map) {
+    return value.map((k, v) => MapEntry('$k', _coerceValue(v)));
+  }
+  if (value is List) {
+    return value.map(_coerceValue).toList();
+  }
+  return value;
 }

--- a/src/transfer-util/lib/screens/diagnostics_screen.dart
+++ b/src/transfer-util/lib/screens/diagnostics_screen.dart
@@ -1,0 +1,377 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/diagnostic_report.dart';
+import '../services/diagnostics_service.dart';
+
+/// Field diagnostics: characterise this phone + controller in one tap, watch the
+/// step-by-step log, and export a report that pinpoints why a transfer fails.
+class DiagnosticsScreen extends StatefulWidget {
+  const DiagnosticsScreen({super.key});
+
+  @override
+  State<DiagnosticsScreen> createState() => _DiagnosticsScreenState();
+}
+
+class _DiagnosticsScreenState extends State<DiagnosticsScreen> {
+  DiagnosticReport? _report;
+  bool _exporting = false;
+
+  DiagnosticsService get _service => context.read<DiagnosticsService>();
+
+  Future<void> _runScan() async {
+    final report = await _service.runFullScan();
+    if (!mounted) return;
+    setState(() => _report = report);
+  }
+
+  /// The report to export: the last scan, or a freshly assembled session report
+  /// (which still includes environment + USB enumeration + the full step log).
+  Future<DiagnosticReport> _reportToExport() async =>
+      _report ?? await _service.buildSessionReport();
+
+  Future<void> _export(
+    String label,
+    Future<String?> Function(DiagnosticReport) action,
+  ) async {
+    setState(() => _exporting = true);
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      final report = await _reportToExport();
+      final result = await action(report);
+      if (!mounted) return;
+      setState(() => _report = report);
+      messenger.showSnackBar(SnackBar(content: Text(result ?? label)));
+    } catch (e) {
+      messenger.showSnackBar(SnackBar(content: Text('$label failed: $e')));
+    } finally {
+      if (mounted) setState(() => _exporting = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final service = context.watch<DiagnosticsService>();
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Diagnostics'),
+        actions: [
+          IconButton(
+            tooltip: 'Clear log',
+            onPressed: service.busy
+                ? null
+                : () {
+                    service.log.clear();
+                    setState(() => _report = null);
+                  },
+            icon: const Icon(Icons.delete_sweep_outlined),
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 620),
+            child: ListView(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+              children: [
+                Text(
+                  'Run a scan with the controller plugged in to capture exactly '
+                  'what this phone sees — USB enumeration, permission, MTP storage '
+                  'and the DJI waypoint path — then export the report.',
+                  style: theme.textTheme.bodyMedium
+                      ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+                ),
+                const SizedBox(height: 16),
+                FilledButton.icon(
+                  onPressed: service.busy ? null : _runScan,
+                  icon: service.busy
+                      ? const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.troubleshoot),
+                  label: Text(service.busy
+                      ? 'Scanning…'
+                      : 'Run full diagnostic scan'),
+                ),
+                if (_report != null) ...[
+                  const SizedBox(height: 16),
+                  _SummaryCard(report: _report!),
+                ],
+                const SizedBox(height: 20),
+                _ExportBar(
+                  busy: _exporting || service.busy,
+                  onShare: () =>
+                      _export('Shared', (r) async => (await _service.share(r)) ? 'Opened share sheet' : 'Share cancelled'),
+                  onCopy: () => _export('Copied to clipboard', (r) async {
+                    await _service.copyToClipboard(r);
+                    return 'Copied to clipboard';
+                  }),
+                  onSave: () => _export('Saved', (r) async {
+                    final path = await _service.saveToDownloads(r);
+                    return path != null ? 'Saved to Downloads/DroneTM' : 'Saved';
+                  }),
+                  onSend: () => _export('Queued for upload', (r) async {
+                    await _service.uploadWhenOnline(r);
+                    final pending = await _service.pendingUploads();
+                    return service.endpoint == null
+                        ? 'Queued ($pending pending) — set an endpoint to upload'
+                        : 'Queued/sent ($pending pending)';
+                  }),
+                ),
+                const SizedBox(height: 20),
+                Text('Log', style: theme.textTheme.titleMedium),
+                const SizedBox(height: 8),
+                _StepLog(log: service.log),
+                const SizedBox(height: 20),
+                _EndpointConfig(service: service),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SummaryCard extends StatelessWidget {
+  const _SummaryCard({required this.report});
+
+  final DiagnosticReport report;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: scheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.summarize, size: 20, color: scheme.onSurface),
+              const SizedBox(width: 10),
+              Text('Summary',
+                  style: theme.textTheme.titleSmall
+                      ?.copyWith(fontWeight: FontWeight.w700)),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(report.summary, style: theme.textTheme.bodyMedium),
+        ],
+      ),
+    );
+  }
+}
+
+class _ExportBar extends StatelessWidget {
+  const _ExportBar({
+    required this.busy,
+    required this.onShare,
+    required this.onCopy,
+    required this.onSave,
+    required this.onSend,
+  });
+
+  final bool busy;
+  final VoidCallback onShare;
+  final VoidCallback onCopy;
+  final VoidCallback onSave;
+  final VoidCallback onSend;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        OutlinedButton.icon(
+          onPressed: busy ? null : onShare,
+          icon: const Icon(Icons.ios_share),
+          label: const Text('Share'),
+        ),
+        OutlinedButton.icon(
+          onPressed: busy ? null : onCopy,
+          icon: const Icon(Icons.copy),
+          label: const Text('Copy'),
+        ),
+        OutlinedButton.icon(
+          onPressed: busy ? null : onSave,
+          icon: const Icon(Icons.download),
+          label: const Text('Save'),
+        ),
+        OutlinedButton.icon(
+          onPressed: busy ? null : onSend,
+          icon: const Icon(Icons.cloud_upload_outlined),
+          label: const Text('Send'),
+        ),
+      ],
+    );
+  }
+}
+
+class _StepLog extends StatelessWidget {
+  const _StepLog({required this.log});
+
+  final DiagnosticLog log;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: log,
+      builder: (context, _) {
+        final steps = log.steps;
+        if (steps.isEmpty) {
+          return Text(
+            'No steps yet. Run a scan, or attempt a transfer from the main '
+            'screen — every step is recorded here.',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+          );
+        }
+        return Container(
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.surfaceContainerHigh,
+            borderRadius: BorderRadius.circular(12),
+          ),
+          padding: const EdgeInsets.symmetric(vertical: 4),
+          child: Column(
+            children: [
+              for (final step in steps.reversed) _StepRow(step: step),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _StepRow extends StatelessWidget {
+  const _StepRow({required this.step});
+
+  final DiagnosticStep step;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final (color, icon) = switch (step.status) {
+      DiagStatus.ok => (Colors.green, Icons.check_circle),
+      DiagStatus.fail => (scheme.error, Icons.error),
+      DiagStatus.timeout => (Colors.orange, Icons.timer_off),
+      DiagStatus.info => (scheme.onSurfaceVariant, Icons.info_outline),
+      DiagStatus.running => (scheme.primary, Icons.more_horiz),
+    };
+    final dur = step.durationMs != null ? '  ${step.durationMs}ms' : '';
+    final code = step.code != null ? '  [${step.code}]' : '';
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, size: 16, color: color),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '${step.name}$code$dur',
+                  style: theme.textTheme.bodySmall
+                      ?.copyWith(fontWeight: FontWeight.w600),
+                ),
+                if (step.detail != null && step.detail!.isNotEmpty)
+                  Text(
+                    step.detail!,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: scheme.onSurfaceVariant,
+                      fontFamily: 'monospace',
+                      fontSize: 11.5,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EndpointConfig extends StatefulWidget {
+  const _EndpointConfig({required this.service});
+
+  final DiagnosticsService service;
+
+  @override
+  State<_EndpointConfig> createState() => _EndpointConfigState();
+}
+
+class _EndpointConfigState extends State<_EndpointConfig> {
+  late final TextEditingController _controller =
+      TextEditingController(text: widget.service.endpoint ?? '');
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Theme(
+      data: theme.copyWith(dividerColor: Colors.transparent),
+      child: ExpansionTile(
+        tilePadding: EdgeInsets.zero,
+        childrenPadding: const EdgeInsets.only(bottom: 8),
+        title: Text('Upload endpoint (optional)',
+            style: theme.textTheme.titleSmall),
+        subtitle: Text(
+          widget.service.endpoint == null
+              ? 'Not set — “Send” queues reports on disk until configured.'
+              : widget.service.endpoint!,
+          style: theme.textTheme.bodySmall
+              ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+        ),
+        children: [
+          TextField(
+            controller: _controller,
+            keyboardType: TextInputType.url,
+            decoration: const InputDecoration(
+              hintText: 'https://…/diagnostics',
+              border: OutlineInputBorder(),
+              isDense: true,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: FilledButton.tonal(
+              onPressed: () async {
+                await widget.service.setEndpoint(_controller.text);
+                if (!context.mounted) return;
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Endpoint saved')),
+                );
+              },
+              child: const Text('Save endpoint'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/src/transfer-util/lib/screens/home_screen.dart
+++ b/src/transfer-util/lib/screens/home_screen.dart
@@ -5,6 +5,7 @@ import '../services/transfer_strategy.dart';
 import '../state/transfer_controller.dart';
 import '../widgets/drone_model_bar.dart';
 import '../widgets/mission_selector.dart';
+import 'diagnostics_screen.dart';
 
 /// The single screen the whole app lives on. It renders one "step" per
 /// [TransferPhase], keeping the flow flat and obvious rather than spread across
@@ -20,6 +21,15 @@ class HomeScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('DroneTM Transfer'),
         actions: [
+          IconButton(
+            tooltip: 'Diagnostics',
+            onPressed: () => Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (_) => const DiagnosticsScreen(),
+              ),
+            ),
+            icon: const Icon(Icons.troubleshoot),
+          ),
           IconButton(
             tooltip: 'How it works',
             onPressed: () => _showHelp(context),

--- a/src/transfer-util/lib/services/diagnostics_service.dart
+++ b/src/transfer-util/lib/services/diagnostics_service.dart
@@ -1,0 +1,431 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+import '../models/diagnostic_report.dart';
+import '../platform/diag_channel.dart';
+import '../platform/mtp_channel.dart';
+
+/// Always-on, app-wide log of diagnostic steps.
+///
+/// The transfer flow and the standalone scan both write here, so an exported
+/// report carries the full recent history regardless of where a failure
+/// happened. It's a global singleton so the transfer strategy can record
+/// without threading a dependency through the whole app.
+class DiagnosticLog extends ChangeNotifier {
+  DiagnosticLog._();
+  static final DiagnosticLog instance = DiagnosticLog._();
+
+  static const _cap = 200;
+  final List<DiagnosticStep> _steps = [];
+  List<DiagnosticStep> get steps => List.unmodifiable(_steps);
+
+  // Most recent heavy captures (from a scan, or grabbed lazily at report time).
+  Map<String, dynamic>? lastEnvironment;
+  List<Map<String, dynamic>>? lastUsbDevices;
+  Map<String, dynamic>? lastMtpTree;
+
+  void record(DiagnosticStep step) {
+    _steps.add(step);
+    if (_steps.length > _cap) _steps.removeRange(0, _steps.length - _cap);
+    notifyListeners();
+  }
+
+  /// Record a finished step. Safe to call from anywhere in the transfer flow.
+  void mark(
+    String name,
+    DiagStatus status, {
+    String? code,
+    String? detail,
+    int? durationMs,
+  }) {
+    record(DiagnosticStep(
+      name: name,
+      status: status,
+      code: code,
+      detail: detail,
+      durationMs: durationMs,
+    ));
+  }
+
+  void clear() {
+    _steps.clear();
+    // Also drop the cached heavy captures, else a later export would reuse a
+    // stale environment/USB/MTP-tree alongside an empty step log.
+    lastEnvironment = null;
+    lastUsbDevices = null;
+    lastMtpTree = null;
+    notifyListeners();
+  }
+}
+
+/// Orchestrates the standalone diagnostic scan and the four report-export paths
+/// (share, clipboard, save-to-Downloads, offline POST queue). Watches its own
+/// `busy` state; the live step list lives in [DiagnosticLog].
+class DiagnosticsService extends ChangeNotifier {
+  DiagnosticsService({MtpChannel? mtp, DiagChannel? diag})
+      : _mtp = mtp ?? MtpChannel(),
+        _diag = diag ?? DiagChannel();
+
+  final MtpChannel _mtp;
+  final DiagChannel _diag;
+  final DiagnosticLog _log = DiagnosticLog.instance;
+
+  static const _permissionTimeout = Duration(seconds: 45);
+
+  bool _busy = false;
+  bool get busy => _busy;
+
+  String? _endpoint;
+  String? get endpoint => _endpoint;
+
+  DiagnosticLog get log => _log;
+
+  /// Load any persisted upload endpoint and try to flush queued reports. Call
+  /// once at startup. Best-effort: never throws.
+  Future<void> init() async {
+    try {
+      await _loadEndpoint();
+      await flushQueue();
+    } catch (_) {
+      // Diagnostics must never block app startup.
+    }
+  }
+
+  // ---- Standalone scan --------------------------------------------------
+
+  /// Probe the phone, the USB bus, and (if a controller is present) the MTP
+  /// responder, recording each step. Needs no KMZ, so any phone+controller combo
+  /// can be characterised in one tap. Returns the assembled report.
+  Future<DiagnosticReport> runFullScan() async {
+    _setBusy(true);
+    try {
+      _log.mark('— diagnostic scan started —', DiagStatus.info);
+
+      final env = await _timed('Read phone environment', _mtp.getEnvironment);
+      if (env != null) _log.lastEnvironment = env;
+
+      final usb = await _timed('Enumerate USB devices', _mtp.dumpUsbDevices);
+      if (usb != null) {
+        _log.lastUsbDevices = usb;
+        _log.mark('USB bus: ${usb.length} device(s)', DiagStatus.info,
+            detail: usb.isEmpty
+                ? null
+                : usb
+                    .map((d) =>
+                        'vid=${d['vendorId']} pid=${d['productId']}${d['isDji'] == true ? ' DJI' : ''}')
+                    .join('; '));
+      }
+
+      Map<String, dynamic>? tree;
+      final devices = await _safe(_mtp.getConnectedDevices) ?? const [];
+      if (devices.isEmpty) {
+        _log.mark('Find controller on USB', DiagStatus.fail,
+            code: 'NO_DEVICE',
+            detail: (usb == null || usb.isEmpty)
+                ? 'No USB devices enumerated at all — no OTG/USB-host support, a '
+                    'charge-only cable, or the controller is not in a USB data mode.'
+                : 'USB devices are present but none match a DJI/MTP controller. '
+                    'Check the product id against device_filter.xml.');
+      } else {
+        final target =
+            devices.firstWhere((d) => d.isDji, orElse: () => devices.first);
+        _log.mark('Find controller on USB', DiagStatus.ok,
+            detail:
+                '${target.name} (vid=${target.vendorId} pid=${target.productId})');
+
+        final granted = await _ensurePermission(target.name, target.hasPermission);
+        if (granted) {
+          final opened = await _timed(
+            'Open MTP session',
+            () => _mtp.openDevice(deviceName: target.name),
+          );
+          if (opened != null) {
+            final info = coerceMap(opened);
+            _log.mark('MTP device info', DiagStatus.info,
+                detail:
+                    'mfr=${info['manufacturer']} model=${info['model']} serial=${info['serialNumber']}');
+            tree = await _timed(
+                'Inspect MTP storage + DJI path', () => _mtp.dumpMtpTree());
+            if (tree != null) {
+              _log.lastMtpTree = tree;
+              _recordDjiPath(tree);
+            }
+            await _safe(_mtp.closeDevice);
+          }
+        }
+      }
+
+      _log.mark('— diagnostic scan finished —', DiagStatus.info);
+      return _assemble('scan', env ?? {}, usb ?? const [], tree);
+    } finally {
+      _setBusy(false);
+    }
+  }
+
+  /// Polls for the USB permission grant rather than using the event channel,
+  /// which the [TransferController] owns. Distinguishes grant from a timeout
+  /// (which on Android 14 can mean the permission broadcast never arrived).
+  Future<bool> _ensurePermission(String name, bool alreadyHas) async {
+    if (alreadyHas) {
+      _log.mark('USB permission', DiagStatus.ok, detail: 'already granted');
+      return true;
+    }
+    final granted = await _safe(() => _mtp.requestPermission(deviceName: name));
+    if (granted == true) {
+      _log.mark('USB permission', DiagStatus.ok, detail: 'already granted');
+      return true;
+    }
+    final sw = Stopwatch()..start();
+    while (sw.elapsed < _permissionTimeout) {
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      final devices = await _safe(_mtp.getConnectedDevices) ?? const [];
+      final match = devices.where((d) => d.name == name);
+      if (match.isNotEmpty && match.first.hasPermission) {
+        _log.mark('USB permission', DiagStatus.ok,
+            durationMs: sw.elapsedMilliseconds);
+        return true;
+      }
+    }
+    _log.mark('USB permission', DiagStatus.timeout,
+        code: 'NO_PERMISSION',
+        durationMs: sw.elapsedMilliseconds,
+        detail:
+            'No grant within 45s. Either the dialog was denied/dismissed, or the '
+            'permission broadcast never arrived (the Android 14 RECEIVER_EXPORTED '
+            'class of hang).');
+    return false;
+  }
+
+  void _recordDjiPath(Map<String, dynamic> tree) {
+    final dji = (tree['djiPath'] as Map?) ?? const {};
+    final missing = dji['missingSegment'];
+    if (missing == null) {
+      final slots = (dji['waypointSlots'] as List?) ?? const [];
+      _log.mark('DJI waypoint path', DiagStatus.ok,
+          detail: 'reached waypoint/ — ${slots.length} mission slot(s)');
+    } else {
+      final children = (dji['childrenAtFailure'] as List?) ?? const [];
+      _log.mark('DJI waypoint path', DiagStatus.fail,
+          code: 'DIR_NOT_FOUND',
+          detail:
+              'stopped at "${dji['deepestSegment'] ?? '(root)'}", missing "$missing". '
+              'present here: ${children.isEmpty ? '(empty)' : children.join(', ')}');
+    }
+  }
+
+  // ---- Report assembly --------------------------------------------------
+
+  /// Build a report from the current session: the last heavy captures (lazily
+  /// grabbing environment + USB if a scan was never run) plus the full step log.
+  Future<DiagnosticReport> buildSessionReport() async {
+    final env = _log.lastEnvironment ?? await _safe(_mtp.getEnvironment) ?? {};
+    final usb =
+        _log.lastUsbDevices ?? await _safe(_mtp.dumpUsbDevices) ?? const [];
+    _log.lastEnvironment = env;
+    _log.lastUsbDevices = usb;
+    return _assemble('session', env, usb, _log.lastMtpTree);
+  }
+
+  DiagnosticReport _assemble(
+    String kind,
+    Map<String, dynamic> env,
+    List<Map<String, dynamic>> usb,
+    Map<String, dynamic>? tree,
+  ) {
+    final snapshot = List<DiagnosticStep>.from(_log.steps);
+    return DiagnosticReport(
+      kind: kind,
+      environment: env,
+      usbDevices: usb,
+      mtpTree: tree,
+      steps: snapshot,
+      // Scope the "last fail" verdict to THIS run so a clean scan after an
+      // earlier failure isn't mislabelled with a stale failure code.
+      summary: _summarize(env, usb, tree, _scopeForSummary(snapshot, kind)),
+    );
+  }
+
+  /// For a scan report, restrict the summary to the steps since the most recent
+  /// scan boundary marker; a session report summarises the whole log. Done by
+  /// content (not index) so it's safe against the 200-entry ring-buffer trim.
+  List<DiagnosticStep> _scopeForSummary(List<DiagnosticStep> all, String kind) {
+    if (kind != 'scan') return all;
+    for (var i = all.length - 1; i >= 0; i--) {
+      if (all[i].status == DiagStatus.info &&
+          all[i].name.contains('scan started')) {
+        return all.sublist(i);
+      }
+    }
+    return all;
+  }
+
+  String _summarize(
+    Map<String, dynamic> env,
+    List<Map<String, dynamic>> usb,
+    Map<String, dynamic>? tree,
+    List<DiagnosticStep> runSteps,
+  ) {
+    final parts = <String>[];
+    final dji = usb.where((d) => d['isDji'] == true).length;
+    final mtp = usb.where((d) => d['looksMtp'] == true).length;
+    parts.add('USB ${usb.length} (DJI $dji, MTP $mtp)');
+    if (env['hasUsbHostFeature'] == false) parts.add('NO USB-host');
+    if (tree != null) {
+      final dpath = (tree['djiPath'] as Map?) ?? const {};
+      parts.add(dpath['missingSegment'] == null
+          ? 'waypoint OK (${(dpath['waypointSlots'] as List?)?.length ?? 0} slots)'
+          : 'path stops @ ${dpath['deepestSegment'] ?? 'root'}');
+    }
+    DiagnosticStep? lastFail;
+    for (final s in runSteps) {
+      if (s.status == DiagStatus.fail || s.status == DiagStatus.timeout) {
+        lastFail = s;
+      }
+    }
+    if (lastFail != null) {
+      parts.add('last fail: ${lastFail.code ?? lastFail.name}');
+    } else if (parts.isNotEmpty) {
+      parts.add('no failures recorded');
+    }
+    return parts.join(' | ');
+  }
+
+  // ---- Export paths -----------------------------------------------------
+
+  Future<bool> share(DiagnosticReport r) =>
+      _diag.shareReport(r.fileName, r.toText());
+
+  Future<void> copyToClipboard(DiagnosticReport r) =>
+      Clipboard.setData(ClipboardData(text: r.toText()));
+
+  Future<String?> saveToDownloads(DiagnosticReport r) =>
+      _diag.saveReportToDownloads(r.fileName, r.toText());
+
+  /// Queue the report for upload and attempt an immediate flush. Failures stay
+  /// on disk and are retried on the next [init]/scan. No-op send until an
+  /// endpoint is configured, but the report is always persisted.
+  Future<void> uploadWhenOnline(DiagnosticReport r) async {
+    await _enqueue(r);
+    try {
+      await flushQueue();
+    } catch (_) {/* stays queued */}
+  }
+
+  Future<void> _enqueue(DiagnosticReport r) async {
+    final dir = await _diag.getAppFilesDir();
+    if (dir == null) return;
+    final qdir = Directory('$dir/diag_queue');
+    if (!await qdir.exists()) await qdir.create(recursive: true);
+    final file = File('${qdir.path}/${r.fileName}.json');
+    await file.writeAsString(jsonEncode(r.toJson()));
+  }
+
+  /// Try to POST every queued report to the configured endpoint. Returns the
+  /// number sent. Sent reports are deleted; the rest stay queued.
+  Future<int> flushQueue() async {
+    final url = _endpoint;
+    if (url == null) return 0;
+    final dir = await _diag.getAppFilesDir();
+    if (dir == null) return 0;
+    final qdir = Directory('$dir/diag_queue');
+    if (!await qdir.exists()) return 0;
+    var sent = 0;
+    for (final entity in qdir.listSync()) {
+      if (entity is! File) continue;
+      try {
+        final body = await entity.readAsString();
+        if (await _post(url, body)) {
+          await entity.delete();
+          sent++;
+        }
+      } catch (_) {/* keep queued */}
+    }
+    return sent;
+  }
+
+  Future<bool> _post(String url, String body) async {
+    final client = HttpClient()
+      ..connectionTimeout = const Duration(seconds: 15);
+    try {
+      final req = await client.postUrl(Uri.parse(url));
+      req.headers.contentType = ContentType.json;
+      req.add(utf8.encode(body));
+      final resp = await req.close();
+      await resp.drain<void>();
+      return resp.statusCode >= 200 && resp.statusCode < 300;
+    } finally {
+      client.close(force: true);
+    }
+  }
+
+  /// Count of reports currently waiting to upload.
+  Future<int> pendingUploads() async {
+    final dir = await _diag.getAppFilesDir();
+    if (dir == null) return 0;
+    final qdir = Directory('$dir/diag_queue');
+    if (!await qdir.exists()) return 0;
+    return qdir.listSync().whereType<File>().length;
+  }
+
+  // ---- Upload endpoint config (persisted) -------------------------------
+
+  Future<void> setEndpoint(String? url) async {
+    final cleaned = (url == null || url.trim().isEmpty) ? null : url.trim();
+    _endpoint = cleaned;
+    final dir = await _diag.getAppFilesDir();
+    if (dir != null) {
+      await File('$dir/diag_endpoint.txt').writeAsString(cleaned ?? '');
+    }
+    notifyListeners();
+  }
+
+  Future<void> _loadEndpoint() async {
+    final dir = await _diag.getAppFilesDir();
+    if (dir == null) return;
+    final file = File('$dir/diag_endpoint.txt');
+    if (await file.exists()) {
+      final value = (await file.readAsString()).trim();
+      _endpoint = value.isEmpty ? null : value;
+      notifyListeners();
+    }
+  }
+
+  // ---- Helpers ----------------------------------------------------------
+
+  /// Run [fn], recording a timed step with its outcome; returns null on failure.
+  Future<T?> _timed<T>(String name, Future<T> Function() fn) async {
+    final sw = Stopwatch()..start();
+    try {
+      final value = await fn();
+      _log.mark(name, DiagStatus.ok, durationMs: sw.elapsedMilliseconds);
+      return value;
+    } on PlatformException catch (e) {
+      _log.mark(name, DiagStatus.fail,
+          code: e.code, detail: e.message, durationMs: sw.elapsedMilliseconds);
+      return null;
+    } catch (e) {
+      _log.mark(name, DiagStatus.fail,
+          detail: '$e', durationMs: sw.elapsedMilliseconds);
+      return null;
+    }
+  }
+
+  /// Run [fn], swallowing errors and returning null. Used where we don't want a
+  /// recorded step (cleanup, polling).
+  Future<T?> _safe<T>(Future<T> Function() fn) async {
+    try {
+      return await fn();
+    } catch (_) {
+      return null;
+    }
+  }
+
+  void _setBusy(bool value) {
+    _busy = value;
+    notifyListeners();
+  }
+}

--- a/src/transfer-util/lib/services/mtp_transfer.dart
+++ b/src/transfer-util/lib/services/mtp_transfer.dart
@@ -2,9 +2,23 @@ import 'dart:async';
 
 import 'package:flutter/services.dart';
 
+import '../models/diagnostic_report.dart';
 import '../models/mission.dart';
 import '../platform/mtp_channel.dart';
+import 'diagnostics_service.dart';
 import 'transfer_strategy.dart';
+
+/// How the USB permission handshake resolved. `timeout` is distinct from
+/// `denied` because on Android 14 a timeout can mean the permission broadcast
+/// never arrived rather than the user saying no — a different bug to chase.
+enum _PermOutcome { granted, denied, timeout }
+
+/// Combine a [PlatformException]'s message with any structured `details`
+/// (e.g. the DJI-path traversal context attached to `DIR_NOT_FOUND`).
+String? _detailOf(PlatformException e) {
+  if (e.details == null) return e.message;
+  return '${e.message ?? ''} ${e.details}'.trim();
+}
 
 /// Primary strategy: talk to the controller directly with Android's
 /// `android.mtp.MtpDevice` API (wrapped by `MtpTransferPlugin.kt`).
@@ -47,6 +61,9 @@ class MtpTransferStrategy implements TransferStrategy {
   Future<void> prepare() async {
     final devices = await _channel.getConnectedDevices();
     if (devices.isEmpty) {
+      DiagnosticLog.instance.mark('Find controller on USB', DiagStatus.fail,
+          code: 'NO_DEVICE',
+          detail: 'no DJI/MTP device on the USB bus (OTG/cable/USB-mode?)');
       throw const TransferException(
         code: 'NO_DEVICE',
         message:
@@ -64,13 +81,27 @@ class MtpTransferStrategy implements TransferStrategy {
       (d) => d.isDji,
       orElse: () => devices.first,
     );
+    DiagnosticLog.instance.mark('Find controller on USB', DiagStatus.ok,
+        detail:
+            '${device.name} (vid=${device.vendorId} pid=${device.productId})');
 
     if (!device.hasPermission) {
       final alreadyGranted =
           await _channel.requestPermission(deviceName: device.name);
       if (!alreadyGranted) {
-        final granted = await _awaitPermissionDecision();
-        if (!granted) {
+        final outcome = await _awaitPermissionDecision();
+        if (outcome != _PermOutcome.granted) {
+          DiagnosticLog.instance.mark(
+            'USB permission',
+            outcome == _PermOutcome.timeout
+                ? DiagStatus.timeout
+                : DiagStatus.fail,
+            code: 'NO_PERMISSION',
+            detail: outcome == _PermOutcome.timeout
+                ? 'no grant within 45s — denied, or the permission broadcast '
+                    'never arrived (Android 14 RECEIVER_EXPORTED class)'
+                : 'permission denied',
+          );
           throw const TransferException(
             code: 'NO_PERMISSION',
             message:
@@ -81,21 +112,42 @@ class MtpTransferStrategy implements TransferStrategy {
           );
         }
       }
+      DiagnosticLog.instance.mark('USB permission', DiagStatus.ok);
+    } else {
+      DiagnosticLog.instance
+          .mark('USB permission', DiagStatus.ok, detail: 'already granted');
     }
 
+    final sw = Stopwatch()..start();
     try {
-      await _channel.openDevice(deviceName: device.name);
+      final info = await _channel.openDevice(deviceName: device.name);
       _opened = true;
+      final di = coerceMap(info);
+      DiagnosticLog.instance.mark('Open MTP session', DiagStatus.ok,
+          durationMs: sw.elapsedMilliseconds,
+          detail:
+              'mfr=${di['manufacturer']} model=${di['model']} serial=${di['serialNumber']}');
     } on PlatformException catch (e) {
+      DiagnosticLog.instance.mark('Open MTP session', DiagStatus.fail,
+          code: e.code, detail: e.message, durationMs: sw.elapsedMilliseconds);
       throw _mapError(e);
     }
   }
 
   @override
   Future<List<Mission>> listMissions() async {
+    final sw = Stopwatch()..start();
     try {
-      return await _channel.listMissions();
+      final missions = await _channel.listMissions();
+      DiagnosticLog.instance.mark('List mission slots', DiagStatus.ok,
+          durationMs: sw.elapsedMilliseconds,
+          detail: '${missions.length} slot(s)');
+      return missions;
     } on PlatformException catch (e) {
+      DiagnosticLog.instance.mark('List mission slots', DiagStatus.fail,
+          code: e.code,
+          detail: _detailOf(e),
+          durationMs: sw.elapsedMilliseconds);
       throw _mapError(e);
     }
   }
@@ -105,9 +157,14 @@ class MtpTransferStrategy implements TransferStrategy {
     required String uuid,
     required Uint8List kmzData,
   }) async {
+    final sw = Stopwatch()..start();
     try {
       final ok = await _channel.transferKmz(uuid: uuid, kmzData: kmzData);
       if (!ok) {
+        DiagnosticLog.instance.mark('Transfer KMZ', DiagStatus.fail,
+            code: 'SEND_FAILED',
+            detail: 'controller returned false',
+            durationMs: sw.elapsedMilliseconds);
         throw const TransferException(
           code: 'SEND_FAILED',
           message:
@@ -116,7 +173,14 @@ class MtpTransferStrategy implements TransferStrategy {
           canFallbackToSaf: true,
         );
       }
+      DiagnosticLog.instance.mark('Transfer KMZ', DiagStatus.ok,
+          durationMs: sw.elapsedMilliseconds,
+          detail: '${kmzData.length} bytes → $uuid');
     } on PlatformException catch (e) {
+      DiagnosticLog.instance.mark('Transfer KMZ', DiagStatus.fail,
+          code: e.code,
+          detail: _detailOf(e),
+          durationMs: sw.elapsedMilliseconds);
       throw _mapError(e);
     }
   }
@@ -133,37 +197,37 @@ class MtpTransferStrategy implements TransferStrategy {
   }
 
   /// Waits for the `usb_permission_granted` / `usb_permission_denied` event
-  /// that follows a permission dialog. Resolves `true` on grant, `false` on
-  /// denial or timeout.
-  Future<bool> _awaitPermissionDecision() {
-    final completer = Completer<bool>();
+  /// that follows a permission dialog, distinguishing grant, denial, and a
+  /// timeout (which may mean the broadcast never arrived).
+  Future<_PermOutcome> _awaitPermissionDecision() {
+    final completer = Completer<_PermOutcome>();
     late final StreamSubscription<MtpEvent> sub;
 
-    void finish(bool granted) {
+    void finish(_PermOutcome outcome) {
       if (completer.isCompleted) return;
       sub.cancel();
-      completer.complete(granted);
+      completer.complete(outcome);
     }
 
     sub = _channel.events.listen(
       (event) {
         switch (event.type) {
           case MtpEventType.usbPermissionGranted:
-            finish(true);
+            finish(_PermOutcome.granted);
           case MtpEventType.usbPermissionDenied:
-            finish(false);
+            finish(_PermOutcome.denied);
           default:
             break;
         }
       },
-      onError: (_) => finish(false),
+      onError: (_) => finish(_PermOutcome.denied),
     );
 
     return completer.future.timeout(
       _permissionTimeout,
       onTimeout: () {
-        finish(false);
-        return false;
+        finish(_PermOutcome.timeout);
+        return _PermOutcome.timeout;
       },
     );
   }

--- a/src/transfer-util/lib/services/saf_transfer.dart
+++ b/src/transfer-util/lib/services/saf_transfer.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/services.dart';
 
+import '../models/diagnostic_report.dart';
 import '../models/mission.dart';
 import '../platform/saf_channel.dart';
+import 'diagnostics_service.dart';
 import 'transfer_strategy.dart';
 
 /// Fallback strategy: Storage Access Framework (SAF).
@@ -42,9 +44,15 @@ class SafTransferStrategy implements TransferStrategy {
 
   @override
   Future<void> prepare() async {
-    if (await _channel.hasPersistedUri()) return;
+    if (await _channel.hasPersistedUri()) {
+      DiagnosticLog.instance
+          .mark('Folder access', DiagStatus.ok, detail: 'already granted');
+      return;
+    }
     final granted = await requestAccess();
     if (!granted) {
+      DiagnosticLog.instance.mark('Folder access', DiagStatus.fail,
+          code: 'NO_DIR', detail: 'folder picker cancelled');
       throw const TransferException(
         code: 'NO_DIR',
         message:
@@ -53,13 +61,22 @@ class SafTransferStrategy implements TransferStrategy {
             '(Android > data > dji.go.v5 > files > waypoint).',
       );
     }
+    DiagnosticLog.instance
+        .mark('Folder access', DiagStatus.ok, detail: 'granted via picker');
   }
 
   @override
   Future<List<Mission>> listMissions() async {
+    final sw = Stopwatch()..start();
     try {
-      return await _channel.listMissions();
+      final missions = await _channel.listMissions();
+      DiagnosticLog.instance.mark('List mission slots (SAF)', DiagStatus.ok,
+          durationMs: sw.elapsedMilliseconds,
+          detail: '${missions.length} slot(s)');
+      return missions;
     } on PlatformException catch (e) {
+      DiagnosticLog.instance.mark('List mission slots (SAF)', DiagStatus.fail,
+          code: e.code, detail: e.message, durationMs: sw.elapsedMilliseconds);
       throw _mapError(e);
     }
   }
@@ -69,15 +86,25 @@ class SafTransferStrategy implements TransferStrategy {
     required String uuid,
     required Uint8List kmzData,
   }) async {
+    final sw = Stopwatch()..start();
     try {
       final ok = await _channel.transferKmz(uuid: uuid, kmzData: kmzData);
       if (!ok) {
+        DiagnosticLog.instance.mark('Write KMZ to folder', DiagStatus.fail,
+            code: 'WRITE_FAILED',
+            detail: 'channel returned false',
+            durationMs: sw.elapsedMilliseconds);
         throw const TransferException(
           code: 'WRITE_FAILED',
           message: 'Could not write the file to the controller. Try again.',
         );
       }
+      DiagnosticLog.instance.mark('Write KMZ to folder', DiagStatus.ok,
+          durationMs: sw.elapsedMilliseconds,
+          detail: '${kmzData.length} bytes → $uuid');
     } on PlatformException catch (e) {
+      DiagnosticLog.instance.mark('Write KMZ to folder', DiagStatus.fail,
+          code: e.code, detail: e.message, durationMs: sw.elapsedMilliseconds);
       throw _mapError(e);
     }
   }

--- a/src/transfer-util/lib/state/transfer_controller.dart
+++ b/src/transfer-util/lib/state/transfer_controller.dart
@@ -3,11 +3,13 @@ import 'dart:async';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 
+import '../models/diagnostic_report.dart';
 import '../models/drone_model.dart';
 import '../models/kmz_file.dart';
 import '../models/mission.dart';
 import '../platform/mtp_channel.dart';
 import '../platform/saf_channel.dart';
+import '../services/diagnostics_service.dart';
 import '../services/mtp_transfer.dart';
 import '../services/saf_transfer.dart';
 import '../services/transfer_strategy.dart';
@@ -264,6 +266,11 @@ class TransferController extends ChangeNotifier {
     _error = null;
     _setPhase(TransferPhase.connecting);
     _status = isUsb ? 'Opening controller over USB…' : 'Checking folder access…';
+    DiagnosticLog.instance.mark(
+      '— ${isUsb ? 'USB/MTP' : 'SAF'} attempt —',
+      DiagStatus.info,
+      detail: 'model=${_model.id} file=${_file?.name}',
+    );
     notifyListeners();
 
     try {


### PR DESCRIPTION
## Why

Flightplan transfer is DroneTM's #1 field issue. The transfer app works, but when it fails on a phone it surfaces a single generic error with no field-collectable record of *why* — so "works on 1/3 phones" is unactionable. This adds a diagnostics layer that turns each attempt (or a standalone scan) into a structured, exportable report pinpointing the failing step and the raw USB/MTP facts underneath it.

## What's in it

**Native capture** (`MtpTransferPlugin`)
- `getEnvironment` — phone make/model, Android SDK, USB-host feature, app version
- `dumpUsbDevices` — every USB device *unfiltered*, with full interface detail, so an RC2 enumerating with an unexpected product id is visible instead of looking identical to "nothing plugged in"
- `dumpMtpTree` — storage volumes + the DJI-path traversal (deepest segment reached, the missing segment, siblings present where it stopped). Runs on a dedicated worker thread (no UI block / ANR), bounded by depth/width/node budget, uses `compressedSizeLong` for >2 GiB media.

**Always-on step log** (MTP + SAF flows)
- Per-step ok / fail / **timeout**, distinguishing a permission denial from a missing permission broadcast (the Android 14 `RECEIVER_EXPORTED` class of hang)
- Captures the previously-discarded `MtpDeviceInfo`

**Export** (`DiagnosticsPlugin` + Dart) — all offline-first, capture now / send later:
- Share sheet (FileProvider), clipboard, save-to-Downloads (MediaStore on API 29+, app-specific external dir pre-Q to avoid a silent permission failure), and an offline-queued HTTP POST that flushes when a configurable endpoint is reachable

**Diagnostics screen** (troubleshoot icon, top-right): one-tap **Run full diagnostic scan** that needs no KMZ, a live colour-coded log, an export bar, and endpoint config.

No new pub dependencies. Adds the `INTERNET` permission and a `FileProvider`.

## Verification

- `flutter analyze` clean; `flutter build apk --debug` succeeds.
- Reviewed across Kotlin/MTP-API correctness, Dart correctness, manifest/FileProvider, and the offline queue. The findings are folded in: off-thread tree walk, `compressedSizeLong`, run-scoped summary verdict, pre-Q save without a runtime permission, SAF per-step logging, and cache reset on "Clear log".

## How to test (DJI RC2)

1. `cd src/transfer-util && flutter install` (or `adb install -r build/app/outputs/flutter-apk/app-debug.apk`)
2. Plug the phone into the RC2 with a **data** cable → open the app → troubleshoot icon → **Run full diagnostic scan**
3. **Share** the report. Repeat on each test phone — the reports show exactly why the failing phones fail (no-OTG vs charge-only cable vs permission-timeout vs PID-mismatch vs no waypoint slot).

## Notes

- Base is `transfer-util-lib` so the diff is diagnostics-only; retarget to `feat/file-transfer-util` / `dev` if preferred.
- `gradle.properties` carries the Flutter 3.44 migrator's `builtInKotlin` / `newDsl=false` flags, needed for the build on that SDK.
- Design doc: `src/transfer-util/docs/plans/2026-06-08-mtp-transfer-diagnostics-design.md`
