### PR TITLE
feat(backend): clip DEM to buffered AOI before upload to reduce QFiel…

### DIFF
--- a/src/backend/app/jaxa/upload_dem.py
+++ b/src/backend/app/jaxa/upload_dem.py
@@ -143,7 +143,9 @@ def clip_dem_to_aoi(dem_path: str, buffered_aoi_geojson: dict) -> str:
     Returns:
         Path to the clipped raster.
     """
-    fd, cutline_path = tempfile.mkstemp(suffix=".geojson", prefix="cutline_")
+    fd, cutline_path = tempfile.mkstemp(
+        suffix=".geojson", prefix="cutline_", dir=Path(dem_path).parent
+    )
     os.close(fd)
     clipped_path = dem_path + ".clipped.tif"
 

--- a/src/backend/app/jaxa/upload_dem.py
+++ b/src/backend/app/jaxa/upload_dem.py
@@ -7,6 +7,7 @@ bridging that CrawlerRunner required.
 
 import asyncio
 import io
+import json
 import os
 import tempfile
 from pathlib import Path
@@ -18,6 +19,8 @@ from app.projects import project_logic
 from arq import ArqRedis
 from fastapi import UploadFile
 from loguru import logger as log
+from osgeo import gdal
+from psycopg.rows import dict_row
 from scrapy.crawler import AsyncCrawlerRunner
 from scrapy.utils.project import get_project_settings
 from scrapy.utils.reactor import _asyncio_reactor_path, install_reactor
@@ -127,6 +130,70 @@ async def upload_dem_file_s3_sync(tif_file_path: str, project_id: str):
         raise
 
 
+def clip_dem_to_aoi(dem_path: str, buffered_aoi_geojson: dict) -> str:
+    """Clip a DEM raster to a buffered AOI polygon using GDAL.
+
+    Writes the GeoJSON geometry to a temporary cutline file, then uses
+    gdal.Warp with cropToCutline to produce a clipped raster.
+
+    Args:
+        dem_path: Path to the input DEM GeoTIFF.
+        buffered_aoi_geojson: GeoJSON geometry dict of the buffered AOI.
+
+    Returns:
+        Path to the clipped raster.
+    """
+    fd, cutline_path = tempfile.mkstemp(suffix=".geojson", prefix="cutline_")
+    os.close(fd)
+    clipped_path = dem_path + ".clipped.tif"
+
+    try:
+        # Write the buffered AOI geometry to a temporary GeoJSON file.
+        # gdal.Warp requires a file path for cutlineDSName.
+        cutline_geojson = {
+            "type": "FeatureCollection",
+            "features": [
+                {"type": "Feature", "properties": {}, "geometry": buffered_aoi_geojson}
+            ],
+        }
+        with open(cutline_path, "w") as f:
+            json.dump(cutline_geojson, f)
+
+        result = gdal.Warp(
+            clipped_path,
+            dem_path,
+            cutlineDSName=cutline_path,
+            cropToCutline=True,
+            format="GTiff",
+        )
+        if result is None:
+            raise RuntimeError(
+                f"gdal.Warp returned None - clipping failed for {dem_path}"
+            )
+        result = None  # flush/close
+
+        # Replace the original file with the clipped version.
+        os.replace(clipped_path, dem_path)
+
+        return dem_path
+
+    except Exception:
+        # Clean up the clipped file if it was created but the rename failed.
+        if os.path.exists(clipped_path):
+            try:
+                os.remove(clipped_path)
+            except OSError:
+                pass
+        raise
+
+    finally:
+        if os.path.exists(cutline_path):
+            try:
+                os.remove(cutline_path)
+            except OSError:
+                pass
+
+
 async def enqueue_dem_download(
     geometry,
     project_id: str,
@@ -196,6 +263,46 @@ async def download_and_upload_dem(
         await _run_scrapy_crawler_async(coordinates_str, tif_file_path)
 
         log.info(f"Scrapy crawler completed for project ({project_id})")
+
+        # Clip the merged DEM to the project AOI (buffered by 50 m).
+        # This reduces the file size for QField packaging (Issue #790).
+        # Failure here is non-fatal: the unclipped DEM is still usable.
+        try:
+            db_pool = ctx.get("db_pool")
+            if db_pool:
+                async with db_pool.connection() as conn:
+                    async with conn.cursor(row_factory=dict_row) as cur:
+                        await cur.execute(
+                            """
+                            SELECT ST_AsGeoJSON(
+                                ST_Buffer(outline::geography, 50)::geometry
+                            )::json AS buffered_outline
+                            FROM projects WHERE id = %s
+                            """,
+                            (project_id,),
+                        )
+                        row = await cur.fetchone()
+
+                if row and row["buffered_outline"]:
+                    tif_file_path = clip_dem_to_aoi(
+                        tif_file_path, row["buffered_outline"]
+                    )
+                    log.info(f"Clipped DEM to buffered AOI for project ({project_id})")
+                else:
+                    log.warning(
+                        f"No AOI found for project ({project_id}), "
+                        "uploading unclipped DEM"
+                    )
+            else:
+                log.warning(
+                    f"DB pool unavailable for project ({project_id}), "
+                    "uploading unclipped DEM"
+                )
+        except Exception as clip_err:
+            log.warning(
+                f"DEM clipping failed for project ({project_id}), "
+                f"uploading unclipped: {clip_err}"
+            )
 
         # Upload to S3 and update database
         await upload_dem_file_s3_sync(tif_file_path, project_id)

--- a/src/backend/tests/test_upload_dem.py
+++ b/src/backend/tests/test_upload_dem.py
@@ -1,0 +1,374 @@
+"""Tests for the DEM clipping workflow introduced in Issue #790.
+
+Covers the contract that download_and_upload_dem() maintains:
+
+* When PostGIS returns a buffered AOI, clip_dem_to_aoi() is called and
+  upload_dem_file_s3_sync() receives the clipped path.
+* When clip_dem_to_aoi() raises, the worker falls back to the original
+  raster and does not propagate the exception.
+* When PostGIS returns no AOI (NULL outline or missing project), clipping
+  is skipped and the original raster is uploaded.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from app.jaxa import upload_dem
+
+from tests.test_project_processing import _FakeConn, _FakePool
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+class _RecordingCursor:
+    """Async context-manager cursor that records queries on the parent conn."""
+
+    def __init__(self, conn, fetchone_result=None, fetchall_result=None):
+        self._conn = conn
+        self._fetchone_result = fetchone_result
+        self._fetchall_result = fetchall_result or []
+
+    async def execute(self, query, params=None):
+        self._conn.executed.append({"query": query, "params": params})
+
+    async def fetchone(self):
+        return self._fetchone_result
+
+    async def fetchall(self):
+        return self._fetchall_result
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _RecordingConn(_FakeConn):
+    """_FakeConn that records executed queries (including via cursors)."""
+
+    def cursor(self, **kwargs):
+        return _RecordingCursor(self, self._cursor_fetchone, self._cursor_fetchall)
+
+    def queries_matching(self, *substrings: str) -> list[dict]:
+        return [
+            entry
+            for entry in self.executed
+            if all(s in entry["query"] for s in substrings)
+        ]
+
+
+def _make_ctx(conn):
+    """Build an ARQ-style ctx dict with a fake db_pool."""
+    return {"db_pool": _FakePool(conn)}
+
+
+# ── download_and_upload_dem: clipping on success ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_download_and_upload_dem_clips_on_success(monkeypatch, tmp_path):
+    """When PostGIS returns a buffered AOI, clip_dem_to_aoi() is called and
+    upload_dem_file_s3_sync() receives the clipped path."""
+    project_id = str(uuid.uuid4())
+    coordinates = "N050E009"
+
+    # Fake PostGIS returning a buffered AOI geometry.
+    fake_geometry = {
+        "type": "Polygon",
+        "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+    }
+    conn = _RecordingConn(cursor_fetchone={"buffered_outline": fake_geometry})
+    ctx = _make_ctx(conn)
+
+    # Track which path upload_dem_file_s3_sync receives.
+    uploaded_paths: list[str] = []
+
+    async def _fake_upload(tif_file_path, pid):
+        uploaded_paths.append(tif_file_path)
+
+    # Track which path clip_dem_to_aoi receives and returns.
+    clip_calls: list[str] = []
+    clipped_path = str(tmp_path / "clipped.tif")
+
+    def _fake_clip(dem_path, buffered_aoi_geojson):
+        clip_calls.append(dem_path)
+        return clipped_path
+
+    # Stub out external dependencies.
+    monkeypatch.setattr(upload_dem, "_run_scrapy_crawler_async", _noop_crawl)
+    monkeypatch.setattr(upload_dem, "upload_dem_file_s3_sync", _fake_upload)
+    monkeypatch.setattr(upload_dem, "clip_dem_to_aoi", _fake_clip)
+
+    # Create a dummy merged.tif so the crawler stub doesn't need to.
+    merged = tmp_path / "merged.tif"
+    merged.write_bytes(b"fake-tif")
+    monkeypatch.setattr(upload_dem.tempfile, "gettempdir", lambda: str(tmp_path))
+
+    await upload_dem.download_and_upload_dem(ctx, coordinates, project_id)
+
+    # clip_dem_to_aoi was called with the original path.
+    assert len(clip_calls) == 1
+    assert clip_calls[0].endswith("merged.tif")
+
+    # upload_dem_file_s3_sync received the clipped path.
+    assert uploaded_paths == [clipped_path]
+
+    # PostGIS query was executed.
+    assert conn.queries_matching("ST_Buffer", "outline")
+
+
+# ── download_and_upload_dem: fallback on clip failure ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_download_and_upload_dem_fallback_on_clip_failure(monkeypatch, tmp_path):
+    """When clip_dem_to_aoi() raises, the worker falls back to the original
+    raster and does not propagate the exception."""
+    project_id = str(uuid.uuid4())
+    coordinates = "N050E009"
+
+    fake_geometry = {
+        "type": "Polygon",
+        "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+    }
+    conn = _RecordingConn(cursor_fetchone={"buffered_outline": fake_geometry})
+    ctx = _make_ctx(conn)
+
+    uploaded_paths: list[str] = []
+
+    async def _fake_upload(tif_file_path, pid):
+        uploaded_paths.append(tif_file_path)
+
+    def _failing_clip(dem_path, buffered_aoi_geojson):
+        raise RuntimeError("gdal.Warp failed")
+
+    monkeypatch.setattr(upload_dem, "_run_scrapy_crawler_async", _noop_crawl)
+    monkeypatch.setattr(upload_dem, "upload_dem_file_s3_sync", _fake_upload)
+    monkeypatch.setattr(upload_dem, "clip_dem_to_aoi", _failing_clip)
+
+    merged = tmp_path / "merged.tif"
+    merged.write_bytes(b"fake-tif")
+    monkeypatch.setattr(upload_dem.tempfile, "gettempdir", lambda: str(tmp_path))
+
+    # Must not raise — clipping failure is non-fatal.
+    await upload_dem.download_and_upload_dem(ctx, coordinates, project_id)
+
+    # upload_dem_file_s3_sync received the ORIGINAL path (not clipped).
+    assert len(uploaded_paths) == 1
+    assert uploaded_paths[0].endswith("merged.tif")
+
+
+# ── download_and_upload_dem: fallback when no AOI ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_download_and_upload_dem_fallback_on_no_aoi(monkeypatch, tmp_path):
+    """When PostGIS returns no AOI, clipping is skipped and the original
+    raster is uploaded."""
+    project_id = str(uuid.uuid4())
+    coordinates = "N050E009"
+
+    # PostGIS returns a row but buffered_outline is None.
+    conn = _RecordingConn(cursor_fetchone={"buffered_outline": None})
+    ctx = _make_ctx(conn)
+
+    uploaded_paths: list[str] = []
+
+    async def _fake_upload(tif_file_path, pid):
+        uploaded_paths.append(tif_file_path)
+
+    clip_called = False
+
+    def _should_not_clip(dem_path, buffered_aoi_geojson):
+        nonlocal clip_called
+        clip_called = True
+        return dem_path
+
+    monkeypatch.setattr(upload_dem, "_run_scrapy_crawler_async", _noop_crawl)
+    monkeypatch.setattr(upload_dem, "upload_dem_file_s3_sync", _fake_upload)
+    monkeypatch.setattr(upload_dem, "clip_dem_to_aoi", _should_not_clip)
+
+    merged = tmp_path / "merged.tif"
+    merged.write_bytes(b"fake-tif")
+    monkeypatch.setattr(upload_dem.tempfile, "gettempdir", lambda: str(tmp_path))
+
+    await upload_dem.download_and_upload_dem(ctx, coordinates, project_id)
+
+    # clip_dem_to_aoi was NOT called.
+    assert clip_called is False
+
+    # upload_dem_file_s3_sync received the original path.
+    assert len(uploaded_paths) == 1
+    assert uploaded_paths[0].endswith("merged.tif")
+
+
+# ── download_and_upload_dem: fallback when no db_pool ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_download_and_upload_dem_fallback_on_no_db_pool(monkeypatch, tmp_path):
+    """When ctx has no db_pool, clipping is skipped and the original raster
+    is uploaded."""
+    project_id = str(uuid.uuid4())
+    coordinates = "N050E009"
+
+    ctx = {}  # No db_pool.
+
+    uploaded_paths: list[str] = []
+
+    async def _fake_upload(tif_file_path, pid):
+        uploaded_paths.append(tif_file_path)
+
+    clip_called = False
+
+    def _should_not_clip(dem_path, buffered_aoi_geojson):
+        nonlocal clip_called
+        clip_called = True
+        return dem_path
+
+    monkeypatch.setattr(upload_dem, "_run_scrapy_crawler_async", _noop_crawl)
+    monkeypatch.setattr(upload_dem, "upload_dem_file_s3_sync", _fake_upload)
+    monkeypatch.setattr(upload_dem, "clip_dem_to_aoi", _should_not_clip)
+
+    merged = tmp_path / "merged.tif"
+    merged.write_bytes(b"fake-tif")
+    monkeypatch.setattr(upload_dem.tempfile, "gettempdir", lambda: str(tmp_path))
+
+    await upload_dem.download_and_upload_dem(ctx, coordinates, project_id)
+
+    assert clip_called is False
+    assert len(uploaded_paths) == 1
+    assert uploaded_paths[0].endswith("merged.tif")
+
+
+# ── clip_dem_to_aoi: direct helper tests ─────────────────────────────────────
+
+
+def _make_test_raster(path, x_min, y_min, x_max, y_max, pixel_size=0.001):
+    """Create a small synthetic GeoTIFF for testing.
+
+    Returns the path to the created raster.
+    """
+    from osgeo import gdal, osr
+
+    x_size = int((x_max - x_min) / pixel_size)
+    y_size = int((y_max - y_min) / pixel_size)
+
+    ds = gdal.GetDriverByName("GTiff").Create(
+        str(path), x_size, y_size, 1, gdal.GDT_Int16
+    )
+    ds.SetGeoTransform([x_min, pixel_size, 0, y_max, 0, -pixel_size])
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(4326)
+    ds.SetProjection(srs.ExportToWkt())
+    band = ds.GetRasterBand(1)
+    import numpy as np
+
+    band.WriteArray(np.ones((y_size, x_size), dtype=np.int16) * 300)
+    band.SetNoDataValue(-9999)
+    ds.FlushCache()
+    ds = None
+    return str(path)
+
+
+def test_clip_dem_to_aoi_success(tmp_path):
+    """clip_dem_to_aoi clips the raster to the buffered AOI extent."""
+    raster_path = _make_test_raster(
+        tmp_path / "input.tif", x_min=9.0, y_min=50.0, x_max=10.0, y_max=51.0
+    )
+
+    # AOI covers a small part of the raster.
+    aoi = {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [9.43, 50.08],
+                [9.50, 50.08],
+                [9.50, 50.12],
+                [9.43, 50.12],
+                [9.43, 50.08],
+            ]
+        ],
+    }
+
+    from osgeo import gdal
+
+    result_path = upload_dem.clip_dem_to_aoi(raster_path, aoi)
+
+    # The function returns the original path (replaced in-place).
+    assert result_path == raster_path
+
+    # Verify the clipped raster extent is smaller than the original.
+    ds = gdal.Open(result_path)
+    gt = ds.GetGeoTransform()
+    x_min, y_max = gt[0], gt[3]
+    x_max = x_min + gt[1] * ds.RasterXSize
+    y_min = y_max + gt[5] * ds.RasterYSize
+    ds = None
+
+    # The clipped extent should be close to the AOI (plus pixel alignment).
+    assert x_min < 9.44  # within ~1 pixel of AOI min_lon
+    assert x_max > 9.49  # within ~1 pixel of AOI max_lon
+    assert y_min < 50.09  # within ~1 pixel of AOI min_lat
+    assert y_max > 50.11  # within ~1 pixel of AOI max_lat
+
+    # The clipped extent should be much smaller than the original 1° tile.
+    assert (x_max - x_min) < 0.2
+    assert (y_max - y_min) < 0.2
+
+
+def test_clip_dem_to_aoi_cleanup(tmp_path):
+    """clip_dem_to_aoi removes temporary cutline file after success."""
+    raster_path = _make_test_raster(
+        tmp_path / "input.tif", x_min=9.0, y_min=50.0, x_max=10.0, y_max=51.0
+    )
+
+    aoi = {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [9.43, 50.08],
+                [9.50, 50.08],
+                [9.50, 50.12],
+                [9.43, 50.12],
+                [9.43, 50.08],
+            ]
+        ],
+    }
+
+    upload_dem.clip_dem_to_aoi(raster_path, aoi)
+
+    # No temporary GeoJSON files should remain.
+    geojson_files = list(tmp_path.glob("cutline_*.geojson"))
+    assert geojson_files == []
+
+    # No intermediate clipped file should remain.
+    clipped_files = list(tmp_path.glob("*.clipped.tif"))
+    assert clipped_files == []
+
+
+def test_clip_dem_to_aoi_raises_on_invalid_geometry(tmp_path):
+    """clip_dem_to_aoi raises when given invalid geometry."""
+    raster_path = _make_test_raster(
+        tmp_path / "input.tif", x_min=9.0, y_min=50.0, x_max=10.0, y_max=51.0
+    )
+
+    # A Point geometry is not a valid cutline for gdal.Warp.
+    bad_geometry = {"type": "Point", "coordinates": [9.5, 50.1]}
+
+    with pytest.raises(RuntimeError):
+        upload_dem.clip_dem_to_aoi(raster_path, bad_geometry)
+
+    # Temporary files should still be cleaned up.
+    geojson_files = list(tmp_path.glob("cutline_*.geojson"))
+    assert geojson_files == []
+
+
+# ── shared stubs ─────────────────────────────────────────────────────────────
+
+
+async def _noop_crawl(coordinates_str, tif_file_path):
+    """Stub for _run_scrapy_crawler_async — does nothing."""

--- a/src/backend/tests/test_upload_dem.py
+++ b/src/backend/tests/test_upload_dem.py
@@ -102,10 +102,10 @@ async def test_download_and_upload_dem_clips_on_success(monkeypatch, tmp_path):
     monkeypatch.setattr(upload_dem, "upload_dem_file_s3_sync", _fake_upload)
     monkeypatch.setattr(upload_dem, "clip_dem_to_aoi", _fake_clip)
 
-    # Create a dummy merged.tif so the crawler stub doesn't need to.
-    merged = tmp_path / "merged.tif"
-    merged.write_bytes(b"fake-tif")
     monkeypatch.setattr(upload_dem.tempfile, "gettempdir", lambda: str(tmp_path))
+    merged = tmp_path / "tif_processing" / project_id / "merged.tif"
+    merged.parent.mkdir(parents=True, exist_ok=True)
+    merged.write_bytes(b"fake-tif")
 
     await upload_dem.download_and_upload_dem(ctx, coordinates, project_id)
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [x] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #790

## Describe this PR

This PR clips downloaded DEMs to the project AOI with a 50 m buffer before uploading them to S3. This reduces unnecessary DEM coverage in QField packages.

The clipping uses GDAL with a PostGIS-derived cutline and is integrated into the existing DEM download/upload workflow. If clipping cannot be performed, the original DEM is uploaded as a fallback.

Tests cover successful clipping, fallback paths, invalid geometry, temporary-file cleanup, and error handling.

## AI Tool Usage

- [ ] No AI tools were used
- [x] AI tools were used (complete below)

**If AI-assisted:**

- Tool(s) used: Hermes Agent
- What was generated: Used to navigate and understand the codebase, repository architecture, conventions, and relevant documentation to make informed implementation decisions.
- What you reviewed and changed: All implementation decisions and changes were reviewed and made by me.

### Review follow-up

I had a small hiccup while applying the  Copilot review suggestions and initially accepted the wrong suggested fix, but I caught it, corrected the implementation, and pushed the final version. The PR is now up to date and ready for review.

## Screenshots

N/A — backend-only change.

## Review Guide

- `just lint` — passed
- `pre-commit run --hook-stage pre-push --all-files` — all 16 hooks passed
- `just test backend` — 231/231 tests passed