### PR TITLE
Refactoring False Positives in Flight Tail Algorithm

### DIFF
--- a/src/backend/app/images/flight_tail_removal.py
+++ b/src/backend/app/images/flight_tail_removal.py
@@ -7,13 +7,8 @@ from psycopg import Connection
 from psycopg.rows import dict_row
 
 from app.models.enums import ImageStatus
-from app.utils import (
-    calculate_angular_difference,
-    circular_mean_pair,
-    circular_mean_list,
-)
 
-
+'''
 def _confirm_stable_heading(project_list: list, image_index: int, steps: int) -> bool:
     """
     Confirms if a suspected change in the flight trajectory is sustained.
@@ -65,6 +60,43 @@ def _confirm_stable_heading(project_list: list, image_index: int, steps: int) ->
             if azimuth_difference > 10:
                 return False
         return True
+'''
+
+
+def _find_main_axis(flight_segment_images, field="yaw_deg"):
+    """
+    Follows same logic from 'find_axis' suggested flight tail removal focused on 'FlightYawDegree' to find
+    main axis/baseline for flight segment.
+    """
+    # Count up flight headings, treating 180-degree rotations as equivalent
+    photos_by_heading = [[] for h in range(180)]
+    for image in flight_segment_images:
+        # Check if yaw_deg exists
+        if image[field] is None:
+            continue
+        heading = int(image[field] % 180)
+        photos_by_heading[heading].append(image)
+
+    # Find the 10-degree sector where most flight headings fall
+    best_h, max_count = None, 0
+    for h in range(180):
+        count_in_sector = sum(len(photos_by_heading[i % 180]) for i in range(h, h + 10))
+        if count_in_sector > max_count:
+            best_h, max_count = h, count_in_sector
+
+    # Collect all the photos with headings within that 10-degree sector
+    aligned_photos = []
+    for i in range(best_h, best_h + 10):
+        aligned_photos += photos_by_heading[i % 180]
+
+    # These headings are all between best_h and best_h + 10, so subtracting
+    # best_h makes them safe to average (all positive, no discontinuity).
+    aligned_headings = [(p[field] - best_h) % 180 for p in aligned_photos]
+
+    assert all(0 <= h <= 10 for h in aligned_headings)
+    average_heading = sum(aligned_headings) / len(aligned_headings)
+
+    return (best_h + average_heading) % 180
 
 
 async def _flag_flight_tail_images(
@@ -107,7 +139,7 @@ async def mark_and_remove_flight_tail_imagery(
     """
     Identifies and flags flight tail imagery taken during takeoff and landing to prevent photogrammetric distortion.
 
-    This function inspects the transit phases of a flight trajectory by analyzing azimuthal shifts between consecutive
+    This function inspects the transit phases of a flight trajectory by analyzing FlightYawDegree between consecutive
     images to identify potential flightplan tails.
 
     Args:
@@ -144,6 +176,7 @@ async def mark_and_remove_flight_tail_imagery(
                     uploaded_at
                 ) AS sort_ts,
                 NULLIF(exif->>'FlightYawDegree', '')::double precision AS yaw_deg,
+                NULLIF(exif->>'GimbalPitchDegree', '')::double precision AS gimbal_pitch_deg,
                 NULLIF(regexp_replace(COALESCE(exif->>'AbsoluteAltitude',''), '[^0-9+\\-.]+', '', 'g'), '')::double precision AS altitude_m
             FROM project_images
             WHERE project_id = %(project_id)s
@@ -160,6 +193,7 @@ async def mark_and_remove_flight_tail_imagery(
                 uploaded_at,
                 sort_ts,
                 yaw_deg,
+                gimbal_pitch_deg,
                 altitude_m,
                 LAG(sort_ts, 1, sort_ts) OVER (ORDER BY sort_ts ASC) AS prev_sort_ts,
                 LAG(location, 1, location) OVER (ORDER BY sort_ts ASC) AS prev_location,
@@ -174,6 +208,7 @@ async def mark_and_remove_flight_tail_imagery(
                 uploaded_at,
                 sort_ts,
                 yaw_deg,
+                gimbal_pitch_deg,
                 altitude_m,
                 prev_sort_ts,
                 prev_location,
@@ -201,6 +236,7 @@ async def mark_and_remove_flight_tail_imagery(
                 sort_ts,
                 segment_id,
                 yaw_deg,
+                gimbal_pitch_deg,
                 altitude_m,
                 LAG(sort_ts, 1, sort_ts) OVER (PARTITION BY segment_id ORDER BY sort_ts ASC) AS previous_sort_ts,
                 LAG(location, 1, location) OVER (PARTITION BY segment_id ORDER BY sort_ts ASC) AS previous_location,
@@ -219,17 +255,11 @@ async def mark_and_remove_flight_tail_imagery(
             row_num,
             CASE
                 WHEN row_num = 1 THEN NULL
-                ELSE mod(
-                    (degrees(ST_Azimuth(previous_location::geometry, location::geometry)) + 360.0)::numeric,
-                    360::numeric
-                )::double precision
-            END AS azimuth,
-            CASE
-                WHEN row_num = 1 THEN NULL
                 ELSE ST_Distance(previous_location::geography, location::geography)
             END AS distance_moved,
             yaw_deg,
             previous_yaw_deg,
+            gimbal_pitch_deg
             altitude_m,
             previous_altitude_m
         FROM trajectory_data
@@ -257,20 +287,11 @@ async def mark_and_remove_flight_tail_imagery(
         f"Split into {len(segments)} time-contiguous segments"
     )
 
-    MIN_DISTANCE_METERS = 5.0
-    BASELINE_SAMPLE_COUNT = 5  # Increased from 3 for more stable baseline
     ALT_RATE_THRESHOLD_MPS = 2.0
     LOW_LATERAL_FOR_VERTICAL_METERS = 10.0
     MAX_TAIL_FRACTION = 0.25
-    # We require a minimum segment size so the baseline heading estimate is stable.
     MIN_SEGMENT_SIZE = 10
     MIN_SEARCH_IMAGES = 30  # Minimum images to search for tails
-    MIN_TAIL_LENGTH = (
-        5  # Minimum images to constitute a tail (avoids waypoint turn false positives)
-    )
-    MAX_BASELINE_SPREAD_DEG = (
-        30.0  # Max angular spread among baseline samples (transit tails are straight)
-    )
 
     for idx, segment in enumerate(segments):
         log.debug(
@@ -286,6 +307,9 @@ async def mark_and_remove_flight_tail_imagery(
                 f"(minimum required: {MIN_SEGMENT_SIZE})"
             )
             continue
+
+        # Find global mission axis for the flight segment based on yaw_deg
+        global_mission_axis = _find_main_axis(segment, "yaw_deg")
 
         # Mark vertical candidates
         for i, row in enumerate(segment):
@@ -323,168 +347,76 @@ async def mark_and_remove_flight_tail_imagery(
         takeoff_tails_indices = []
         landing_tails_indices = []
 
-        # TAKEOFF DETECTION
-        takeoff_baseline = None
-        takeoff_baseline_samples: list[float] = []
-
-        # Find first valid baseline
-        baseline_start_idx = None
+        takeoff_aligned_with_mission_counter = 0
         for i in range(search_limit):
-            if i == 0:  # Skip first image (no azimuth)
-                continue
-            if segment[i].get("distance_moved", 0) < MIN_DISTANCE_METERS:
-                continue
-            if segment[i].get("vertical_candidate"):
-                continue
-            if segment[i].get("azimuth") is None:
+            image_yaw_to = segment[i].get("yaw_deg")
+            image_gimbal_to = segment[i].get("gimbal_pitch_deg")
+            image_vertical_to = segment[i].get("vertical_candidate")
+
+            # Skip none values
+            if image_yaw_to is None:
                 continue
 
-            takeoff_baseline_samples.append(segment[i]["azimuth"])
-            if len(takeoff_baseline_samples) == 1:
-                baseline_start_idx = i
+            # Check gimbal pitch and if vertical candidate
+            if (image_gimbal_to == 0) or (image_vertical_to is True):
+                takeoff_aligned_with_mission_counter = 0
+                takeoff_tails_indices.append(i)
+                continue
 
-            if len(takeoff_baseline_samples) >= BASELINE_SAMPLE_COUNT:
-                takeoff_baseline = circular_mean_list(takeoff_baseline_samples)
+            # Compare if current yaw degree is aligned with mission axis within 5 degrees
+            yaw_diff_to = abs((image_yaw_to % 180) - global_mission_axis)
+            yaw_aligned_to = min(yaw_diff_to, 180 - yaw_diff_to) < 5
+
+            # Check yaw alignment
+            if yaw_aligned_to:
+                takeoff_aligned_with_mission_counter += 1
+            else:
+                takeoff_aligned_with_mission_counter = 0
+                takeoff_tails_indices.append(i)
+
+            # Check at least 3 photos are within the mission-axis dimensions
+            if takeoff_aligned_with_mission_counter >= 3:
                 break
 
-        # Only proceed if we have a valid, straight baseline (transit tails are straight lines)
-        takeoff_baseline_straight = False
-        if (
-            takeoff_baseline is not None
-            and len(takeoff_baseline_samples) >= BASELINE_SAMPLE_COUNT
-        ):
-            max_spread = max(
-                calculate_angular_difference(
-                    takeoff_baseline_samples[a], takeoff_baseline_samples[b]
-                )
-                for a in range(len(takeoff_baseline_samples))
-                for b in range(a + 1, len(takeoff_baseline_samples))
-            )
-            takeoff_baseline_straight = max_spread <= MAX_BASELINE_SPREAD_DEG
-
-        if (
-            takeoff_baseline is not None
-            and baseline_start_idx is not None
-            and not takeoff_baseline_straight
-        ):
-            log.debug(
-                f"Segment {idx}: Takeoff baseline not straight enough "
-                f"(spread {max_spread:.1f}° > {MAX_BASELINE_SPREAD_DEG}°), skipping takeoff tail detection"
-            )
-
-        if (
-            takeoff_baseline is not None
-            and baseline_start_idx is not None
-            and takeoff_baseline_straight
-        ):
-            for i in range(baseline_start_idx + BASELINE_SAMPLE_COUNT, search_limit):
-                if i == 0 or segment[i].get("azimuth") is None:
-                    continue
-                if segment[i].get("distance_moved", 0) < MIN_DISTANCE_METERS:
-                    continue
-                if segment[i].get("vertical_candidate"):
-                    continue
-
-                current_azimuth = segment[i]["azimuth"]
-                azimuth_difference = calculate_angular_difference(
-                    takeoff_baseline, current_azimuth
-                )
-
-                if azimuth_difference < 45:
-                    # Still in baseline trajectory
-                    takeoff_baseline = circular_mean_pair(
-                        takeoff_baseline, current_azimuth
-                    )
-                elif azimuth_difference > 60:  # Increased threshold from 45 to 60
-                    # Potential turn detected - confirm it and enforce minimum tail length
-                    if i >= MIN_TAIL_LENGTH and _confirm_stable_heading(segment, i, 1):
-                        takeoff_tails_indices = list(range(i))
-                        break
-
         # LANDING DETECTION (similar logic, working backwards)
-        landing_baseline = None
-        landing_baseline_samples: list[float] = []
-        landing_start_idx = None
-
         landing_search_start = segment_length - 1
         landing_search_end = max(segment_length - search_limit, 0)
 
+        landing_aligned_with_mission_counter = 0
         for i in range(landing_search_start, landing_search_end, -1):
-            if segment[i].get("distance_moved", 0) < MIN_DISTANCE_METERS:
-                continue
-            if segment[i].get("vertical_candidate"):
-                continue
-            if segment[i].get("azimuth") is None:
+            image_yaw_land = segment[i].get("yaw_deg")
+            image_gimbal_land = segment[i].get("gimbal_pitch_deg")
+            image_vertical_land = segment[i].get("vertical_candidate")
+
+            # Skip none values
+            if image_yaw_land is None:
                 continue
 
-            landing_baseline_samples.append(segment[i]["azimuth"])
-            if len(landing_baseline_samples) == 1:
-                landing_start_idx = i
+            # Check gimbal pitch and if vertical candidate
+            if (image_gimbal_land == 0) or (image_vertical_land is True):
+                landing_aligned_with_mission_counter = 0
+                landing_tails_indices.append(i)
+                continue
 
-            if len(landing_baseline_samples) >= BASELINE_SAMPLE_COUNT:
-                landing_baseline = circular_mean_list(landing_baseline_samples)
+            # Compare if current yaw degree is aligned with mission axis within 5 degrees
+            yaw_diff_land = abs((image_yaw_land % 180) - global_mission_axis)
+            yaw_aligned_land = min(yaw_diff_land, 180 - yaw_diff_land) < 5
+
+            # Check yaw alignment
+            if yaw_aligned_land:
+                landing_aligned_with_mission_counter += 1
+            else:
+                landing_aligned_with_mission_counter = 0
+                landing_tails_indices.append(i)
+
+            # Check at least 3 photos are within the mission-axis dimensions
+            if landing_aligned_with_mission_counter >= 3:
                 break
-
-        # Only proceed if baseline is straight (transit tails are straight lines)
-        landing_baseline_straight = False
-        if (
-            landing_baseline is not None
-            and len(landing_baseline_samples) >= BASELINE_SAMPLE_COUNT
-        ):
-            max_spread = max(
-                calculate_angular_difference(
-                    landing_baseline_samples[a], landing_baseline_samples[b]
-                )
-                for a in range(len(landing_baseline_samples))
-                for b in range(a + 1, len(landing_baseline_samples))
-            )
-            landing_baseline_straight = max_spread <= MAX_BASELINE_SPREAD_DEG
-
-        if (
-            landing_baseline is not None
-            and landing_start_idx is not None
-            and not landing_baseline_straight
-        ):
-            log.debug(
-                f"Segment {idx}: Landing baseline not straight enough "
-                f"(spread {max_spread:.1f}° > {MAX_BASELINE_SPREAD_DEG}°), skipping landing tail detection"
-            )
-
-        if (
-            landing_baseline is not None
-            and landing_start_idx is not None
-            and landing_baseline_straight
-        ):
-            for i in range(
-                landing_start_idx - BASELINE_SAMPLE_COUNT, landing_search_end, -1
-            ):
-                if segment[i].get("azimuth") is None:
-                    continue
-                if segment[i].get("distance_moved", 0) < MIN_DISTANCE_METERS:
-                    continue
-                if segment[i].get("vertical_candidate"):
-                    continue
-
-                current_azimuth = segment[i]["azimuth"]
-                azimuth_difference = calculate_angular_difference(
-                    landing_baseline, current_azimuth
-                )
-
-                if azimuth_difference < 45:
-                    landing_baseline = circular_mean_pair(
-                        landing_baseline, current_azimuth
-                    )
-                elif azimuth_difference > 60:  # Increased threshold
-                    # Enforce minimum tail length
-                    tail_length = segment_length - (i + 1)
-                    if tail_length >= MIN_TAIL_LENGTH and _confirm_stable_heading(
-                        segment, i, -1
-                    ):
-                        landing_tails_indices = list(range(i + 1, segment_length))
-                        break
 
         # Apply safety checks
         all_tail_indices = takeoff_tails_indices + landing_tails_indices
+        print(f"Mission Axis: {global_mission_axis}")
+        print(f"Total tails found: {len(all_tail_indices)}")
         if all_tail_indices:
             tail_fraction = len(all_tail_indices) / segment_length
             if tail_fraction <= MAX_TAIL_FRACTION:

--- a/src/backend/tests/test_flight_tail_detection.py
+++ b/src/backend/tests/test_flight_tail_detection.py
@@ -50,30 +50,58 @@ async def test_flight_tail_images_marked_rejected(db, create_test_project, auth_
     base_lat = 27.0
 
     # Build a simple path:
-    # - takeoff transit: moving north (azimuth ~0)
-    # - mission: moving east (azimuth ~90)
-    # - landing transit: moving south (azimuth ~180)
+    # - takeoff transit: moving north (yaw ~0)
+    # - mission: moving east (yaw ~90)
+    # - landing transit: moving south (yaw ~180)
 
     # To pass the 25% safety fraction and the search_limit,
     # we need a longer mission (Total ~52 images)
     points: list[tuple[float, float]] = []
+    exif_data = []
 
     # Use ~11m steps so distance-based filtering (MIN_DISTANCE_METERS) doesn't discard points.
     # NOTE: tail detection requires >= 20 images per segment.
 
     # We need at least 5 images for baseline, turn happens at index 6
     for i in range(6):
-        points.append((base_lon, base_lat + i * 0.0001))
+        points.append((base_lon, base_lat + i * 0.0002))
+        exif_data.append(
+            json.dumps(
+                {
+                    "FlightYawDegree": 0.0,
+                    "GimbalPitchDegree": 0.0,
+                    "AbsoluteAltitude": 250.0,
+                }
+            )
+        )
 
     # 40 points east
     east_start_lon, east_start_lat = points[-1]
     for i in range(1, 41):
-        points.append((east_start_lon + i * 0.0001, east_start_lat))
+        points.append((east_start_lon + i * 0.0002, east_start_lat))
+        exif_data.append(
+            json.dumps(
+                {
+                    "FlightYawDegree": 90.0,
+                    "GimbalPitchDegree": -90.0,
+                    "AbsoluteAltitude": 250.0,
+                }
+            )
+        )
 
     # 6 points south
     south_start_lon, south_start_lat = points[-1]
     for i in range(1, 7):
-        points.append((south_start_lon, south_start_lat - i * 0.0001))
+        points.append((south_start_lon, south_start_lat - i * 0.0002))
+        exif_data.append(
+            json.dumps(
+                {
+                    "FlightYawDegree": 180.0,
+                    "GimbalPitchDegree": -90.0,
+                    "AbsoluteAltitude": 250.0,
+                }
+            )
+        )
 
     now = datetime.now(timezone.utc)
     inserted_ids: list[uuid.UUID] = []
@@ -97,7 +125,8 @@ async def test_flight_tail_images_marked_rejected(db, create_test_project, auth_
                     location,
                     uploaded_by,
                     status,
-                    uploaded_at
+                    uploaded_at,
+                    exif
                 )
                 VALUES (
                     %(project_id)s,
@@ -109,7 +138,8 @@ async def test_flight_tail_images_marked_rejected(db, create_test_project, auth_
                     ST_SetSRID(ST_MakePoint(%(lon)s, %(lat)s), 4326),
                     %(uploaded_by)s,
                     'assigned',
-                    %(uploaded_at)s
+                    %(uploaded_at)s,
+                    %(exif)s
                 )
                 RETURNING id
                 """,
@@ -124,6 +154,7 @@ async def test_flight_tail_images_marked_rejected(db, create_test_project, auth_
                     "lat": lat,
                     "uploaded_by": auth_user.id,
                     "uploaded_at": uploaded_at,
+                    "exif": exif_data[i],
                 },
             )
             row = await cur.fetchone()
@@ -192,14 +223,22 @@ async def test_flight_tail_does_not_override_existing_rejection_reason(
     base_lat = 27.0
 
     points: list[tuple[float, float]] = []
+    exif_data = []
     for i in range(8):
         points.append((base_lon, base_lat + i * 0.0001))
+        exif_data.append(json.dumps({"FlightYawDegree": 0.0, "GimbalPitchDegree": 0.0}))
     east_start_lon, east_start_lat = points[-1]
     for i in range(1, 11):
         points.append((east_start_lon + i * 0.0001, east_start_lat))
+        exif_data.append(
+            json.dumps({"FlightYawDegree": 90.0, "GimbalPitchDegree": -90.0})
+        )
     south_start_lon, south_start_lat = points[-1]
     for i in range(1, 9):
         points.append((south_start_lon, south_start_lat - i * 0.0001))
+        exif_data.append(
+            json.dumps({"FlightYawDegree": 180.0, "GimbalPitchDegree": 0.0})
+        )
 
     now = datetime.now(timezone.utc)
 
@@ -227,7 +266,8 @@ async def test_flight_tail_does_not_override_existing_rejection_reason(
                     uploaded_by,
                     status,
                     rejection_reason,
-                    uploaded_at
+                    uploaded_at,
+                    exif
                 )
                 VALUES (
                     %(project_id)s,
@@ -240,7 +280,8 @@ async def test_flight_tail_does_not_override_existing_rejection_reason(
                     %(uploaded_by)s,
                     'assigned',
                     %(rejection_reason)s,
-                    %(uploaded_at)s
+                    %(uploaded_at)s,
+                    %(exif)s
                 )
                 """,
                 {
@@ -259,6 +300,7 @@ async def test_flight_tail_does_not_override_existing_rejection_reason(
                         if i in pre_rejected_idx
                         else None
                     ),
+                    "exif": exif_data[i],
                 },
             )
 
@@ -488,6 +530,8 @@ async def test_vertical_takeoff_tail(db, create_test_project, auth_user):
 
             exif_data = json.dumps(
                 {
+                    "FlightYawDegree": 90.0,
+                    "GimbalPitchDegree": -90.0,
                     "AbsoluteAltitude": str(alt),
                     "DateTimeOriginal": ts.strftime("%Y:%m:%d %H:%M:%S"),
                 }
@@ -612,6 +656,8 @@ async def test_multi_batch_rejections(db, create_test_project, auth_user):
 
                 exif_data = json.dumps(
                     {
+                        "FlightYawDegree": 90.0,
+                        "GimbalPitchDegree": -90.0,
                         "DateTimeOriginal": ts.strftime("%Y:%m:%d %H:%M:%S"),
                         "AbsoluteAltitude": str(alt),
                     }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #788 

## Describe this PR

The flight tail removal algorithm now moves away from azimuth calculations and uses a `_find_main_axis`, suggested by Ping, that focuses on the FlightYawDegree parameter. 

The algorithm now:
- Goes through each flight segment:
    - Skips small segments, calculates the global mission axis from `_find_main_azis`
    - Continues to flags vertical candidates
    - Then inspects each takeoff and landing search image in range:
          - A counter is created to keep track of "non-transit images"
         - Checks if image has a gimbal pitch of 0 or is a vertical candidate
              - If so, image is flagged as a tail
         - Compares the current image's yaw degree against the mission axis 
              - If there is more than a 5-degree difference, image is flagged as a tail
        - Once counter reaches 3 "non-transit images", loop is exited 
   - Final safety checks were left the same.

Tests are updated to have FlightYawDegree and GimbalPitchDegree in their exif data.

## AI Tool Usage

- [ ] No AI tools were used
- [X] AI tools were used (complete below)

**If AI-assisted:**

- Tool(s) used: Google Gemini 
- What was generated: No code was generated; I inquired more about the differences in the drone metadata calculations for yaw degree, gimbal pitch, and azimuths to understand the new code implementation, as I am still new to drone imagery capturing, processing, and metadata parameters. 
- I did have trouble with passing the `test_flight_tail_images_marked_rejected` test function after implementation and adding exif_data. I used Google Gemini to catch that the test was producing multiple vertical candidates with the "i * 0.0001" calculation, and refined to "0.0002" instead.

- What you reviewed and changed: Updating `test_flight_tail_images_marked_rejected`'s points parameters to  0.0002

## Alternative Approaches Considered

I first created a check that checked all three parameters (gimbal, vertical candidate and main axis deviations) at once, but then broke it up by checking gimbal pitch and vertical candidates first, before checking yaw degree deviations from the main axis.

## Review Guide

Run `just test backend`

## Checklist

- [X] I have read the [Contributing Guide](https://github.com/hotosm/drone-tm/blob/dev/CONTRIBUTING.md)
- [X] I have read the [Code of Conduct](https://docs.hotosm.org/code-of-conduct)
- [X] PR is focused and small
- [X] Tests are included or updated
- [X] I understand all code in this PR and can answer questions about it
- [X] No secrets, credentials, or sensitive data are included
- [X] Commit messages are descriptive
- [X] Related docs and screenshots are updated
