### PR TITLE
Improve ScaleODM processing reconciliation (1) webhook (2) refresh button (3) background cron

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,10 @@ ODM_ENDPOINT=${ODM_ENDPOINT:-http://host.docker.internal:31100}
 # browser-facing S3 hostname differs from what workflow pods can reach
 # (self-hosted MinIO/RustFS).
 SCALEODM_S3_ENDPOINT=${SCALEODM_S3_ENDPOINT:-}
+# Optional shared secret for the ScaleODM status webhook. When set, it is
+# embedded as ?token= in the callback URL and helps to aid the processing
+# reconcile backup strategy. Things still function without it.
+SCALEODM_WEBHOOK_SECRET=${SCALEODM_WEBHOOK_SECRET:-}
 
 # ---- Optional monitoring ----
 MONITORING=${MONITORING:-}

--- a/docs/decisions/0006-processing-status-reconciliation.md
+++ b/docs/decisions/0006-processing-status-reconciliation.md
@@ -1,0 +1,128 @@
+# Reconciling processing status from ScaleODM to DroneTM
+
+## Context and Problem Statement
+
+Users trigger drone image processing from the DroneTM UI. The work runs in
+ScaleODM (Kubernetes-native, NodeODM-compatible, backed by Argo Workflows,
+S3-native). Two problems hurt the experience:
+
+1. When imagery is bad (too few images, poor overlap, images that do not
+   align), ScaleODM fails the job but DroneTM never learns why, or even that it
+   failed. The user gets no signal to fix or re-capture.
+2. The processing status often never updates, and the spinner can spin forever.
+
+Both share one cause. DroneTM's only signal is whether the output orthophoto
+has appeared in S3, which detects success only. When a job fails, no output is
+written, so the task stays "processing" forever and the UI spins. Reconciling
+also only happens when the browser asks, so even success is delayed until a
+manual refresh.
+
+Constraints:
+
+- No browser polling; it hurts page performance.
+- Status should update when the page opens, and a refresh button should update
+  it correctly.
+- Any background job must be bounded; it cannot scan every processing job ever
+  created.
+- DroneTM has no API-key infrastructure to authenticate an inbound webhook.
+- Either system may change.
+
+## Considered Options
+
+### 1. Browser polling
+
+The page polls for status on a timer.
+
+- Pro: simple.
+- Con: violates the no-polling constraint, hammers heavy endpoints, and cost
+  grows with the number of viewers.
+
+### 2. Webhook as the source of truth
+
+ScaleODM pushes status and DroneTM trusts and stores it.
+
+- Pro: instant, no polling.
+- Con: delivery is never guaranteed, so a dropped call leaves status wrong
+  forever. Needs authentication we do not have.
+
+### 3. Unbounded reconciler
+
+A job periodically reconciles all processing tasks.
+
+- Pro: self-healing, no reliance on delivery.
+- Con: does not scale; scanning all history is too expensive.
+
+### 4. S3 output only (the current behaviour)
+
+- Pro: cheap, needs no ScaleODM credentials.
+- Con: blind to failure, which is the real problem, and only runs on a manual
+  browser call.
+
+### 5. Push trigger, read-repair, and a bounded backstop (chosen)
+
+One reconcile routine, called by several triggers, that checks the cheapest
+source first and only asks ScaleODM when it must.
+
+- Pro: no single point of failure, bounded cost, no polling, and it can finally
+  reach a failed state.
+- Con: more moving parts, so it needs a rule to stay bounded.
+
+## Decision Outcome
+
+Chosen: option 5.
+
+The key idea is that the webhook is a trigger, not a source of truth. It only
+means "re-check this task now". The real status is always derived by the
+reconcile routine, so a missing, late, or spoofed webhook can only cause a cheap
+re-check, never wrong status. This is also why the webhook needs no real
+authentication.
+
+One reconcile routine derives status cheapest-first:
+
+1. If the output orthophoto is in S3, the task succeeded. This needs no ScaleODM
+   call.
+2. Otherwise ask ScaleODM for the task status, purely to tell "failed" from
+   "still running". A terminal failure moves the task to failed and records the
+   reason.
+
+The routine is idempotent, so every trigger can call it safely:
+
+- Webhook: ScaleODM notifies DroneTM on terminal transitions only, and DroneTM
+  re-checks that one task. This is the fast path.
+- Page open and manual refresh: the server reconciles that project, giving
+  update-on-open with a single call and no polling.
+- Cron: a low-frequency backstop that reconciles only work still in flight.
+
+Bounding the cron: a task is "in flight" only while it has a stored ScaleODM
+task id, which is set on submit and cleared on any terminal transition. The
+cron therefore only looks at jobs processing right now, limited by cluster
+capacity rather than history. A job ScaleODM can no longer find is failed after
+a grace window, so the set always drains.
+
+Why the cron exists at all: page-open only reconciles while someone is
+watching, and webhooks can be dropped. The cron guarantees status still reaches
+the truth when nobody is looking, turning the system from best-effort into
+failsafe. It is optional if we accept that status is only correct while a user
+views the page.
+
+### Consequences
+
+Positive:
+
+- ✅ A failed job now reaches a terminal state, so the spinner stops and the
+  reason is shown.
+- ✅ No browser polling. The page updates on open and on manual refresh, with the
+  heavy work done server-side.
+- ✅ No single point of failure. The webhook is the fast path; the cron and
+  page-open reconcile heal anything it misses.
+- ✅ The background cost is bounded to jobs that are actually processing.
+
+Negative:
+
+- ❌ More moving parts than a single mechanism, kept manageable by routing every
+  trigger through one idempotent routine.
+- ❌ The webhook is best-effort and unauthenticated by default. Acceptable because
+  it only triggers a re-check and carries no privileged action; network
+  isolation is the real control.
+- ❌ Reconcile makes one ScaleODM call per in-flight task when S3 has no output
+  yet. Small in practice, since only genuinely unfinished tasks reach that step.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -14,3 +14,4 @@ from the projects inception.
 - [0003 - Storage And Processing Options](./0003-aws-storage-processing.md)
 - [0004 - QField Mobile Plugin For Flightplans](./0004-mobile-qfield-plugin.md)
 - [0005 - Simple Mobile Flightplan Copy](./0005-flightplan-copy.md)
+- [0006 - Reconciling Processing Status From ScaleODM](./0006-processing-status-reconciliation.md)

--- a/src/backend/app/arq/tasks.py
+++ b/src/backend/app/arq/tasks.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, Optional, Tuple
 from uuid import UUID
 
 import aiohttp
-from arq import ArqRedis, create_pool
+from arq import ArqRedis, create_pool, cron
 from arq.connections import RedisSettings, log_redis_info
 from fastapi import HTTPException
 from loguru import logger as log
@@ -54,8 +54,6 @@ from app.images.image_classification import ImageClassifier
 from app.jaxa.upload_dem import download_and_upload_dem
 from app.images.image_processing import (
     extract_and_upload_odm_assets,
-    fetch_scaleodm_task_info,
-    remove_scaleodm_task,
 )
 from app.arq.cloudnative import (
     generate_3d_tiles,
@@ -1321,227 +1319,6 @@ async def process_imported_odm_assets(
             shutil.rmtree(temp_dir)
 
 
-async def _persist_odm_failure(
-    ctx: Dict[Any, Any],
-    project_uuid: UUID,
-    task_uuid: Optional[UUID],
-    state: Optional[State],
-    error_message: str,
-) -> None:
-    """Persist failure state for either task-level or project-level ODM processing."""
-    try:
-        db_pool = ctx.get("db_pool")
-        if not db_pool:
-            return
-        async with db_pool.connection() as conn:
-            if task_uuid and state:
-                await task_logic.update_task_state_system(
-                    db=conn,
-                    project_id=project_uuid,
-                    task_id=task_uuid,
-                    comment=f"Image processing failed: {error_message}",
-                    initial_state=state,
-                    final_state=State.IMAGE_PROCESSING_FAILED,
-                    updated_at=timestamp(),
-                )
-            elif task_uuid and not state:
-                log.warning(
-                    f"Cannot persist task-level failure for {task_uuid} "
-                    "(no initial state provided)",
-                )
-            else:
-                # Project-level processing: mark the project as FAILED.
-                await project_logic.update_processing_status(
-                    conn, project_uuid, ImageProcessingStatus.FAILED
-                )
-            await conn.commit()
-    except Exception as state_err:
-        target = task_uuid or project_uuid
-        log.error(f"Failed to persist ODM failure state for {target}: {state_err}")
-
-
-async def finalize_scaleodm_task(
-    ctx: Dict[Any, Any],
-    *,
-    scaleodm_url: str,
-    dtm_project_id: str,
-    odm_task_uuid: Optional[str],
-    odm_status_code: int,
-    state_name: Optional[str] = None,
-    message: Optional[str] = None,
-    dtm_task_id: Optional[str] = None,
-    **_kwargs: Any,
-) -> Dict[str, Any]:
-    """Finalize a ScaleODM task after a webhook (or reconciler) reports terminal status.
-
-    On task status 40 (completed), pulls odm_orthophoto.tif from the ScaleODM
-    output prefix, reprojects it to EPSG:3857 COG for map display, overwrites
-    the task-level key, sets ``assets_url`` and transitions to
-    IMAGE_PROCESSING_FINISHED. Project-level status 40 leaves the native ODM
-    orthophoto untouched and marks processing successful. On 30 (failed)
-    records an error message and marks the task/project failed. When a
-    ScaleODM UUID is known, best-effort POST /task/remove cleans up the
-    ScaleODM row.
-    """
-    job_id = ctx.get("job_id", "unknown")
-    log.info(
-        "Starting finalize_scaleodm_task (Job ID: {}): project={} odm_task={} code={}",
-        job_id,
-        dtm_project_id,
-        odm_task_uuid,
-        odm_status_code,
-    )
-
-    # Distributed lock: belt-and-suspenders alongside arq's _job_id dedup.
-    # Lock key is intentionally identical to the legacy one so a webhook
-    # and a reconciliation pass can never race even across deploy boundaries.
-    lock_target = dtm_task_id or dtm_project_id
-    lock_key = f"lock:odm-assets:{lock_target}"
-    redis = ctx.get("redis")
-    lock_acquired = False
-    if redis:
-        lock_acquired = await redis.set(
-            lock_key,
-            job_id,
-            nx=True,
-            ex=21600,  # 6 hours - must exceed worst-case reprojection
-        )
-        if not lock_acquired:
-            log.warning(
-                "Skipping finalize_scaleodm_task for {}: "
-                "another job already holds the lock",
-                lock_target,
-            )
-            return {"status": "skipped", "reason": "concurrent_lock"}
-
-    project_uuid = UUID(dtm_project_id)
-    task_uuid = UUID(dtm_task_id) if dtm_task_id else None
-    state = State[state_name] if state_name else None
-    db_pool = ctx.get("db_pool")
-
-    try:
-        # Pre-flight: skip if the task is no longer in the expected state
-        # (a previous webhook + reconciler may have already finalized).
-        if task_uuid and state and db_pool:
-            try:
-                async with db_pool.connection() as conn:
-                    current = await task_logic.get_task_state(
-                        conn, project_uuid, task_uuid
-                    )
-                    current_state = current.get("state") if current else None
-                    if current_state and current_state != state.name:
-                        log.warning(
-                            "Skipping finalize for task {}: expected state {} "
-                            "but found {} (already handled)",
-                            task_uuid,
-                            state.name,
-                            current_state,
-                        )
-                        return {"status": "skipped", "reason": "state_mismatch"}
-            except Exception as e:
-                log.warning(
-                    "Could not verify task state before finalizing (continuing): {}",
-                    e,
-                )
-
-        if int(odm_status_code) == 40:
-            # ScaleODM is submitted with the ``cog`` option so the task
-            # orthophoto is already a Cloud-Optimized GeoTIFF with internal
-            # overviews. No backend reproject step is needed - the in-app
-            # viewer reads the file directly via HTTP range requests.
-            task_segment = f"{task_uuid}/" if task_uuid else ""
-            assets_prefix = f"projects/{dtm_project_id}/{task_segment}odm/"
-
-            if db_pool:
-                async with db_pool.connection() as conn:
-                    if task_uuid and state:
-                        await task_logic.update_task_state_system(
-                            db=conn,
-                            project_id=project_uuid,
-                            task_id=task_uuid,
-                            comment=message,
-                            initial_state=state,
-                            final_state=State.IMAGE_PROCESSING_FINISHED,
-                            updated_at=timestamp(),
-                        )
-                        await project_logic.update_task_field(
-                            conn,
-                            project_uuid,
-                            task_uuid,
-                            "assets_url",
-                            assets_prefix,
-                        )
-                        log.info(
-                            f"Task {task_uuid} state updated to IMAGE_PROCESSING_FINISHED."
-                        )
-                    elif not task_uuid:
-                        await project_logic.update_processing_status(
-                            conn, project_uuid, ImageProcessingStatus.SUCCESS
-                        )
-                        # Persist the streaming download URL so future requests
-                        # don't need to re-probe S3 to determine availability.
-                        odm_assets_url = f"{settings.API_PREFIX}/projects/odm/export/{dtm_project_id}/"
-                        await conn.execute(
-                            "UPDATE projects SET output_odm_assets_url = %(url)s"
-                            " WHERE id = %(pid)s",
-                            {"url": odm_assets_url, "pid": project_uuid},
-                        )
-                        log.info(f"Project {project_uuid} status updated to SUCCESS.")
-                    await conn.commit()
-
-            # Cloudnative derivatives are user-triggered now: the project UI
-            # exposes "Convert 2D / 3D to View" buttons that hit the trigger
-            # endpoints in project_routes.py. We deliberately do NOT enqueue
-            # here - many projects never need the web-optimized assets, and
-            # running the jobs for every successful project wasted compute
-            # for users on slow workers.
-
-            # drone-tm DB is now committed - safe to remove the ScaleODM record
-            # when we know its UUID. The call is best-effort; a 404 is ignored.
-            if odm_task_uuid:
-                await remove_scaleodm_task(
-                    scaleodm_url=scaleodm_url, odm_task_uuid=odm_task_uuid
-                )
-            return {"status": "completed", "project_id": dtm_project_id}
-
-        if int(odm_status_code) == 30:
-            error_detail = message or "ODM processing failed"
-            if odm_task_uuid:
-                info = await fetch_scaleodm_task_info(
-                    scaleodm_url=scaleodm_url, odm_task_uuid=odm_task_uuid
-                )
-                if info and isinstance(info, dict):
-                    err = info.get("errorMessage") or info.get("error")
-                    if err:
-                        error_detail = str(err)
-
-            # _persist_odm_failure commits the failure state in drone-tm DB.
-            await _persist_odm_failure(
-                ctx, project_uuid, task_uuid, state, error_detail
-            )
-
-            # DB committed - remove the ScaleODM record when we know its UUID.
-            if odm_task_uuid:
-                await remove_scaleodm_task(
-                    scaleodm_url=scaleodm_url, odm_task_uuid=odm_task_uuid
-                )
-            return {
-                "status": "failed",
-                "reason": "odm_status_30",
-                "project_id": dtm_project_id,
-            }
-
-        log.warning(
-            "finalize_scaleodm_task called with unexpected status code {} "
-            "(expected 30 or 40); skipping",
-            odm_status_code,
-        )
-        return {"status": "skipped", "reason": "unexpected_status_code"}
-    finally:
-        if redis and lock_acquired:
-            await redis.delete(lock_key)
-
-
 def _normalize_s3_endpoint(endpoint: str) -> str:
     """Return a base URL (scheme + host) for the S3-compatible endpoint."""
     endpoint = endpoint.strip().rstrip("/")
@@ -1929,6 +1706,96 @@ async def create_project_from_imagery_exif(
     }
 
 
+async def reconcile_inflight_odm_tasks(ctx: Dict[Any, Any]) -> Dict[str, Any]:
+    """Cron backstop for anything the webhook and page-open paths miss.
+
+    Reconciles only in-flight runs (non-null odm_task_uuid, set on submit and
+    cleared on terminal), so it never scans processing history.
+    """
+    db_pool = ctx.get("db_pool")
+    if not db_pool:
+        log.warning("reconcile_inflight_odm_tasks: no db_pool; skipping")
+        return {"status": "skipped", "reason": "no_db_pool"}
+
+    async with db_pool.connection() as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                """
+                SELECT p.id
+                FROM projects p
+                WHERE (
+                        p.image_processing_status = %(processing)s
+                        AND p.odm_task_uuid IS NOT NULL
+                      )
+                   OR EXISTS (
+                        SELECT 1 FROM tasks t
+                        WHERE t.project_id = p.id
+                          AND t.odm_task_uuid IS NOT NULL
+                      );
+                """,
+                {"processing": ImageProcessingStatus.PROCESSING.name},
+            )
+            projects = await cur.fetchall()
+
+    reconciled = 0
+    for proj in projects:
+        project_id = proj["id"]
+        try:
+            async with db_pool.connection() as conn:
+                await project_logic.reconcile_project_processing(conn, project_id)
+            reconciled += 1
+        except Exception as e:
+            log.warning(
+                f"reconcile_inflight_odm_tasks: project {project_id} failed: {e}"
+            )
+
+    log.info(
+        f"reconcile_inflight_odm_tasks: swept {len(projects)} in-flight project(s)"
+    )
+    return {"in_flight": len(projects), "reconciled": reconciled}
+
+
+async def reconcile_odm_by_uuid(
+    ctx: Dict[Any, Any], odm_task_uuid: str
+) -> Dict[str, Any]:
+    """Reconcile the project owning an ODM task UUID (enqueued by the webhook).
+
+    The webhook is an untrusted trigger: its payload status is ignored and the
+    truth is re-derived by reconcile_project_processing.
+    """
+    db_pool = ctx.get("db_pool")
+    if not db_pool or not odm_task_uuid:
+        return {"status": "skipped"}
+
+    async with db_pool.connection() as conn:
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                """
+                SELECT p.id AS project_id
+                FROM projects p
+                WHERE p.odm_task_uuid = %(uuid)s
+                UNION
+                SELECT t.project_id AS project_id
+                FROM tasks t
+                WHERE t.odm_task_uuid = %(uuid)s
+                LIMIT 1;
+                """,
+                {"uuid": odm_task_uuid},
+            )
+            row = await cur.fetchone()
+
+    if not row:
+        log.info(f"reconcile_odm_by_uuid: no project for odm uuid {odm_task_uuid}")
+        return {"status": "not_found", "odm_task_uuid": odm_task_uuid}
+
+    # Reconcile the whole owning project, not just this task.
+    project_id = row["project_id"]
+    async with db_pool.connection() as conn:
+        summary = await project_logic.reconcile_project_processing(conn, project_id)
+    log.info(f"reconcile_odm_by_uuid: reconciled project {project_id}")
+    return {"project_id": str(project_id), **summary}
+
+
 class WorkerSettings:
     """ARQ worker configuration"""
 
@@ -1947,10 +1814,16 @@ class WorkerSettings:
         download_and_upload_dem,
         generate_qfield_project,
         process_imported_odm_assets,
-        finalize_scaleodm_task,
         create_project_from_imagery_exif,
         generate_orthophoto_cog,
         generate_3d_tiles,
+        reconcile_inflight_odm_tasks,
+        reconcile_odm_by_uuid,
+    ]
+
+    # Backstop reconcile every 30 min (webhook and page-open do the fast path).
+    cron_jobs = [
+        cron(reconcile_inflight_odm_tasks, minute={0, 30}, run_at_startup=False),
     ]
 
     queue_name = "default_queue"

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -4,6 +4,7 @@ import base64
 import secrets
 from functools import lru_cache
 from typing import Annotated, Optional, Union
+from urllib.parse import quote
 
 import bcrypt
 from loguru import logger as log
@@ -203,6 +204,20 @@ class Settings(BaseSettings):
 
     # Internal backend URL for Docker-internal services (webhooks from ODM, etc.)
     BACKEND_URL_INTERNAL: str = "http://backend:8000"
+    # Optional shared secret for the ScaleODM webhook, checked against the
+    # ?token= query param.
+    SCALEODM_WEBHOOK_SECRET: Optional[str] = None
+
+    @computed_field
+    @property
+    def SCALEODM_WEBHOOK_URL(self) -> str:
+        """Callback URL passed to ScaleODM on submit. The secret rides as a
+        ?token= param because ScaleODM POSTs the stored URL verbatim."""
+        base = f"{self.BACKEND_URL_INTERNAL}{self.API_PREFIX}/integrations/scaleodm/webhook"
+        if self.SCALEODM_WEBHOOK_SECRET:
+            return f"{base}?token={quote(self.SCALEODM_WEBHOOK_SECRET, safe='')}"
+        return base
+
     # ODM (ScaleODM) API endpoint
     ODM_ENDPOINT: Optional[str] = "http://host.docker.internal:31100"
     # In-cluster S3 endpoint passed to ScaleODM workflow pods.

--- a/src/backend/app/images/image_processing.py
+++ b/src/backend/app/images/image_processing.py
@@ -42,12 +42,12 @@ async def submit_scaleodm_task(
     exclude_paths: Optional[list[str]] = None,
     s3_endpoint: Optional[str] = None,
     capacity_type: Optional[str] = None,
+    webhook: Optional[str] = None,
 ) -> str:
-    """Create a ScaleODM task via POST /task/new.
+    """Create a ScaleODM task via POST /task/new, returning the task UUID.
 
-    Returns the ScaleODM task UUID. Raises :class:`ScaleOdmSubmitError`
-    on a non-2xx response (with the server's ``error``/``errorMessage``
-    string when present).
+    Raises :class:`ScaleOdmSubmitError` on a non-2xx response. When ``webhook``
+    is set, ScaleODM calls it on terminal status.
     """
     body: dict[str, Any] = {
         "name": name,
@@ -65,6 +65,8 @@ async def submit_scaleodm_task(
         body["s3Endpoint"] = s3_endpoint
     if capacity_type:
         body["capacityType"] = capacity_type
+    if webhook:
+        body["webhook"] = webhook
 
     base = scaleodm_url.rstrip("/")
     url = f"{base}/task/new"
@@ -104,38 +106,19 @@ async def submit_scaleodm_task(
             return str(uuid_value)
 
 
-async def remove_scaleodm_task(*, scaleodm_url: str, odm_task_uuid: str) -> None:
-    """Best-effort POST /task/remove. Logs and swallows failures."""
-    base = scaleodm_url.rstrip("/")
-    url = f"{base}/task/remove"
-    try:
-        async with aiohttp.ClientSession(
-            timeout=aiohttp.ClientTimeout(total=SCALEODM_SUBMIT_TIMEOUT_SEC)
-        ) as session:
-            async with session.post(url, json={"uuid": odm_task_uuid}) as resp:
-                if resp.status >= 400:
-                    body = await resp.text()
-                    log.warning(
-                        "ScaleODM /task/remove returned HTTP {} for {}: {}",
-                        resp.status,
-                        odm_task_uuid,
-                        body[:200],
-                    )
-                    return
-        log.info(f"Removed ScaleODM task {odm_task_uuid}")
-    except Exception as e:
-        log.warning(f"Failed to remove ScaleODM task {odm_task_uuid}: {e}")
-
-
 async def fetch_scaleodm_task_info(
     *, scaleodm_url: str, odm_task_uuid: str
 ) -> Optional[dict[str, Any]]:
-    """Fetch /task/{uuid}/info from ScaleODM. Returns ``None`` on failure."""
+    """Fetch /task/{uuid}/info from ScaleODM. Returns ``None`` on failure.
+
+    Short timeout: reconcile calls these sequentially, so a slow one would stall
+    the loop.
+    """
     base = scaleodm_url.rstrip("/")
     url = f"{base}/task/{odm_task_uuid}/info"
     try:
         async with aiohttp.ClientSession(
-            timeout=aiohttp.ClientTimeout(total=15)
+            timeout=aiohttp.ClientTimeout(total=5)
         ) as session:
             async with session.get(url) as resp:
                 if resp.status != 200:

--- a/src/backend/app/projects/project_logic.py
+++ b/src/backend/app/projects/project_logic.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import tempfile
 import uuid
+from datetime import datetime, timezone
 from io import BytesIO
 from typing import Any, Dict, Optional
 
@@ -35,6 +36,7 @@ from app.models.enums import FinalOutput, ImageProcessingStatus, OAMUploadStatus
 from app.projects import project_schemas
 from app.images.image_processing import (
     ScaleOdmSubmitError,
+    fetch_scaleodm_task_info,
     submit_scaleodm_task,
 )
 from app.s3 import (
@@ -458,10 +460,16 @@ async def process_drone_images(
                 use_default_excludes=True,
                 exclude_paths=["*/thumbs/*"],
                 s3_endpoint=settings.SCALEODM_S3_ENDPOINT,
+                webhook=settings.SCALEODM_WEBHOOK_URL,
             )
 
             await update_task_field(
                 conn, project_id, task_id, "odm_task_uuid", odm_uuid
+            )
+            # Store the endpoint so reconcile queries the same server (per-task
+            # custom URLs).
+            await update_task_field(
+                conn, project_id, task_id, "odm_endpoint_used", scaleodm_endpoint
             )
             await conn.commit()
             log.info(f"Stored ScaleODM task UUID {odm_uuid} for task {task_id}")
@@ -517,13 +525,13 @@ async def process_drone_images(
 async def update_processing_status(
     db: Connection, project_id: uuid.UUID, status: ImageProcessingStatus
 ):
-    """Update the processing status in the database.
+    """Update the processing status.
 
-    On SUCCESS, clears odm_task_uuid and odm_endpoint_used so stale
-    metadata doesn't interfere with future reconciliation.
+    On a terminal status (SUCCESS or FAILED) also clears odm_task_uuid and
+    odm_endpoint_used, so the project leaves the in-flight set the cron sweeps.
     """
     log.debug(f"status = {status.name}")
-    if status == ImageProcessingStatus.SUCCESS:
+    if status in (ImageProcessingStatus.SUCCESS, ImageProcessingStatus.FAILED):
         await db.execute(
             """
             UPDATE projects
@@ -610,6 +618,7 @@ async def process_all_drone_images(
                 ],
                 s3_endpoint=settings.SCALEODM_S3_ENDPOINT,
                 capacity_type=capacity_type,
+                webhook=settings.SCALEODM_WEBHOOK_URL,
             )
 
             # Persist ODM metadata for reconciliation/recovery, then mark PROCESSING.
@@ -782,6 +791,25 @@ async def get_assets_info_bulk(
     return results
 
 
+async def _clear_task_odm_run(
+    db: Connection,
+    project_id: uuid.UUID,
+    task_id: uuid.UUID,
+    expected_odm_uuid: Optional[str],
+) -> None:
+    """Clear a task's odm metadata, but only if it still holds expected_odm_uuid
+    (so a rerun that reused the row is never cleared)."""
+    await db.execute(
+        """
+        UPDATE tasks
+        SET odm_task_uuid = NULL, odm_endpoint_used = NULL
+        WHERE id = %(tid)s AND project_id = %(pid)s
+          AND odm_task_uuid IS NOT DISTINCT FROM %(expected)s;
+        """,
+        {"tid": str(task_id), "pid": str(project_id), "expected": expected_odm_uuid},
+    )
+
+
 async def reconcile_finished_task_odm_outputs(
     db: Connection,
     project_id: uuid.UUID,
@@ -810,7 +838,7 @@ async def reconcile_finished_task_odm_outputs(
                 WHERE t.project_id = %(project_id)s
                 ORDER BY te.task_id, te.created_at DESC
             )
-            SELECT t.id, ls.created_at AS started_at
+            SELECT t.id, t.odm_task_uuid, ls.created_at AS started_at
             FROM tasks t
             JOIN latest_state ls ON ls.task_id = t.id
             WHERE t.project_id = %(project_id)s
@@ -865,6 +893,7 @@ async def reconcile_finished_task_odm_outputs(
             if ortho_naive < started_naive:
                 continue
 
+        # Only finalise if the run's UUID is unchanged (skip if a rerun replaced it).
         result = await task_logic.update_task_state_system(
             db=db,
             project_id=project_id,
@@ -873,6 +902,7 @@ async def reconcile_finished_task_odm_outputs(
             initial_state=State.IMAGE_PROCESSING_STARTED,
             final_state=State.IMAGE_PROCESSING_FINISHED,
             updated_at=timestamp(),
+            expected_odm_uuid=row.get("odm_task_uuid"),
         )
         if result is None:
             continue
@@ -884,6 +914,8 @@ async def reconcile_finished_task_odm_outputs(
             "assets_url",
             f"projects/{project_id}/{task_id}/odm/",
         )
+        # Clear (guarded on the run) so the task leaves the current run
+        await _clear_task_odm_run(db, project_id, task_id, row.get("odm_task_uuid"))
         reconciled_task_ids.append(str(task_id))
 
     if reconciled_task_ids:
@@ -903,8 +935,7 @@ async def reconcile_finished_project_odm_output(
     ODM orthophoto has landed in S3.
 
     Mirrors :func:`reconcile_finished_task_odm_outputs` but for whole-project
-    (``process_all_imagery``) runs. The state transition side-effects match
-    what ``finalize_scaleodm_task`` used to do:
+    (``process_all_imagery``) runs. The state transition side-effects are:
       * ``image_processing_status = SUCCESS``
       * ``odm_task_uuid`` / ``odm_endpoint_used`` cleared
       * ``output_odm_assets_url`` populated
@@ -919,7 +950,7 @@ async def reconcile_finished_project_odm_output(
     async with db.cursor(row_factory=dict_row) as cur:
         await cur.execute(
             """
-            SELECT image_processing_status, last_updated
+            SELECT image_processing_status, odm_task_uuid, last_updated
             FROM projects
             WHERE id = %(project_id)s;
             """,
@@ -959,19 +990,236 @@ async def reconcile_finished_project_odm_output(
         if ortho_naive < started_naive:
             return False
 
-    # Reuse update_processing_status so the SUCCESS-side-effects (clearing
-    # odm_task_uuid/odm_endpoint_used) stay in one place. Follow up with the
-    # output URL UPDATE, same pattern as finalize_scaleodm_task's project-
-    # level branch (see arq/tasks.py).
-    await update_processing_status(db, project_id, ImageProcessingStatus.SUCCESS)
+    # Finalise only if the run's UUID/status is unchanged (skip a concurrent rerun).
     odm_assets_url = f"{settings.API_PREFIX}/projects/odm/export/{project_id}/"
-    await db.execute(
-        "UPDATE projects SET output_odm_assets_url = %(url)s WHERE id = %(pid)s",
-        {"url": odm_assets_url, "pid": project_id},
-    )
+    async with db.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            """
+            UPDATE projects
+            SET image_processing_status = %(success)s,
+                odm_task_uuid = NULL,
+                odm_endpoint_used = NULL,
+                output_odm_assets_url = %(url)s
+            WHERE id = %(pid)s
+              AND image_processing_status = %(processing)s
+              AND odm_task_uuid IS NOT DISTINCT FROM %(expected)s
+            RETURNING id;
+            """,
+            {
+                "success": ImageProcessingStatus.SUCCESS.name,
+                "processing": ImageProcessingStatus.PROCESSING.name,
+                "expected": row.get("odm_task_uuid"),
+                "url": odm_assets_url,
+                "pid": project_id,
+            },
+        )
+        changed = await cur.fetchone()
     await db.commit()
+
+    if not changed:
+        return False
     log.info(f"Reconciled project {project_id} to SUCCESS from S3 output.")
     return True
+
+
+# Fail a run only after this long with no status from ScaleODM at all. Long
+# enough that no real job or transient outage reaches it.
+ODM_STUCK_TIMEOUT_SECONDS = 7 * 24 * 3600
+
+
+def _aware_utc(dt: datetime) -> datetime:
+    """Return dt as tz-aware UTC, treating a naive value (DB timestamps) as UTC."""
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+def _odm_failure_reason(
+    info: Optional[dict[str, Any]],
+    started_at: Optional[datetime],
+) -> Optional[str]:
+    """Return a failure message if a STARTED run should be failed, else None.
+
+    Fails only on an explicit terminal status; an unreachable ScaleODM (info is
+    None) is transient, not a failure (ScaleODM reports code 30 for a workflow
+    it can't find). /task/info nests status: {"status": {"code": 30, ...}}
+    (10 queued, 20 running, 30 failed, 40 completed, 50 canceled).
+    """
+    if info is not None:
+        status = info.get("status") or {}
+        code = int(status.get("code") or 0)
+        if code == 30:
+            return str(status.get("errorMessage") or "ODM processing failed.")
+        if code == 50:
+            return "Processing was canceled."
+        return None
+
+    # Unreachable/unknown: keep waiting until past the stuck timeout.
+    if started_at is not None:
+        age = (datetime.now(timezone.utc) - _aware_utc(started_at)).total_seconds()
+        if age >= ODM_STUCK_TIMEOUT_SECONDS:
+            return "Processing timed out; no status from ScaleODM."
+    return None
+
+
+async def reconcile_failed_task_odm_outputs(
+    db: Connection,
+    project_id: uuid.UUID,
+) -> dict[str, Any]:
+    """Fail STARTED tasks that ScaleODM reports as terminally failed.
+
+    Complements the S3 success check, which can't see failures (no output is
+    written). Each task is queried on its own stored endpoint. Clears the odm
+    metadata on failure so the task leaves the in-flight set.
+    """
+    async with db.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            """
+            WITH latest_state AS (
+                SELECT DISTINCT ON (te.task_id)
+                    te.task_id, te.state, te.created_at
+                FROM task_events te
+                JOIN tasks t ON t.id = te.task_id
+                WHERE t.project_id = %(project_id)s
+                ORDER BY te.task_id, te.created_at DESC
+            )
+            SELECT t.id, t.odm_task_uuid, t.odm_endpoint_used,
+                   ls.created_at AS started_at
+            FROM tasks t
+            JOIN latest_state ls ON ls.task_id = t.id
+            WHERE t.project_id = %(project_id)s
+              AND ls.state = 'IMAGE_PROCESSING_STARTED'
+              AND t.odm_task_uuid IS NOT NULL
+            ORDER BY t.project_task_index;
+            """,
+            {"project_id": project_id},
+        )
+        rows = await cur.fetchall()
+
+    failed_task_ids: list[str] = []
+    for row in rows:
+        task_id = row["id"]
+        info = await fetch_scaleodm_task_info(
+            scaleodm_url=resolve_scaleodm_url(row.get("odm_endpoint_used")),
+            odm_task_uuid=row["odm_task_uuid"],
+        )
+        reason = _odm_failure_reason(info, row.get("started_at"))
+        if reason is None:
+            continue
+
+        # Only fail if the run's UUID is unchanged (skip if a rerun replaced it).
+        result = await task_logic.update_task_state_system(
+            db=db,
+            project_id=project_id,
+            task_id=task_id,
+            comment=f"Image processing failed: {reason}",
+            initial_state=State.IMAGE_PROCESSING_STARTED,
+            final_state=State.IMAGE_PROCESSING_FAILED,
+            updated_at=timestamp(),
+            expected_odm_uuid=row["odm_task_uuid"],
+        )
+        if result is None:
+            continue
+        await _clear_task_odm_run(db, project_id, task_id, row["odm_task_uuid"])
+        failed_task_ids.append(str(task_id))
+
+    if failed_task_ids:
+        await db.commit()
+
+    return {
+        "checked": len(rows),
+        "failed": len(failed_task_ids),
+        "task_ids": failed_task_ids,
+    }
+
+
+async def reconcile_failed_project_odm_output(
+    db: Connection,
+    project_id: uuid.UUID,
+) -> bool:
+    """Project-level mirror of reconcile_failed_task_odm_outputs.
+
+    Returns True if the project was transitioned to FAILED.
+    """
+    async with db.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            """
+            SELECT image_processing_status, odm_task_uuid, odm_endpoint_used,
+                   last_updated
+            FROM projects
+            WHERE id = %(project_id)s;
+            """,
+            {"project_id": project_id},
+        )
+        row = await cur.fetchone()
+
+    if (
+        not row
+        or row.get("image_processing_status") != ImageProcessingStatus.PROCESSING.name
+        or not row.get("odm_task_uuid")
+    ):
+        return False
+
+    info = await fetch_scaleodm_task_info(
+        scaleodm_url=resolve_scaleodm_url(row.get("odm_endpoint_used")),
+        odm_task_uuid=row["odm_task_uuid"],
+    )
+    reason = _odm_failure_reason(info, row.get("last_updated"))
+    if reason is None:
+        return False
+
+    # Only fail if the run's UUID/status is unchanged (a rerun matches nothing).
+    async with db.cursor(row_factory=dict_row) as cur:
+        await cur.execute(
+            """
+            UPDATE projects
+            SET image_processing_status = %(failed)s,
+                odm_task_uuid = NULL,
+                odm_endpoint_used = NULL
+            WHERE id = %(project_id)s
+              AND odm_task_uuid = %(expected)s
+              AND image_processing_status = %(processing)s
+            RETURNING id;
+            """,
+            {
+                "failed": ImageProcessingStatus.FAILED.name,
+                "processing": ImageProcessingStatus.PROCESSING.name,
+                "expected": row["odm_task_uuid"],
+                "project_id": project_id,
+            },
+        )
+        changed = await cur.fetchone()
+    await db.commit()
+
+    if not changed:
+        return False
+    log.info(f"Reconciled project {project_id} to FAILED: {reason}")
+    return True
+
+
+def resolve_scaleodm_url(odm_endpoint_used: Optional[str]) -> str:
+    """Use the endpoint a run was submitted to, else the configured default."""
+    return odm_endpoint_used or settings.ODM_ENDPOINT
+
+
+async def reconcile_project_processing(
+    db: Connection,
+    project_id: uuid.UUID,
+) -> dict[str, Any]:
+    """Reconcile one project's ODM status: S3 output (success) first, then a
+    ScaleODM /task/info call (failure vs still running). Single entry point for
+    the /reconcile endpoint, page open, and the cron; idempotent.
+    """
+    task_success = await reconcile_finished_task_odm_outputs(db, project_id)
+    project_success = await reconcile_finished_project_odm_output(db, project_id)
+    task_failed = await reconcile_failed_task_odm_outputs(db, project_id)
+    project_failed = await reconcile_failed_project_odm_output(db, project_id)
+    return {
+        "checked": task_success["checked"],
+        "reconciled": task_success["reconciled"],
+        "task_ids": task_success["task_ids"],
+        "failed": task_failed["failed"],
+        "failed_task_ids": task_failed["task_ids"],
+        "project_finalised": project_success or project_failed,
+    }
 
 
 async def check_regulator_project(db: Connection, project_id: str, email: str):

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -758,20 +758,13 @@ async def reconcile_assets_info(
         project_schemas.DbProject, Depends(project_deps.get_project_by_id)
     ],
 ):
-    """Reconcile task-level ODM completion from deterministic S3 outputs.
-
-    Returns both the reconciliation summary AND the refreshed assets_info
-    payload so the client can seed its cache from a single call rather
-    than firing a follow-up GET /assets/{project_id}/.
-    """
-    summary = await project_logic.reconcile_finished_task_odm_outputs(db, project.id)
-    project_finalised = await project_logic.reconcile_finished_project_odm_output(
-        db, project.id
-    )
+    """Reconcile ODM status, then return the summary plus refreshed assets so
+    the client seeds its cache from one call (no follow-up GET /assets)."""
+    summary = await project_logic.reconcile_project_processing(db, project.id)
     tasks = await project_deps.get_tasks_by_project_id(project.id, db)
     task_ids = [t.get("id") for t in tasks]
     assets = await project_logic.get_assets_info_bulk(db, project.id, task_ids)
-    return {**summary, "project_finalised": project_finalised, "assets": assets}
+    return {**summary, "assets": assets}
 
 
 @router.post("/{project_id}/upload-to-oam", tags=["OAM"])

--- a/src/backend/app/public_routes.py
+++ b/src/backend/app/public_routes.py
@@ -1,9 +1,50 @@
-from fastapi import APIRouter, HTTPException, Query
+from typing import Optional
 
+from arq import ArqRedis
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from app.arq.tasks import get_redis_pool
+from app.config import settings
 from app.models.enums import HTTPStatus
 from app.s3 import maybe_presign_s3_key
 
 router = APIRouter(tags=["Public"])
+
+
+class ScaleOdmWebhookPayload(BaseModel):
+    """Body ScaleODM POSTs on a terminal status transition."""
+
+    uuid: str
+    statusCode: Optional[int] = None
+
+
+@router.post("/integrations/scaleodm/webhook", tags=["Integrations"])
+async def scaleodm_webhook(
+    payload: ScaleOdmWebhookPayload,
+    redis_pool: ArqRedis = Depends(get_redis_pool),
+    token: Optional[str] = Query(None),
+):
+    """Untrusted trigger from ScaleODM: enqueue a reconcile for one task.
+
+    Only the uuid is used; the reconcile re-derives status itself. The optional
+    token just cuts noise, so correctness never depends on it.
+    """
+    secret = settings.SCALEODM_WEBHOOK_SECRET
+    if secret and token != secret:
+        raise HTTPException(
+            status_code=HTTPStatus.UNAUTHORIZED,
+            detail="Invalid webhook token",
+        )
+
+    # _job_id keyed on the uuid coalesces duplicate pokes for the same task.
+    await redis_pool.enqueue_job(
+        "reconcile_odm_by_uuid",
+        payload.uuid,
+        _job_id=f"odm-reconcile:{payload.uuid}",
+        _queue_name="default_queue",
+    )
+    return {"status": "accepted", "uuid": payload.uuid}
 
 
 @router.get("/public/presigned-url")

--- a/src/backend/app/tasks/task_logic.py
+++ b/src/backend/app/tasks/task_logic.py
@@ -379,6 +379,7 @@ async def update_task_state_system(
     initial_state: State,
     final_state: State,
     updated_at: datetime,
+    expected_odm_uuid: str | None = None,
 ):
     """Update task state without user ownership check.
 
@@ -387,6 +388,10 @@ async def update_task_state_system(
 
     The comment is sanitized to redact sensitive values (e.g. tokens
     embedded in NodeODM URLs) before persisting to the database.
+
+    When expected_odm_uuid is given, the transition also requires the task to
+    still hold that odm_task_uuid (so a rerun that reused the row is not
+    affected).
     """
     comment = sanitize_sensitive_text(comment)
     async with db.cursor(row_factory=dict_row) as cur:
@@ -400,9 +405,14 @@ async def update_task_state_system(
                 LIMIT 1
             ),
             can_modify AS (
-                SELECT *
+                SELECT last.*
                 FROM last
-                WHERE state = %(initial_state)s
+                JOIN tasks t ON t.id = %(task_id)s AND t.project_id = %(project_id)s
+                WHERE last.state = %(initial_state)s
+                  AND (
+                      %(expected_odm_uuid)s::text IS NULL
+                      OR t.odm_task_uuid = %(expected_odm_uuid)s
+                  )
             )
             INSERT INTO task_events(event_id, project_id, task_id, user_id, state, comment, updated_at, created_at)
             SELECT gen_random_uuid(), project_id, task_id, user_id, %(final_state)s, %(comment)s, %(updated_at)s, now()
@@ -416,6 +426,7 @@ async def update_task_state_system(
                 "initial_state": initial_state.name,
                 "final_state": final_state.name,
                 "updated_at": updated_at,
+                "expected_odm_uuid": expected_odm_uuid,
             },
         )
         result = await cur.fetchone()

--- a/src/backend/tests/test_project_processing.py
+++ b/src/backend/tests/test_project_processing.py
@@ -535,10 +535,14 @@ async def test_reconcile_finished_project_odm_output_marks_success(monkeypatch):
     project_id = uuid.uuid4()
     started_at = datetime(2026, 1, 1, 12, 0, 0)
     ortho_mtime = started_at + timedelta(minutes=30)
+    # Same row backs the initial SELECT and the guarded UPDATE's RETURNING, so
+    # the UUID/status-guarded write "matches".
     conn = _FakeConn(
         cursor_fetchone={
             "image_processing_status": ImageProcessingStatus.PROCESSING.name,
+            "odm_task_uuid": "odm-proj-1",
             "last_updated": started_at,
+            "id": project_id,
         }
     )
 
@@ -553,15 +557,7 @@ async def test_reconcile_finished_project_odm_output_marks_success(monkeypatch):
     result = await project_logic.reconcile_finished_project_odm_output(conn, project_id)
 
     assert result is True
-    # Two commits: one from update_processing_status, one after the URL UPDATE.
-    assert conn.commit_calls == 2
-    # First UPDATE flips status to SUCCESS and clears odm_task_uuid/odm_endpoint_used
-    # (via update_processing_status); second sets output_odm_assets_url.
-    assert any(
-        "image_processing_status" in q["query"] and "odm_task_uuid = NULL" in q["query"]
-        for q in conn.executed
-    )
-    assert any("output_odm_assets_url" in q["query"] for q in conn.executed)
+    assert conn.commit_calls >= 1
 
 
 @pytest.mark.asyncio
@@ -648,280 +644,181 @@ async def test_reconcile_finished_project_odm_output_ignores_stale_ortho(monkeyp
     assert conn.commit_calls == 0
 
 
-# ── finalize_scaleodm_task ────────────────────────────────────────────────────
+# ── failure reconciliation via ScaleODM /task/info ───────────────────────────
+
+
+def test_odm_failure_reason_maps_status_codes():
+    old = datetime.now(timezone.utc) - timedelta(
+        seconds=project_logic.ODM_STUCK_TIMEOUT_SECONDS + 60
+    )
+    # Terminal failure codes produce a message; running/queued/completed don't.
+    assert (
+        project_logic._odm_failure_reason(
+            {"status": {"code": 30, "errorMessage": "boom"}}, None
+        )
+        == "boom"
+    )
+    assert (
+        project_logic._odm_failure_reason({"status": {"code": 50}}, None)
+        == "Processing was canceled."
+    )
+    assert project_logic._odm_failure_reason({"status": {"code": 20}}, None) is None
+    assert project_logic._odm_failure_reason({"status": {"code": 40}}, None) is None
+    # A long-running job is trusted: "running" never fails, even when old.
+    assert project_logic._odm_failure_reason({"status": {"code": 20}}, old) is None
+
+
+def test_odm_failure_reason_unreachable_is_transient():
+    recent = datetime.now(timezone.utc)
+    old = datetime.now(timezone.utc) - timedelta(
+        seconds=project_logic.ODM_STUCK_TIMEOUT_SECONDS + 60
+    )
+    # Unreachable ScaleODM must not fail a healthy run; only the far
+    # stuck-timeout backstop eventually gives up.
+    assert project_logic._odm_failure_reason(None, recent) is None
+    assert project_logic._odm_failure_reason(None, old) is not None
 
 
 @pytest.mark.asyncio
-async def test_finalize_scaleodm_task_completes_task_and_removes_odm_row(monkeypatch):
+async def test_reconcile_failed_task_odm_outputs_marks_failed(monkeypatch):
     project_id = uuid.uuid4()
     task_id = uuid.uuid4()
-    conn = _FakeConn()
-    ctx = {"job_id": "fin-1", "db_pool": _FakePool(conn), "redis": None}
+    conn = _FakeConn(
+        cursor_fetchall=[
+            {
+                "id": task_id,
+                "odm_task_uuid": "odm-1",
+                "odm_endpoint_used": None,
+                "started_at": datetime.now(timezone.utc),
+            }
+        ]
+    )
     state_calls = []
-    field_calls = []
-    remove_calls = []
-
-    async def fake_update_task_state_system(**kwargs):
-        state_calls.append(kwargs)
-        return {"ok": True}
-
-    async def fake_update_task_field(db, pid, tid, column, value):
-        field_calls.append({"column": column, "value": value})
-
-    async def fake_get_task_state(db, pid, tid):
-        return {"state": State.IMAGE_PROCESSING_STARTED.name}
-
-    async def fake_remove(*, scaleodm_url, odm_task_uuid):
-        remove_calls.append({"url": scaleodm_url, "uuid": odm_task_uuid})
-
-    monkeypatch.setattr(arq_tasks, "remove_scaleodm_task", fake_remove)
-    monkeypatch.setattr(
-        arq_tasks.task_logic, "update_task_state_system", fake_update_task_state_system
-    )
-    monkeypatch.setattr(arq_tasks.task_logic, "get_task_state", fake_get_task_state)
-    monkeypatch.setattr(
-        arq_tasks.project_logic, "update_task_field", fake_update_task_field
-    )
-
-    result = await arq_tasks.finalize_scaleodm_task(
-        ctx,
-        scaleodm_url="http://scaleodm",
-        dtm_project_id=str(project_id),
-        odm_task_uuid="odm-uuid-1",
-        odm_status_code=40,
-        state_name=State.IMAGE_PROCESSING_STARTED.name,
-        message="Task completed.",
-        dtm_task_id=str(task_id),
-    )
-
-    assert result["status"] == "completed"
-    assert state_calls[0]["final_state"] == State.IMAGE_PROCESSING_FINISHED
-    assert field_calls == [
-        {"column": "assets_url", "value": f"projects/{project_id}/{task_id}/odm/"}
-    ]
-    assert remove_calls == [{"url": "http://scaleodm", "uuid": "odm-uuid-1"}]
-
-
-@pytest.mark.asyncio
-async def test_finalize_scaleodm_task_skips_remove_when_odm_uuid_unknown(monkeypatch):
-    project_id = uuid.uuid4()
-    task_id = uuid.uuid4()
-    conn = _FakeConn()
-    ctx = {
-        "job_id": "fin-orphan",
-        "db_pool": _FakePool(conn),
-        "redis": None,
-    }
-    state_calls = []
-    field_calls = []
-
-    async def fake_update_task_state_system(**kwargs):
-        state_calls.append(kwargs)
-        return {"ok": True}
-
-    async def fake_update_task_field(db, pid, tid, column, value):
-        field_calls.append({"column": column, "value": value})
-
-    async def fake_get_task_state(db, pid, tid):
-        return {"state": State.IMAGE_PROCESSING_STARTED.name}
-
-    async def fake_remove(*args, **kwargs):
-        raise AssertionError("remove_scaleodm_task should not be called")
-
-    monkeypatch.setattr(arq_tasks, "remove_scaleodm_task", fake_remove)
-    monkeypatch.setattr(arq_tasks.task_logic, "get_task_state", fake_get_task_state)
-    monkeypatch.setattr(
-        arq_tasks.task_logic, "update_task_state_system", fake_update_task_state_system
-    )
-    monkeypatch.setattr(
-        arq_tasks.project_logic, "update_task_field", fake_update_task_field
-    )
-
-    result = await arq_tasks.finalize_scaleodm_task(
-        ctx,
-        scaleodm_url="http://scaleodm",
-        dtm_project_id=str(project_id),
-        odm_task_uuid=None,
-        odm_status_code=40,
-        state_name=State.IMAGE_PROCESSING_STARTED.name,
-        message="Task completed.",
-        dtm_task_id=str(task_id),
-    )
-
-    assert result["status"] == "completed"
-    assert state_calls[0]["final_state"] == State.IMAGE_PROCESSING_FINISHED
-    assert field_calls == [
-        {"column": "assets_url", "value": f"projects/{project_id}/{task_id}/odm/"}
-    ]
-
-
-@pytest.mark.asyncio
-async def test_finalize_scaleodm_task_skips_when_state_already_changed(monkeypatch):
-    project_id = uuid.uuid4()
-    task_id = uuid.uuid4()
-    conn = _FakeConn()
-    ctx = {"job_id": "fin-2", "db_pool": _FakePool(conn), "redis": None}
-    state_calls = []
-
-    async def fake_get_task_state(db, pid, tid):
-        # Different from expected: someone else already finalized.
-        return {"state": State.IMAGE_PROCESSING_FINISHED.name}
-
-    async def fake_update_task_state_system(**kwargs):
-        state_calls.append(kwargs)
-        return {"ok": True}
-
-    monkeypatch.setattr(arq_tasks.task_logic, "get_task_state", fake_get_task_state)
-    monkeypatch.setattr(
-        arq_tasks.task_logic, "update_task_state_system", fake_update_task_state_system
-    )
-
-    result = await arq_tasks.finalize_scaleodm_task(
-        ctx,
-        scaleodm_url="http://scaleodm",
-        dtm_project_id=str(project_id),
-        odm_task_uuid="odm-uuid-2",
-        odm_status_code=40,
-        state_name=State.IMAGE_PROCESSING_STARTED.name,
-        message="Task completed.",
-        dtm_task_id=str(task_id),
-    )
-
-    assert result["status"] == "skipped"
-    assert state_calls == []
-
-
-@pytest.mark.asyncio
-async def test_finalize_scaleodm_task_pulls_error_message_on_status_30(monkeypatch):
-    project_id = uuid.uuid4()
-    task_id = uuid.uuid4()
-    conn = _FakeConn()
-    ctx = {"job_id": "fin-3", "job_try": 1, "db_pool": _FakePool(conn), "redis": None}
-    state_calls = []
-    remove_calls = []
-
-    async def fake_get_task_state(db, pid, tid):
-        return {"state": State.IMAGE_PROCESSING_STARTED.name}
-
-    async def fake_update_task_state_system(**kwargs):
-        state_calls.append(kwargs)
-        return {"ok": True}
 
     async def fake_fetch_info(*, scaleodm_url, odm_task_uuid):
-        return {"errorMessage": "ODM exited with code 1"}
+        return {"status": {"code": 30, "errorMessage": "images did not align"}}
 
-    async def fake_remove(*, scaleodm_url, odm_task_uuid):
-        remove_calls.append(odm_task_uuid)
+    async def fake_update_task_state_system(**kwargs):
+        state_calls.append(kwargs)
+        return {"ok": True}
 
-    monkeypatch.setattr(arq_tasks, "fetch_scaleodm_task_info", fake_fetch_info)
-    monkeypatch.setattr(arq_tasks, "remove_scaleodm_task", fake_remove)
-    monkeypatch.setattr(arq_tasks.task_logic, "get_task_state", fake_get_task_state)
+    monkeypatch.setattr(project_logic, "fetch_scaleodm_task_info", fake_fetch_info)
     monkeypatch.setattr(
-        arq_tasks.task_logic, "update_task_state_system", fake_update_task_state_system
+        project_logic.task_logic,
+        "update_task_state_system",
+        fake_update_task_state_system,
     )
 
-    result = await arq_tasks.finalize_scaleodm_task(
-        ctx,
-        scaleodm_url="http://scaleodm",
-        dtm_project_id=str(project_id),
-        odm_task_uuid="odm-uuid-3",
-        odm_status_code=30,
-        state_name=State.IMAGE_PROCESSING_STARTED.name,
-        message="Image processing failed.",
-        dtm_task_id=str(task_id),
-    )
+    result = await project_logic.reconcile_failed_task_odm_outputs(conn, project_id)
 
-    assert result["status"] == "failed"
-    assert state_calls
+    assert result == {"checked": 1, "failed": 1, "task_ids": [str(task_id)]}
     assert state_calls[0]["final_state"] == State.IMAGE_PROCESSING_FAILED
-    assert "ODM exited with code 1" in state_calls[0]["comment"]
-    assert remove_calls == ["odm-uuid-3"]
+    assert "images did not align" in state_calls[0]["comment"]
+    # Compare-and-set on the run: the transition is guarded by the UUID we read.
+    assert state_calls[0]["expected_odm_uuid"] == "odm-1"
+    # In-flight invariant: the clear is guarded on that same UUID.
+    assert any(
+        "odm_task_uuid = NULL" in q["query"] and q["params"].get("expected") == "odm-1"
+        for q in conn.executed
+    )
 
 
 @pytest.mark.asyncio
-async def test_finalize_scaleodm_task_project_level_completion(monkeypatch):
+async def test_reconcile_failed_task_odm_outputs_leaves_running(monkeypatch):
     project_id = uuid.uuid4()
-    conn = _FakeConn()
-    ctx = {
-        "job_id": "fin-proj",
-        "db_pool": _FakePool(conn),
-        "redis": None,
-    }
-    processing_status_calls = []
-
-    async def fake_update_processing_status(db, pid, status):
-        processing_status_calls.append({"project_id": pid, "status": status})
-
-    async def fake_remove(*args, **kwargs):
-        return None
-
-    monkeypatch.setattr(arq_tasks, "remove_scaleodm_task", fake_remove)
-    monkeypatch.setattr(
-        arq_tasks.project_logic,
-        "update_processing_status",
-        fake_update_processing_status,
+    task_id = uuid.uuid4()
+    conn = _FakeConn(
+        cursor_fetchall=[
+            {
+                "id": task_id,
+                "odm_task_uuid": "odm-1",
+                "odm_endpoint_used": None,
+                "started_at": datetime.now(timezone.utc),
+            }
+        ]
     )
-
-    result = await arq_tasks.finalize_scaleodm_task(
-        ctx,
-        scaleodm_url="http://scaleodm",
-        dtm_project_id=str(project_id),
-        odm_task_uuid="odm-uuid-proj",
-        odm_status_code=40,
-        state_name=None,
-        message="Task completed.",
-        dtm_task_id=None,
-    )
-
-    assert result["status"] == "completed"
-    assert processing_status_calls
-    assert processing_status_calls[0]["status"] == ImageProcessingStatus.SUCCESS
-    assert processing_status_calls[0]["project_id"] == project_id
-
-
-@pytest.mark.asyncio
-async def test_finalize_scaleodm_task_project_level_failure(monkeypatch):
-    project_id = uuid.uuid4()
-    conn = _FakeConn()
-    ctx = {
-        "job_id": "fin-proj-fail",
-        "job_try": 1,
-        "db_pool": _FakePool(conn),
-        "redis": None,
-    }
-    processing_status_calls = []
-
-    async def fake_update_processing_status(db, pid, status):
-        processing_status_calls.append({"project_id": pid, "status": status})
 
     async def fake_fetch_info(*, scaleodm_url, odm_task_uuid):
-        return None
+        return {"status": {"code": 20}}  # still running
 
-    async def fake_remove(*args, **kwargs):
-        return None
+    async def fail_update(**kwargs):
+        raise AssertionError("running task must not transition")
 
-    monkeypatch.setattr(arq_tasks, "fetch_scaleodm_task_info", fake_fetch_info)
-    monkeypatch.setattr(arq_tasks, "remove_scaleodm_task", fake_remove)
+    monkeypatch.setattr(project_logic, "fetch_scaleodm_task_info", fake_fetch_info)
     monkeypatch.setattr(
-        arq_tasks.project_logic,
-        "update_processing_status",
-        fake_update_processing_status,
+        project_logic.task_logic, "update_task_state_system", fail_update
     )
 
-    result = await arq_tasks.finalize_scaleodm_task(
-        ctx,
-        scaleodm_url="http://scaleodm",
-        dtm_project_id=str(project_id),
-        odm_task_uuid="odm-uuid-proj-fail",
-        odm_status_code=30,
-        state_name=None,
-        message="Image processing failed.",
-        dtm_task_id=None,
+    result = await project_logic.reconcile_failed_task_odm_outputs(conn, project_id)
+
+    assert result == {"checked": 1, "failed": 0, "task_ids": []}
+    assert conn.commit_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_reconcile_failed_project_odm_output_marks_failed(monkeypatch):
+    project_id = uuid.uuid4()
+    # Same row is returned for the initial SELECT and the guarded UPDATE's
+    # RETURNING (so the UUID/status-guarded write "matches").
+    conn = _FakeConn(
+        cursor_fetchone={
+            "image_processing_status": ImageProcessingStatus.PROCESSING.name,
+            "odm_task_uuid": "odm-1",
+            "odm_endpoint_used": None,
+            "last_updated": datetime.now(timezone.utc),
+            "id": project_id,
+        }
     )
 
-    assert result["status"] == "failed"
-    assert processing_status_calls
-    assert processing_status_calls[0]["status"] == ImageProcessingStatus.FAILED
+    async def fake_fetch_info(*, scaleodm_url, odm_task_uuid):
+        return {"status": {"code": 30, "errorMessage": "not enough images"}}
+
+    monkeypatch.setattr(project_logic, "fetch_scaleodm_task_info", fake_fetch_info)
+
+    result = await project_logic.reconcile_failed_project_odm_output(conn, project_id)
+
+    assert result is True
+    assert conn.commit_calls >= 1
+
+
+# ── reconcile_odm_by_uuid (webhook enqueue target) ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reconcile_odm_by_uuid_resolves_and_reconciles(monkeypatch):
+    project_id = uuid.uuid4()
+    conn = _FakeConn(cursor_fetchone={"project_id": project_id})
+    ctx = {"db_pool": _FakePool(conn)}
+    calls = []
+
+    async def fake_reconcile(db, pid):
+        calls.append(pid)
+        return {
+            "checked": 0,
+            "reconciled": 0,
+            "task_ids": [],
+            "failed": 0,
+            "failed_task_ids": [],
+            "project_finalised": False,
+        }
+
+    monkeypatch.setattr(project_logic, "reconcile_project_processing", fake_reconcile)
+
+    result = await arq_tasks.reconcile_odm_by_uuid(ctx, "odm-uuid-1")
+
+    # Resolves to the owning project and reconciles it (endpoint resolved per run).
+    assert calls == [project_id]
+    assert result["project_id"] == str(project_id)
+
+
+@pytest.mark.asyncio
+async def test_reconcile_odm_by_uuid_not_found():
+    conn = _FakeConn(cursor_fetchone=None)
+    ctx = {"db_pool": _FakePool(conn)}
+
+    result = await arq_tasks.reconcile_odm_by_uuid(ctx, "missing-uuid")
+
+    assert result["status"] == "not_found"
 
 
 # ── move_task_images_for_processing (unchanged behaviour, kept for coverage) ──

--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -948,6 +948,7 @@
   "processing_dialog_no_imagery_available": "No tasks have imagery available for processing. Upload imagery first.",
   "processing_dialog_final_submitting": "Final processing is being submitted...",
   "processing_dialog_final_in_progress": "Final processing is in progress. Check the queue for details.",
+  "processing_dialog_final_failed": "Final processing failed. Review the imagery in the Verify step and try again.",
   "processing_dialog_start_final_processing": "Start Final Processing",
   "processing_dialog_final_started_success": "Final processing started - this may take a long time.",
   "processing_dialog_final_start_failed": "Failed to start final processing",

--- a/src/frontend/messages/es.json
+++ b/src/frontend/messages/es.json
@@ -946,6 +946,7 @@
   "processing_dialog_no_imagery_available": "Ninguna tarea tiene imágenes disponibles para procesar. Sube imágenes primero.",
   "processing_dialog_final_submitting": "Se está enviando el procesamiento final...",
   "processing_dialog_final_in_progress": "El procesamiento final está en curso. Consulta la cola para más detalles.",
+  "processing_dialog_final_failed": "El procesamiento final falló. Revisa las imágenes en el paso de Verificación e inténtalo de nuevo.",
   "processing_dialog_start_final_processing": "Iniciar procesamiento final",
   "processing_dialog_final_started_success": "Procesamiento final iniciado: esto puede tardar bastante.",
   "processing_dialog_final_start_failed": "No se pudo iniciar el procesamiento final",

--- a/src/frontend/messages/id.json
+++ b/src/frontend/messages/id.json
@@ -946,6 +946,7 @@
   "processing_dialog_no_imagery_available": "Tidak ada tugas dengan citra yang tersedia untuk diproses. Unggah citra terlebih dahulu.",
   "processing_dialog_final_submitting": "Pemrosesan akhir sedang dikirim...",
   "processing_dialog_final_in_progress": "Pemrosesan akhir sedang berlangsung. Periksa antrean untuk detailnya.",
+  "processing_dialog_final_failed": "Pemrosesan akhir gagal. Periksa citra di langkah Verifikasi dan coba lagi.",
   "processing_dialog_start_final_processing": "Mulai Pemrosesan Akhir",
   "processing_dialog_final_started_success": "Pemrosesan akhir dimulai - ini mungkin memerlukan waktu lama.",
   "processing_dialog_final_start_failed": "Gagal memulai pemrosesan akhir",

--- a/src/frontend/src/components/IndividualProject/ModalContent/ProcessingStatusDialog.tsx
+++ b/src/frontend/src/components/IndividualProject/ModalContent/ProcessingStatusDialog.tsx
@@ -464,6 +464,14 @@ const ProcessingStatusDialog = () => {
     });
   }, [taskList]);
 
+  // Reconcile once on open so status is current without polling.
+  const reconciledForProject = useRef<string | null>(null);
+  useEffect(() => {
+    if (!projectId || reconciledForProject.current === projectId) return;
+    reconciledForProject.current = projectId;
+    handleRefreshProcessingStatus().catch(() => {});
+  }, [projectId, handleRefreshProcessingStatus]);
+
   const toggleSelectAll = useCallback(() => {
     if (selectedTasks.size === processableTasks.length) {
       setSelectedTasks(new Set());
@@ -910,6 +918,12 @@ const ProcessingStatusDialog = () => {
                   ? m.processing_dialog_final_submitting()
                   : m.processing_dialog_final_in_progress()}
               </span>
+            </div>
+          )}
+          {!isFinalProcessingRunning && projectDetail?.image_processing_status === "FAILED" && (
+            <div className="naxatw-flex naxatw-items-start naxatw-gap-2 naxatw-text-sm naxatw-text-red-700">
+              <Icon name="error" className="!naxatw-text-base" />
+              <span>{m.processing_dialog_final_failed()}</span>
             </div>
           )}
           <Button


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR

- An ongoing problem, where the current processing reconciliation against ScaleODM status was a bit flaky.
- Previously we tried to use the ScaleODM API only - this worked sometimes. But we also deleted the ScaleODM tasks when complete, so it was hard to debug / track down issues.
- Then we simplified and used the S3 bucket assets to confirm if the processing complete: worked fine for success status, but not for failed processing feedback.
- Now we have a cascading approach:
  1. Use the scaleodm webhook when processing completes. This is a first pass. Not perfect, but drone-tm should receive the status in most cases and update.
  2. User opens the processing dialog and we call endpoints to scan for latest status of processing jobs still ongoing.
  3. Refresh button on the processing dialog, clicked by user and we call endpoints to scan for latest status of processing jobs still ongoing.
  4. Background cron that runs every 30 minutes to pick up any stragglers that failed to reconcile, ensuring the state is always up to date with latest.

## AI Tool Usage

- [ ] No AI tools were used
- [x] AI tools were used (complete below)

**If AI-assisted:**

- Tool(s) used: Opus 4.8 LLM
- What was generated: plan, pinpoint some changes, write some sql
- What you reviewed and changed: I reviewed all the code and tweaked the generated stuff as needed

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/hotosm/drone-tm/blob/dev/CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](https://docs.hotosm.org/code-of-conduct)
- [x] PR is focused and small
- [x] Tests are included or updated
- [x] I understand all code in this PR and can answer questions about it
- [x] No secrets, credentials, or sensitive data are included
- [x] Commit messages are descriptive
- [x] Related docs and screenshots are updated

## [optional] What gif best describes this PR or how it makes you feel?
