### PR TITLE
fix(backend): use tempfile for flightplan output instead of /tmp

### DIFF
--- a/src/backend/app/projects/project_logic.py
+++ b/src/backend/app/projects/project_logic.py
@@ -244,22 +244,25 @@ async def process_task_metrics(db, tasks_data, project):
         }
 
         if project.is_terrain_follow:
-            dem_path = os.path.join(tempfile.gettempdir(), str(uuid.uuid4()), "dem.tif")
             points = create_waypoint(**waypoint_params)
-            try:
-                get_file_from_bucket(
-                    settings.S3_BUCKET_NAME,
-                    f"projects/{project.id}/dem.tif",
-                    dem_path,
-                )
+            # Scoped temp dir: the DEM directory was never removed, and the
+            # elevation file used a fixed name shared by every concurrent call
+            with tempfile.TemporaryDirectory(prefix="dem_") as temp_dir:
+                dem_path = os.path.join(temp_dir, "dem.tif")
                 outfile_with_elevation = os.path.join(
-                    tempfile.gettempdir(), "output_file_with_elevation.geojson"
+                    temp_dir, "output_file_with_elevation.geojson"
                 )
-                add_elevation_from_dem(dem_path, points, outfile_with_elevation)
-                with open(outfile_with_elevation) as inpointsfile:
-                    points_with_elevation = inpointsfile.read()
-            except Exception:
-                points_with_elevation = points
+                try:
+                    get_file_from_bucket(
+                        settings.S3_BUCKET_NAME,
+                        f"projects/{project.id}/dem.tif",
+                        dem_path,
+                    )
+                    add_elevation_from_dem(dem_path, points, outfile_with_elevation)
+                    with open(outfile_with_elevation) as inpointsfile:
+                        points_with_elevation = inpointsfile.read()
+                except Exception:
+                    points_with_elevation = points
 
             if (
                 isinstance(points_with_elevation, dict)

--- a/src/backend/app/waypoints/flightplan_output.py
+++ b/src/backend/app/waypoints/flightplan_output.py
@@ -1,6 +1,9 @@
+import shutil
+
 from drone_flightplan.drone_type import DRONE_PARAMS, DroneType
 from fastapi import HTTPException
 from fastapi.responses import FileResponse
+from starlette.background import BackgroundTask
 
 FLIGHTPLAN_OUTPUTS = {
     "DJI_WMPL": {
@@ -42,11 +45,27 @@ def build_flightplan_download_response(
     outpath: str,
     drone_type: DroneType,
     filename_stem: str,
+    cleanup_dir: str | None = None,
 ):
-    """Wrap a generated flightplan file in the correct download response."""
+    """Wrap a generated flightplan file in the correct download response.
+
+    Args:
+        outpath: The generated flightplan file to serve.
+        drone_type: Used to pick the media type and file extension.
+        filename_stem: Download filename, without extension.
+        cleanup_dir: Temporary directory to remove once the response has been
+            sent. Flightplans are generated per request and are of no use
+            afterwards, so without this they accumulate until the server runs
+            out of disk.
+    """
     config = get_flightplan_output_config(drone_type)
     return FileResponse(
         outpath,
         media_type=config["media_type"],
         filename=f"{filename_stem}{config['suffix']}",
+        background=(
+            BackgroundTask(shutil.rmtree, cleanup_dir, ignore_errors=True)
+            if cleanup_dir
+            else None
+        ),
     )

--- a/src/backend/app/waypoints/waypoint_routes.py
+++ b/src/backend/app/waypoints/waypoint_routes.py
@@ -35,6 +35,7 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from fastapi.responses import FileResponse
 from psycopg import Connection
 from shapely.geometry import shape
+from starlette.background import BackgroundTask
 
 log = logging.getLogger(__name__)
 
@@ -185,13 +186,20 @@ async def get_task_flightplan(
     if download:
         # Output writers each treat `outfile` differently (some as a file path,
         # some as a base dir for a subdirectory tree). They all expect a unique
-        # non-existent path under a writable tmpdir.
-        outfile = os.path.join(tempfile.gettempdir(), f"flightplan-{uuid.uuid4()}")
-        outpath = write_flightplan_file(placemarks, drone_type, outfile, mode)
+        # non-existent path under a writable tmpdir, which is removed again
+        # once the response has been sent.
+        temp_dir = tempfile.mkdtemp(prefix="flightplan_")
+        try:
+            outfile = os.path.join(temp_dir, "flightplan")
+            outpath = write_flightplan_file(placemarks, drone_type, outfile, mode)
+        except Exception:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+            raise
         return build_flightplan_download_response(
             outpath,
             drone_type=drone_type,
             filename_stem=f"task-{project_task_index}-{mode.name}-project-{project_id}",
+            cleanup_dir=temp_dir,
         )
 
     flight_data = calculate_flight_time_from_placemarks(placemarks)
@@ -262,6 +270,7 @@ async def generate_wmpl_kmz(
             detail="Either altitude or gsd is required",
         )
 
+    dem_path = None
     if terrain_follow:
         if not dem:
             raise HTTPException(
@@ -279,56 +288,70 @@ async def generate_wmpl_kmz(
         with open(dem_path, "wb") as buffer:
             shutil.copyfileobj(dem.file, buffer)
 
-    boundary = merge_multipolygon(geojson.loads(await project_geojson.read()))
+    try:
+        boundary = merge_multipolygon(geojson.loads(await project_geojson.read()))
 
-    # create a takeoff point in this format ["lon","lat"]
-    take_off_point = [take_off_point.longitude, take_off_point.latitude]
-    if not check_point_within_buffer(take_off_point, boundary, 200):
-        raise HTTPException(
-            status_code=400,
-            detail="Take off point should be within 200m of the boundary",
-        )
+        # create a takeoff point in this format ["lon","lat"]
+        take_off_point = [take_off_point.longitude, take_off_point.latitude]
+        if not check_point_within_buffer(take_off_point, boundary, 200):
+            raise HTTPException(
+                status_code=400,
+                detail="Take off point should be within 200m of the boundary",
+            )
 
-    if not download:
-        points = create_waypoint(
-            project_area=boundary,
-            agl=altitude,
-            gsd=gsd,
-            forward_overlap=forward_overlap,
-            side_overlap=side_overlap,
-            flight_mode=flight_mode,
-            generate_3d=generate_3d,
-            take_off_point=take_off_point,
-            drone_type=drone_type,
-        )
-        return geojson.loads(points)
-    else:
-        output_file = create_flightplan(
-            aoi=boundary,
-            forward_overlap=forward_overlap,
-            side_overlap=side_overlap,
-            agl=altitude,
-            gsd=gsd,
-            flight_mode=flight_mode,
-            dem=dem_path if dem else None,
-            outfile=os.path.join(tempfile.gettempdir(), str(uuid.uuid4())),
-            take_off_point=take_off_point,
-            drone_type=drone_type,
-        )
+        if not download:
+            points = create_waypoint(
+                project_area=boundary,
+                agl=altitude,
+                gsd=gsd,
+                forward_overlap=forward_overlap,
+                side_overlap=side_overlap,
+                flight_mode=flight_mode,
+                generate_3d=generate_3d,
+                take_off_point=take_off_point,
+                drone_type=drone_type,
+            )
+            return geojson.loads(points)
+        else:
+            # Removed again by the response background task, once sent
+            temp_dir = tempfile.mkdtemp(prefix="flightplan_")
+            try:
+                output_file = create_flightplan(
+                    aoi=boundary,
+                    forward_overlap=forward_overlap,
+                    side_overlap=side_overlap,
+                    agl=altitude,
+                    gsd=gsd,
+                    flight_mode=flight_mode,
+                    dem=dem_path,
+                    outfile=os.path.join(temp_dir, "flightplan"),
+                    take_off_point=take_off_point,
+                    drone_type=drone_type,
+                )
+            except Exception:
+                shutil.rmtree(temp_dir, ignore_errors=True)
+                raise
 
-        return build_flightplan_download_response(
-            output_file,
-            drone_type=drone_type,
-            filename_stem="output",
-        )
+            return build_flightplan_download_response(
+                output_file,
+                drone_type=drone_type,
+                filename_stem="output",
+                cleanup_dir=temp_dir,
+            )
+    finally:
+        # The uploaded DEM is only needed while the flightplan is generated
+        if dem_path and os.path.exists(dem_path):
+            os.remove(dem_path)
 
 
 @router.post("/{task_id}/generate-kmz/")
 async def generate_kmz_with_placemarks(
     task_id: uuid.UUID, data: waypoint_schemas.PlacemarksFeature
 ):
+    # Removed again by the response background task, once sent
+    temp_dir = tempfile.mkdtemp(prefix="flightplan_")
     try:
-        outfile = os.path.join(tempfile.gettempdir(), f"{task_id}_flight_plan.kmz")
+        outfile = os.path.join(temp_dir, f"{task_id}_flight_plan.kmz")
 
         kmz_file = create_wpml(data.model_dump(), outfile)
         if not os.path.exists(kmz_file):
@@ -337,7 +360,9 @@ async def generate_kmz_with_placemarks(
             kmz_file,
             media_type="application/zip",
             filename=f"{task_id}_flight_plan.kmz",
+            background=BackgroundTask(shutil.rmtree, temp_dir, ignore_errors=True),
         )
 
     except Exception as e:
+        shutil.rmtree(temp_dir, ignore_errors=True)
         raise HTTPException(status_code=500, detail=f"Error generating KMZ: {e!s}")

--- a/src/backend/packages/drone-flightplan/drone_flightplan/create_flightplan.py
+++ b/src/backend/packages/drone-flightplan/drone_flightplan/create_flightplan.py
@@ -112,10 +112,14 @@ def build_placemarks(
 def write_flightplan_file(
     placemarks: dict,
     drone_type: DroneType,
-    outfile: str,
+    outfile: str | None = None,
     flight_mode: FlightMode = FlightMode.WAYLINES,
 ) -> str:
-    """Serialize placemarks to the drone-specific output format on disk."""
+    """Serialize placemarks to the drone-specific output format on disk.
+
+    When `outfile` is omitted the writer picks a temporary path, which the
+    caller then owns and must clean up once the file has been consumed.
+    """
     output_format = DRONE_PARAMS[drone_type].get("OUTPUT_FORMAT")
 
     if output_format == "DJI_WMPL":

--- a/src/backend/packages/drone-flightplan/drone_flightplan/output/dji.py
+++ b/src/backend/packages/drone-flightplan/drone_flightplan/output/dji.py
@@ -23,6 +23,7 @@ device and partially supported WPML functions in the DJI waypoint implementation
 import argparse
 import logging
 import os
+import tempfile
 import xml.etree.ElementTree as ET
 import zipfile
 from xml.etree.ElementTree import Element
@@ -31,6 +32,7 @@ import geojson
 from geojson import FeatureCollection
 
 from drone_flightplan.enums import RCLostOptions
+from drone_flightplan.output.output_paths import resolve_output_path
 
 # Instantiate logger
 log = logging.getLogger(__name__)
@@ -48,7 +50,17 @@ def zip_directory(directory_path, zip_path):
                 )
 
 
-def create_zip_file(waylines_path_uid):
+def create_zip_file(waylines_path_uid, output_file_name=None):
+    """Package a directory containing waylines.wpml into a .kmz file.
+
+    Args:
+        waylines_path_uid: Directory holding the generated waylines.wpml.
+        output_file_name: Destination .kmz path. Defaults to output.kmz
+            alongside the source, as before.
+
+    Returns:
+        Path to the generated .kmz file.
+    """
     # Create the wpmz folder if it doesn't exist
     wpmz_path = f"{waylines_path_uid}/wpmz"
     os.makedirs(wpmz_path, exist_ok=True)
@@ -61,7 +73,8 @@ def create_zip_file(waylines_path_uid):
         f.write(wpml_content)
 
     # Create a Zip file containing the contents of the wpmz folder directly
-    output_file_name = f"{waylines_path_uid}/output.kmz"
+    if output_file_name is None:
+        output_file_name = f"{waylines_path_uid}/output.kmz"
     zip_directory(wpmz_path, output_file_name)
 
     return output_file_name
@@ -467,31 +480,55 @@ def create_kml(mission_config, folder):
     return kml
 
 
-def create_xml(placemarks, global_height, output_file_path="/tmp/"):
+def resolve_kmz_path(output_file_path: str | None) -> str:
+    """Resolve the destination .kmz path.
+
+    An existing directory is still accepted, since `output_file_path` used to
+    be treated as the directory the mission tree was written into.
+    """
+    if output_file_path is not None and os.path.isdir(output_file_path):
+        return os.path.join(output_file_path, "output.kmz")
+
+    return resolve_output_path(
+        output_file_path, suffix=".kmz", prefix="dji_flightplan_"
+    )
+
+
+def create_xml(placemarks, global_height, output_file_path: str | None = None):
     mission_config = create_mission_config(global_height)
     folder = create_folder(placemarks)
     kml = create_kml(mission_config, folder)
 
     tree = ET.ElementTree(kml)
 
-    folder_name = "flight"
-    os.makedirs(os.path.join(output_file_path, folder_name), exist_ok=True)
-    waylines_path = os.path.join(output_file_path, folder_name, "waylines.wpml")
+    output_file_name = resolve_kmz_path(output_file_path)
 
-    tree.write(waylines_path, encoding="UTF-8", xml_declaration=True)
-    output_file_name = create_zip_file(os.path.join(output_file_path, folder_name))
+    # The waylines.wpml / wpmz tree is only scratch space needed to build the
+    # .kmz, so keep it in a managed temp dir. It used to be left behind under
+    # /tmp on every single call.
+    with tempfile.TemporaryDirectory(prefix="dji_flightplan_") as temp_dir:
+        flight_dir = os.path.join(temp_dir, "flight")
+        os.makedirs(flight_dir, exist_ok=True)
+        waylines_path = os.path.join(flight_dir, "waylines.wpml")
+
+        tree.write(waylines_path, encoding="UTF-8", xml_declaration=True)
+        create_zip_file(flight_dir, output_file_name)
+
     return output_file_name
 
 
 def create_wpml(
     placemark_geojson: str | FeatureCollection | dict,
-    output_file_path: str = "/tmp/",
+    output_file_path: str | None = None,
 ):
     """Arguments:
         placemark_geojson: The placemark coordinates to be included in the flightplan mission
-        output_file_path: The output file path for the wpml file
+        output_file_path: Destination path for the generated .kmz file.
+            An existing directory is also accepted, in which case output.kmz
+            is written inside it. Defaults to a temporary file, which the
+            caller is responsible for removing.
     Returns:
-        wpml file.
+        Path to the generated .kmz file.
     """
     # global height is taken from the first point
     try:

--- a/src/backend/packages/drone-flightplan/drone_flightplan/output/litchi.py
+++ b/src/backend/packages/drone-flightplan/drone_flightplan/output/litchi.py
@@ -33,6 +33,7 @@ import geojson
 from geojson import FeatureCollection
 
 from drone_flightplan.enums import FlightMode
+from drone_flightplan.output.output_paths import resolve_output_path
 
 log = logging.getLogger(__name__)
 
@@ -148,7 +149,7 @@ def create_litchi_waypoint(
 
 def create_litchi_csv(
     placemark_geojson: str | FeatureCollection | dict,
-    output_file_path: str = "/tmp/mission.csv",
+    output_file_path: str | None = None,
     flight_mode: FlightMode = FlightMode.WAYLINES,
     photo_interval_time: float = 2.0,
     photo_interval_distance: float | None = None,
@@ -180,7 +181,8 @@ def create_litchi_csv(
             - speed: (optional) speed in m/s
             - gimbal_angle: (optional) camera pitch angle in degrees
             - heading: (optional) aircraft heading in degrees
-        output_file_path: Path for output .csv file
+        output_file_path: Path for output .csv file. Defaults to a temporary
+            file, which the caller is responsible for removing.
         flight_mode: WAYPOINTS (photo at each point) or WAYLINES (interval photos)
         speed: Default flight speed in m/s
         photo_interval_time: Time between photos in seconds (WAYLINES mode)
@@ -312,6 +314,10 @@ def create_litchi_csv(
 
     # Get fieldnames from first waypoint (they're ordered correctly)
     fieldnames = list(waypoints[0].keys())
+
+    output_file_path = resolve_output_path(
+        output_file_path, suffix=".csv", prefix="litchi_mission_"
+    )
 
     with open(output_file_path, "w", newline="") as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)

--- a/src/backend/packages/drone-flightplan/drone_flightplan/output/mavlink.py
+++ b/src/backend/packages/drone-flightplan/drone_flightplan/output/mavlink.py
@@ -31,6 +31,7 @@ import geojson
 from geojson import FeatureCollection
 
 from drone_flightplan.enums import FlightMode
+from drone_flightplan.output.output_paths import resolve_output_path
 
 log = logging.getLogger(__name__)
 
@@ -382,7 +383,7 @@ def create_return_to_launch(index: int) -> str:
 
 def create_mavlink_plan(
     placemark_geojson: str | FeatureCollection | dict,
-    output_file_path: str = "/tmp/mission.waypoints",
+    output_file_path: str | None = None,
     flight_mode: FlightMode = FlightMode.WAYPOINTS,
     photo_interval_time: float = 2.0,
 ) -> str:
@@ -402,7 +403,8 @@ def create_mavlink_plan(
 
     Args:
         placemark_geojson: GeoJSON FeatureCollection with waypoint data
-        output_file_path: Path for output .waypoints file
+        output_file_path: Path for output .waypoints file. Defaults to a
+            temporary file, which the caller is responsible for removing.
         flight_mode: WAYPOINTS (photo at each point) or WAYLINES (interval photos)
         photo_interval_time: Time between photos in seconds for WAYLINES mode
 
@@ -530,6 +532,10 @@ def create_mavlink_plan(
     # Write Mission File
     # Add all mission items to the output
     lines.extend(mission_items)
+
+    output_file_path = resolve_output_path(
+        output_file_path, suffix=".waypoints", prefix="mavlink_mission_"
+    )
 
     # Write to file with newline separation
     with open(output_file_path, "w") as f:

--- a/src/backend/packages/drone-flightplan/drone_flightplan/output/output_paths.py
+++ b/src/backend/packages/drone-flightplan/drone_flightplan/output/output_paths.py
@@ -1,0 +1,43 @@
+"""Helpers for deciding where generated flightplan files are written."""
+
+import logging
+import os
+import tempfile
+
+log = logging.getLogger(__name__)
+
+
+def resolve_output_path(
+    output_file_path: str | None,
+    suffix: str,
+    prefix: str = "flightplan_",
+) -> str:
+    """Resolve the destination path for a generated flightplan file.
+
+    The output modules used to default to hardcoded paths under `/tmp`
+    (e.g. `/tmp/mission.csv`). That had two problems: concurrent missions
+    overwrote each other's file, and nothing ever removed them, so the
+    deployed server slowly filled up.
+
+    Args:
+        output_file_path: Caller-provided destination. `None` means
+            "generate a temporary path for me".
+        suffix: Extension used when generating a temporary file.
+        prefix: Filename prefix used when generating a temporary file.
+
+    Returns:
+        The path to write the output to. When the path is generated here the
+        file is created empty and ownership passes to the caller, which must
+        remove it once consumed.
+    """
+    if output_file_path is None:
+        file_descriptor, generated_path = tempfile.mkstemp(suffix=suffix, prefix=prefix)
+        os.close(file_descriptor)
+        log.debug(f"No output path provided, using temporary file: {generated_path}")
+        return generated_path
+
+    parent_dir = os.path.dirname(output_file_path)
+    if parent_dir:
+        os.makedirs(parent_dir, exist_ok=True)
+
+    return output_file_path

--- a/src/backend/packages/drone-flightplan/drone_flightplan/output/qgroundcontrol.py
+++ b/src/backend/packages/drone-flightplan/drone_flightplan/output/qgroundcontrol.py
@@ -27,6 +27,7 @@ import geojson
 from geojson import FeatureCollection
 
 from drone_flightplan.enums import FlightMode
+from drone_flightplan.output.output_paths import resolve_output_path
 
 log = logging.getLogger(__name__)
 
@@ -351,7 +352,7 @@ def create_return_to_launch_item() -> dict:
 
 def create_qgroundcontrol_plan(
     placemark_geojson: str | FeatureCollection | dict,
-    output_file_path: str = "/tmp/mission.plan",
+    output_file_path: str | None = None,
     flight_mode: FlightMode = FlightMode.WAYPOINTS,
     photo_interval_time: float = 2.0,
     photo_interval_distance: float | None = None,
@@ -381,7 +382,8 @@ def create_qgroundcontrol_plan(
             - altitude: altitude in meters
             - speed: (optional) speed in m/s
             - gimbal_angle: (optional) camera pitch angle in degrees
-        output_file_path: Path for output .plan file
+        output_file_path: Path for output .plan file. Defaults to a temporary
+            file, which the caller is responsible for removing.
         flight_mode: WAYPOINTS (photo at each point) or WAYLINES (interval photos)
         photo_interval_time: Time between photos in seconds (WAYLINES mode)
         photo_interval_distance: Distance between photos in meters (WAYLINES mode)
@@ -543,6 +545,10 @@ def create_qgroundcontrol_plan(
         # Empty rally points (can be populated later if needed)
         "rallyPoints": {"version": 2, "points": []},
     }
+
+    output_file_path = resolve_output_path(
+        output_file_path, suffix=".plan", prefix="qgc_mission_"
+    )
 
     # Write the plan to file as formatted JSON
     with open(output_file_path, "w") as f:

--- a/src/backend/tests/test_flightplan_output_paths.py
+++ b/src/backend/tests/test_flightplan_output_paths.py
@@ -1,0 +1,138 @@
+import os
+import tempfile
+import zipfile
+
+import geojson
+import pytest
+from app.waypoints.flightplan_output import build_flightplan_download_response
+from drone_flightplan.drone_type import DroneType
+from drone_flightplan.output.dji import create_wpml
+from drone_flightplan.output.litchi import create_litchi_csv
+from drone_flightplan.output.mavlink import create_mavlink_plan
+from drone_flightplan.output.output_paths import resolve_output_path
+from drone_flightplan.output.qgroundcontrol import create_qgroundcontrol_plan
+
+WRITERS = [
+    create_wpml,
+    create_litchi_csv,
+    create_mavlink_plan,
+    create_qgroundcontrol_plan,
+]
+
+
+@pytest.fixture
+def placemarks():
+    """A minimal three waypoint mission, valid for every output format."""
+    coordinates = [
+        (20.306835, 51.4583672, 80),
+        (20.307056, 51.4583026, 90),
+        (20.3065566, 51.4583901, 80),
+    ]
+    return geojson.FeatureCollection(
+        [
+            geojson.Feature(
+                geometry=geojson.Point(coordinate),
+                properties={
+                    "index": index,
+                    "altitude": coordinate[2],
+                    "elevation": 0,
+                    "speed": 10.0,
+                    "gimbal_angle": -90,
+                    "heading": 0,
+                    "take_photo": True,
+                },
+            )
+            for index, coordinate in enumerate(coordinates)
+        ]
+    )
+
+
+@pytest.fixture
+def isolated_tmpdir(monkeypatch, tmp_path):
+    """Point the tempfile module at an empty dir, so leftovers are visible."""
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+    return tmp_path
+
+
+@pytest.mark.parametrize("writer", WRITERS)
+def test_writer_without_output_path_uses_managed_tempfile(
+    writer, placemarks, isolated_tmpdir
+):
+    outpath = writer(placemarks)
+
+    assert os.path.isfile(outpath)
+    assert os.path.getsize(outpath) > 0
+    # Written under the temp dir, not to a hardcoded /tmp/mission.* path
+    assert os.path.dirname(outpath) == str(isolated_tmpdir)
+
+
+@pytest.mark.parametrize("writer", WRITERS)
+def test_writer_generates_a_unique_path_per_call(writer, placemarks, isolated_tmpdir):
+    # Concurrent missions used to overwrite each other's output file
+    assert writer(placemarks) != writer(placemarks)
+
+
+@pytest.mark.parametrize("writer", WRITERS)
+def test_writer_honours_explicit_output_path(writer, placemarks, tmp_path):
+    target = str(tmp_path / "nested" / "mission")
+
+    outpath = writer(placemarks, target)
+
+    assert outpath == target
+    assert os.path.isfile(outpath)
+
+
+def test_dji_leaves_no_scratch_files_behind(placemarks, isolated_tmpdir):
+    kmz_path = create_wpml(placemarks)
+
+    # The waylines.wpml / wpmz tree is scratch space and must not survive
+    assert [entry.name for entry in isolated_tmpdir.iterdir()] == [
+        os.path.basename(kmz_path)
+    ]
+    assert zipfile.ZipFile(kmz_path).namelist() == ["wpmz/waylines.wpml"]
+
+
+def test_dji_still_accepts_a_directory_as_output_path(placemarks, tmp_path):
+    outpath = create_wpml(placemarks, str(tmp_path))
+
+    assert outpath == str(tmp_path / "output.kmz")
+    assert zipfile.ZipFile(outpath).namelist() == ["wpmz/waylines.wpml"]
+
+
+def test_resolve_output_path_creates_missing_parent_directories(tmp_path):
+    target = str(tmp_path / "does" / "not" / "exist" / "mission.csv")
+
+    assert resolve_output_path(target, suffix=".csv") == target
+    assert os.path.isdir(os.path.dirname(target))
+
+
+def test_download_response_removes_the_temporary_directory(tmp_path):
+    temp_dir = tmp_path / "flightplan"
+    temp_dir.mkdir()
+    outpath = temp_dir / "mission.kmz"
+    outpath.write_bytes(b"kmz")
+
+    response = build_flightplan_download_response(
+        str(outpath),
+        drone_type=DroneType.DJI_MINI_4_PRO,
+        filename_stem="task-1",
+        cleanup_dir=str(temp_dir),
+    )
+
+    assert response.background is not None
+    response.background.func(*response.background.args, **response.background.kwargs)
+    assert not temp_dir.exists()
+
+
+def test_download_response_without_cleanup_dir_keeps_the_file(tmp_path):
+    outpath = tmp_path / "mission.kmz"
+    outpath.write_bytes(b"kmz")
+
+    response = build_flightplan_download_response(
+        str(outpath),
+        drone_type=DroneType.DJI_MINI_4_PRO,
+        filename_stem="task-1",
+    )
+
+    assert response.background is None
+    assert outpath.exists()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [x] 🧑‍💻 Refactor
- [x] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #597

## Describe this PR

The output writers defaulted to hardcoded paths under `/tmp`: `/tmp/mission.csv`, `/tmp/mission.waypoints`, `/tmp/mission.plan` and `/tmp/` for DJI. That causes two distinct problems on a deployed server:

1. **Collisions.** Those are fixed, global filenames. Two users generating a flightplan at the same time write to the same file, and one overwrites the other.
2. **Accumulation.** Nothing ever removes the files, which is the disk-filling behaviour described in the issue.

The DJI writer was the worst of the two, because it doesn't just leave the final file behind. Building a `.kmz` means creating a `flight/` directory, writing `waylines.wpml` into it, copying that same file into a `wpmz/` subdirectory, and zipping. All of that scratch state was left on disk.

Measured with a throwaway script, pointing the writers at a sandbox directory and generating three flightplans:

```
before                                after
  mission.csv                           mission.csv
  flight/output.kmz                     output.kmz
  flight/waylines.wpml
  flight/wpmz/waylines.wpml
```

Roughly 24 KB of scratch files per DJI flightplan, permanently. And `mission.csv` is a single file for all three runs, which is the collision problem made visible.

### Changes

**`drone_flightplan/output/output_paths.py`** (new) — a `resolve_output_path()` helper. `None` means "give me a managed temporary path"; an explicit path is honoured, with missing parent directories created.

**`litchi.py`, `mavlink.py`, `qgroundcontrol.py`** — `output_file_path` defaults to `None` instead of a `/tmp` path. Resolution happens immediately before writing, so a validation failure (e.g. empty FeatureCollection) doesn't leave an empty temp file behind.

**`dji.py`** — the `waylines.wpml` / `wpmz` tree is now built inside a `tempfile.TemporaryDirectory()`, so only the requested `.kmz` survives the call. `create_zip_file()` takes an optional destination so the archive can land outside that scratch directory; omitting it keeps the previous behaviour.

**`app/waypoints/flightplan_output.py`** — `build_flightplan_download_response()` accepts `cleanup_dir` and attaches a `BackgroundTask` that removes it. The file can't be deleted when the handler returns, because `FileResponse` streams it afterwards; a background task runs at the right moment, once the response has been sent.

**`app/waypoints/waypoint_routes.py`** — all three flightplan endpoints generate into a per-request temp directory, cleaned up after the response. If generation raises there is no response and therefore no background task, so those paths remove the directory directly.

The uploaded DEM in `generate_wmpl_kmz` is also removed in a `finally` block; previously it stayed on disk. While adding that I noticed `dem=dem_path if dem else None` referenced `dem_path`, which is only assigned inside `if terrain_follow:`. Uploading a DEM without `terrain_follow` raised `NameError` and returned a 500. Initialising `dem_path = None` up front was needed for the `finally` anyway and fixes that as a side effect. Happy to split that out if you'd rather keep it separate.

**`app/projects/project_logic.py`** — terrain-follow generation used `tempfile.gettempdir() / "output_file_with_elevation.geojson"`, one fixed filename shared by every concurrent call, and a DEM directory that was never removed. Both are now inside a scoped `TemporaryDirectory`. This is the same class of bug rather than the literal `/tmp` string, so say the word if you'd prefer it in its own PR.

### Behaviour change worth flagging

Callers that relied on the default output location will now get a unique temporary path instead of a fixed one, and must use the returned path. The return value has always been there, and `drone-flightplan` is published on PyPI, so I kept one compatibility affordance: `create_wpml()` still accepts an existing directory as `output_file_path` and writes `output.kmz` inside it.

That also unifies the two conventions noted in the existing comment in `waypoint_routes.py` — DJI treated the argument as a directory while every other writer treated it as a file path. It's now consistently a file path, with the directory form still working.

## AI Tool Usage

- [ ] No AI tools were used
- [x] AI tools were used (complete below)

**If AI-assisted:**

- Tool(s) used: Claude Code (`Assisted-by` trailer is in the commit)
- What was generated: the implementation and the tests, from my analysis of the issue and the surrounding code.
- What you reviewed and changed: I walked through the whole diff before opening this, and I understand and stand behind every change in it. The scope was deliberately widened during review once it became clear the hardcoded defaults were only part of the leak — the DJI scratch tree and the missing cleanup in the routes are where the disk actually fills up. I also decided to keep the directory-argument compatibility path in `create_wpml()` rather than making a clean break, since the package is published separately. The two questions I raised on the issue are still open, and I'm happy to reshape the public API if you prefer a different direction.

## Screenshots

Not applicable — the before/after evidence is the directory listing above.

## Alternative Approaches Considered

**Encapsulating temp handling fully inside the writers** (a `TemporaryDirectory` around the whole function). Rejected: these functions return a path the caller then serves to the user, so a context manager would delete the file before it could be read. `mkstemp` is used instead, with ownership documented as passing to the caller. The context manager is used only where the file's life genuinely ends inside the function — the DJI scratch tree.

**Leaving the writers alone and only cleaning up in the routes.** That would fix the disk usage but not the collisions between concurrent missions, and would leave the misleading `/tmp` defaults in a published package.

**Making `output_file_path` a required argument.** Cleaner in isolation, but a breaking change for every external caller with no compatibility path, for little benefit.

## Review Guide

Suggested reading order: `output_paths.py` (the helper), then `dji.py` (the only non-trivial writer change), then `flightplan_output.py` and `waypoint_routes.py` (cleanup after the response is sent).

New tests are in `src/backend/tests/test_flightplan_output_paths.py`. The `isolated_tmpdir` fixture repoints `tempfile.tempdir` at an empty directory, which is what makes "exactly one file remains" assertable.

To confirm they're meaningful rather than tautological: stash the source changes, keep the test file, and the suite reports **15 failed, 2 passed**. With the fix applied, **17 passed**.

Manual check: generate a flightplan download for a DJI project and for a non-DJI drone type, confirm the file downloads intact and that no `flightplan_*` directory is left in the container's temp dir afterwards.

**What I could not verify:** the full backend suite. It needs the Docker Compose stack (Postgres, Dragonfly, S3) and I couldn't run it on this machine. The 17 new tests were run in isolation against the package and `flightplan_output.py`, with `osgeo` stubbed since GDAL isn't installable here. `ruff check` and `ruff format --check` are clean across `src/backend`. Everything else is down to CI.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/hotosm/drone-tm/blob/dev/CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](https://docs.hotosm.org/code-of-conduct)
- [x] PR is focused and small
- [x] Tests are included or updated
- [x] I understand all code in this PR and can answer questions about it
- [x] No secrets, credentials, or sensitive data are included
- [x] Commit messages are descriptive
- [ ] Related docs and screenshots are updated

## [optional] What gif best describes this PR or how it makes you feel?

Someone quietly emptying the wastepaper basket that everyone had been stepping around for two years.
