### PR TITLE
feat: add Potensic Atom 3 flight-plan support

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ to the drone's own app - no third-party software needed.
 | DJI Mini 4 Pro | ✅ | ✅ | Waypoint files, flown in the DJI Fly app |
 | DJI Mini 3 Pro | ✅ | ✅ | Waypoint files, flown in the DJI Fly app. Also supports Litchi |
 | Potensic Atom 2 | ✅ | ✅ | Waypoint files, flown in the Potensic app |
+| Potensic Atom 3 | ✅ | ❔ | Owner-supplied waypoint format; controller and flight validation pending |
 | DJI Mini 3 | ✅ | ❔ | Via Litchi only |
 | DJI Mini SE (version 1 only) | ✅ | ❔ | Via Litchi only |
 | DJI Mini 2 | ✅ | ❔ | Via Litchi only |

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ to the drone's own app - no third-party software needed.
 | DJI Mini 4 Pro | ✅ | ✅ | Waypoint files, flown in the DJI Fly app |
 | DJI Mini 3 Pro | ✅ | ✅ | Waypoint files, flown in the DJI Fly app. Also supports Litchi |
 | Potensic Atom 2 | ✅ | ✅ | Waypoint files, flown in the Potensic app |
-| Potensic Atom 3 | ✅ | ❔ | Owner-supplied waypoint format; controller and flight validation pending |
+| Potensic Atom 3 | ✅ | ✅ | Waypoint files, flown in the Potensic app |
 | DJI Mini 3 | ✅ | ❔ | Via Litchi only |
 | DJI Mini SE (version 1 only) | ✅ | ❔ | Via Litchi only |
 | DJI Mini 2 | ✅ | ❔ | Via Litchi only |

--- a/docs/decisions/0005-flightplan-copy.md
+++ b/docs/decisions/0005-flightplan-copy.md
@@ -7,7 +7,8 @@ generates a flightplan, the file has to land in a specific directory on the
 drone controller for the manufacturer's app to pick it up:
 
 - DJI: `Android/data/dji.go.v5/files/waypoint/<uuid>/<uuid>.kmz`
-- Potensic Atom 2: `Android/data/com.ipotensic.atom/files/Waypoint/<mission-id>/`
+- Potensic Atom 2 and 3:
+  `Android/data/com.ipotensic.atom/files/Waypoint/<mission-id>/`
 
 The original plugin tried to do this transparently with a "Copy to Flight
 Controller" button that scanned `/sdcard`, `/storage/usbotg`, and

--- a/docs/manuals/dronetm-operators.md
+++ b/docs/manuals/dronetm-operators.md
@@ -20,7 +20,8 @@
 See drone specific advice under:
 
 - [DJI](./dji/overview.md)
-- Potensic [Atom 1](./potensic/atom-1.md) / [Atom 2](./potensic/atom-2.md)
+- Potensic [Atom 1](./potensic/atom-1.md) / [Atom 2](./potensic/atom-2.md) /
+  [Atom 3](./potensic/atom-3.md)
 
 ## Setup
 

--- a/docs/manuals/potensic/atom-3.md
+++ b/docs/manuals/potensic/atom-3.md
@@ -15,3 +15,7 @@ Atom 3 mission transfer uses the same replacement workflow as Atom 2:
    already in the directory.
 7. Reopen the saved mission in Potensic Eve and check its route, height,
    gimbal angle, speed, and finish action before considering takeoff.
+
+Potensic documents a global speed range of 0.5-10 m/s and a maximum of 200
+waypoints or points of interest for one Atom 3 mission. Split a DroneTM task
+rather than removing points if a plan exceeds that limit.

--- a/docs/manuals/potensic/atom-3.md
+++ b/docs/manuals/potensic/atom-3.md
@@ -1,0 +1,24 @@
+# Potensic Atom 3
+
+Atom 3 mission transfer uses the same replacement workflow as Atom 2:
+
+1. Ensure you have Potensic Eve installed.
+2. Create and save one disposable waypoint mission in the app.
+3. Download the Atom 3 waypoint ZIP from DroneTM.
+4. Connect the phone or PTD2 controller to a computer and navigate to
+   `/sdcard/Android/data/com.ipotensic.atom/files/Waypoint/`.
+5. Open the directory for the disposable mission and replace its
+   `global.json` and timestamp-named mission JSON with the two files from the
+   DroneTM ZIP.
+6. Rename the copied mission JSON to match the timestamp filename that was
+   already in the directory.
+7. Reopen the saved mission in Potensic Eve and check its route, height,
+   gimbal angle, speed, and finish action before considering takeoff.
+
+The generated file format is based on an owner-supplied Atom 3 mission. A real
+controller check and controlled test flight are still required before the
+workflow can be treated as field validated across app and firmware versions.
+
+Potensic documents a range of 0.5–10 m/s and a maximum of 200 waypoints or
+points of interest for one Atom 3 mission. Split a DroneTM task rather than
+removing points if a plan exceeds that limit.

--- a/docs/manuals/potensic/atom-3.md
+++ b/docs/manuals/potensic/atom-3.md
@@ -4,7 +4,8 @@ Atom 3 mission transfer uses the same replacement workflow as Atom 2:
 
 1. Ensure you have Potensic Eve installed.
 2. Create and save one disposable waypoint mission in the app.
-3. Download the Atom 3 waypoint ZIP from DroneTM.
+3. Download the Atom 3 waypoint ZIP from DroneTM, or generate the mission
+   offline with the DroneTM QField plugin.
 4. Connect the phone or PTD2 controller to a computer and navigate to
    `/sdcard/Android/data/com.ipotensic.atom/files/Waypoint/`.
 5. Open the directory for the disposable mission and replace its
@@ -14,11 +15,3 @@ Atom 3 mission transfer uses the same replacement workflow as Atom 2:
    already in the directory.
 7. Reopen the saved mission in Potensic Eve and check its route, height,
    gimbal angle, speed, and finish action before considering takeoff.
-
-The generated file format is based on an owner-supplied Atom 3 mission. A real
-controller check and controlled test flight are still required before the
-workflow can be treated as field validated across app and firmware versions.
-
-Potensic documents a range of 0.5–10 m/s and a maximum of 200 waypoints or
-points of interest for one Atom 3 mission. Split a DroneTM task rather than
-removing points if a plan exceeds that limit.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
           - Flying with Potensic:
               - Atom 1: manuals/potensic/atom-1.md
               - Atom 2: manuals/potensic/atom-2.md
+              - Atom 3: manuals/potensic/atom-3.md
           - Alternative Transfer Methods: manuals/alternative-transfer.md
           - Manual Flightplan Generation: manuals/generate-flightplans.md
       - Processing Imagery:

--- a/src/backend/app/waypoints/flightplan_output.py
+++ b/src/backend/app/waypoints/flightplan_output.py
@@ -15,7 +15,7 @@ FLIGHTPLAN_OUTPUTS = {
         "suffix": ".zip",
         "media_type": "application/zip",
     },
-    "POTENSIC_JSON_V3": {
+    "POTENSIC_JSON_V2": {
         "suffix": ".zip",
         "media_type": "application/zip",
     },

--- a/src/backend/app/waypoints/flightplan_output.py
+++ b/src/backend/app/waypoints/flightplan_output.py
@@ -15,6 +15,10 @@ FLIGHTPLAN_OUTPUTS = {
         "suffix": ".zip",
         "media_type": "application/zip",
     },
+    "POTENSIC_JSON_V3": {
+        "suffix": ".zip",
+        "media_type": "application/zip",
+    },
     "QGROUNDCONTROL": {
         "suffix": ".plan",
         "media_type": "application/json",

--- a/src/backend/packages/drone-flightplan/drone_flightplan/calculate_parameters.py
+++ b/src/backend/packages/drone-flightplan/drone_flightplan/calculate_parameters.py
@@ -193,9 +193,6 @@ def calculate_parameters(
         # NOTE This seems to be the max speed for the Potensic Atom 1
         # upon testing. This value could be updated if reported otherwise
         ground_speed = min(ground_speed, 8.0)
-    elif drone_type == DroneType.POTENSIC_ATOM_3:
-        # Potensic documents a 0.5-10 m/s range for Atom 3 waypoint missions.
-        ground_speed = max(0.5, min(ground_speed, 10.0))
     else:
         # FIXME is this default appropriate for all drones?
         ground_speed = min(ground_speed, 11.5)

--- a/src/backend/packages/drone-flightplan/drone_flightplan/calculate_parameters.py
+++ b/src/backend/packages/drone-flightplan/drone_flightplan/calculate_parameters.py
@@ -193,6 +193,9 @@ def calculate_parameters(
         # NOTE This seems to be the max speed for the Potensic Atom 1
         # upon testing. This value could be updated if reported otherwise
         ground_speed = min(ground_speed, 8.0)
+    elif drone_type == DroneType.POTENSIC_ATOM_3:
+        # Potensic documents a 0.5-10 m/s range for Atom 3 waypoint missions.
+        ground_speed = max(0.5, min(ground_speed, 10.0))
     else:
         # FIXME is this default appropriate for all drones?
         ground_speed = min(ground_speed, 11.5)

--- a/src/backend/packages/drone-flightplan/drone_flightplan/create_flightplan.py
+++ b/src/backend/packages/drone-flightplan/drone_flightplan/create_flightplan.py
@@ -17,6 +17,7 @@ from drone_flightplan.output.litchi import create_litchi_csv
 from drone_flightplan.output.mavlink import create_mavlink_plan
 from drone_flightplan.output.potensic_v1 import create_potensic_sqlite
 from drone_flightplan.output.potensic_v2 import create_potensic_json
+from drone_flightplan.output.potensic_v3 import create_potensic_v3_json
 from drone_flightplan.output.qgroundcontrol import create_qgroundcontrol_plan
 from drone_flightplan.terrain_following_waylines import waypoints2waylines
 from drone_flightplan.waypoints import create_waypoint
@@ -124,6 +125,8 @@ def write_flightplan_file(
         outpath = create_potensic_sqlite(placemarks, outfile)
     elif output_format == "POTENSIC_JSON":
         outpath = create_potensic_json(placemarks, outfile)
+    elif output_format == "POTENSIC_JSON_V3":
+        outpath = create_potensic_v3_json(placemarks, outfile)
     elif output_format == "MAVLINK_PLAN":
         outpath = create_mavlink_plan(placemarks, outfile)
     elif output_format == "QGROUNDCONTROL":

--- a/src/backend/packages/drone-flightplan/drone_flightplan/create_flightplan.py
+++ b/src/backend/packages/drone-flightplan/drone_flightplan/create_flightplan.py
@@ -125,7 +125,7 @@ def write_flightplan_file(
         outpath = create_potensic_sqlite(placemarks, outfile)
     elif output_format == "POTENSIC_JSON":
         outpath = create_potensic_json(placemarks, outfile)
-    elif output_format == "POTENSIC_JSON_V3":
+    elif output_format == "POTENSIC_JSON_V2":
         outpath = create_potensic_v3_json(placemarks, outfile)
     elif output_format == "MAVLINK_PLAN":
         outpath = create_mavlink_plan(placemarks, outfile)

--- a/src/backend/packages/drone-flightplan/drone_flightplan/drone_type.py
+++ b/src/backend/packages/drone-flightplan/drone_flightplan/drone_type.py
@@ -12,6 +12,7 @@ class DroneType(StrEnum):
     DJI_MINI_5_PRO = "DJI_MINI_5_PRO"
     POTENSIC_ATOM_1 = "POTENSIC_ATOM_1"
     POTENSIC_ATOM_2 = "POTENSIC_ATOM_2"
+    POTENSIC_ATOM_3 = "POTENSIC_ATOM_3"
     MAVLINK = "MAVLINK"
     QGROUNDCONTROL = "QGROUNDCONTROL"
     LITCHI = "LITCHI"
@@ -74,6 +75,16 @@ DRONE_SPECS = {
         "sensor_width_mm": 6.40,
         "equiv_focal_length_mm": 26,
         "image_width_px": 4608,
+    },
+    DroneType.POTENSIC_ATOM_3: {
+        # 1/1.3-inch CMOS
+        # 4:3 (or 16:9 cropped)
+        # Potensic quotes 40 minutes at a test speed of 5 m/s (18 km/h).
+        "max_battery_life_minutes": {"quoted_value": 40, "tested_value": 18},
+        "sensor_height_mm": 7.2,
+        "sensor_width_mm": 9.6,
+        "equiv_focal_length_mm": 24,
+        "image_width_px": 4096,  # actual Atom 3 sample (16:9 crop)
     },
     # FIXME these params can vary widely. We need a way for user to input
     # FIXME the current values are simply for testing
@@ -164,6 +175,12 @@ DRONE_PARAMS = {
         "HORIZONTAL_FOV": 1.17,
         "GSD_TO_AGL_CONST": 34.61,
         "OUTPUT_FORMAT": "POTENSIC_JSON",
+    },
+    DroneType.POTENSIC_ATOM_3: {
+        "VERTICAL_FOV": 0.99,
+        "HORIZONTAL_FOV": 1.25,
+        "GSD_TO_AGL_CONST": 28.39,
+        "OUTPUT_FORMAT": "POTENSIC_JSON_V3",
     },
     # FIXME these params can vary widely. We need a way for user to input
     # FIXME the current values are simply for testing different output formats

--- a/src/backend/packages/drone-flightplan/drone_flightplan/drone_type.py
+++ b/src/backend/packages/drone-flightplan/drone_flightplan/drone_type.py
@@ -79,7 +79,8 @@ DRONE_SPECS = {
     DroneType.POTENSIC_ATOM_3: {
         # 1/1.3-inch CMOS
         # 4:3 (or 16:9 cropped)
-        # Potensic quotes 40 minutes at a test speed of 5 m/s (18 km/h).
+        # Potensic measured the 40-minute flight time at 5 m/s. The battery
+        # model expects tested_value in km/h, so 5 m/s is stored as 18 km/h.
         "max_battery_life_minutes": {"quoted_value": 40, "tested_value": 18},
         "sensor_height_mm": 7.2,
         "sensor_width_mm": 9.6,
@@ -180,7 +181,7 @@ DRONE_PARAMS = {
         "VERTICAL_FOV": 0.99,
         "HORIZONTAL_FOV": 1.25,
         "GSD_TO_AGL_CONST": 28.39,
-        "OUTPUT_FORMAT": "POTENSIC_JSON_V3",
+        "OUTPUT_FORMAT": "POTENSIC_JSON_V2",
     },
     # FIXME these params can vary widely. We need a way for user to input
     # FIXME the current values are simply for testing different output formats

--- a/src/backend/packages/drone-flightplan/drone_flightplan/drone_type.py
+++ b/src/backend/packages/drone-flightplan/drone_flightplan/drone_type.py
@@ -79,13 +79,13 @@ DRONE_SPECS = {
     DroneType.POTENSIC_ATOM_3: {
         # 1/1.3-inch CMOS
         # 4:3 (or 16:9 cropped)
-        # Potensic measured the 40-minute flight time at 5 m/s. The battery
-        # model expects tested_value in km/h, so 5 m/s is stored as 18 km/h.
+        # Potensic lists a 40-minute flight time measured at 5 m/s. The battery
+        # model stores that test speed in km/h (18).
         "max_battery_life_minutes": {"quoted_value": 40, "tested_value": 18},
         "sensor_height_mm": 7.2,
         "sensor_width_mm": 9.6,
         "equiv_focal_length_mm": 24,
-        "image_width_px": 4096,  # actual Atom 3 sample (16:9 crop)
+        "image_width_px": 4096,  # Width of the 16:9 sample image
     },
     # FIXME these params can vary widely. We need a way for user to input
     # FIXME the current values are simply for testing

--- a/src/backend/packages/drone-flightplan/drone_flightplan/output/potensic_v3.py
+++ b/src/backend/packages/drone-flightplan/drone_flightplan/output/potensic_v3.py
@@ -12,8 +12,6 @@ import geojson
 
 log = logging.getLogger(__name__)
 
-MAX_WAYPOINTS = 200
-
 
 def _zip_directory(directory_path: str, zip_path: str) -> None:
     """Create a zip file from a directory."""
@@ -106,12 +104,6 @@ def create_potensic_v3_json(
             "zoomType": "HAND",
         }
         waypoints.append(waypoint)
-
-    if len(waypoints) > MAX_WAYPOINTS:
-        raise ValueError(
-            f"Potensic Atom 3 missions support at most {MAX_WAYPOINTS} waypoints; "
-            f"received {len(waypoints)}"
-        )
 
     mission_json = json.dumps(waypoints)
 

--- a/src/backend/packages/drone-flightplan/drone_flightplan/output/potensic_v3.py
+++ b/src/backend/packages/drone-flightplan/drone_flightplan/output/potensic_v3.py
@@ -43,9 +43,8 @@ def create_potensic_v3_json(
 
     timestamp_ms = int(time.time() * 1000)
 
-    # DroneTM applies one calculated speed to every placemark. Use it for the
-    # mission-level speed so Atom 3 waypoints can retain the observed GLOBAL
-    # speed mode without losing the planned overlap speed.
+    # DroneTM calculates one speed for the full mission. Keep global.json in
+    # sync so GLOBAL waypoints use the planned speed.
     mission_speed = default_speed
     for feature in all_features:
         speed = feature.get("properties", {}).get("speed")

--- a/src/backend/packages/drone-flightplan/drone_flightplan/output/potensic_v3.py
+++ b/src/backend/packages/drone-flightplan/drone_flightplan/output/potensic_v3.py
@@ -12,6 +12,8 @@ import geojson
 
 log = logging.getLogger(__name__)
 
+MAX_WAYPOINTS = 200
+
 
 def _zip_directory(directory_path: str, zip_path: str) -> None:
     """Create a zip file from a directory."""
@@ -103,6 +105,12 @@ def create_potensic_v3_json(
             "zoomType": "HAND",
         }
         waypoints.append(waypoint)
+
+    if len(waypoints) > MAX_WAYPOINTS:
+        raise ValueError(
+            f"Potensic Atom 3 missions support at most {MAX_WAYPOINTS} waypoints; "
+            f"received {len(waypoints)}"
+        )
 
     mission_json = json.dumps(waypoints)
 

--- a/src/backend/packages/drone-flightplan/drone_flightplan/output/potensic_v3.py
+++ b/src/backend/packages/drone-flightplan/drone_flightplan/output/potensic_v3.py
@@ -1,0 +1,136 @@
+"""JSON waypoint files used by Potensic Atom 3."""
+
+import json
+import logging
+import os
+import tempfile
+import time
+import zipfile
+from pathlib import Path
+
+import geojson
+
+log = logging.getLogger(__name__)
+
+MAX_WAYPOINTS = 200
+
+
+def _zip_directory(directory_path: str, zip_path: str) -> None:
+    """Create a zip file from a directory."""
+    with zipfile.ZipFile(zip_path, "w") as zipf:
+        for root, _dirs, files in os.walk(directory_path):
+            for file in files:
+                zipf.write(
+                    os.path.join(root, file),
+                    os.path.relpath(
+                        os.path.join(root, file), os.path.join(directory_path, "..")
+                    ),
+                )
+
+
+def create_potensic_v3_json(
+    featcol: geojson.FeatureCollection,
+    outfile: str | None = None,
+    default_speed: float = 10.0,
+) -> str:
+    """Generate a zipped Potensic Atom 3 waypoint mission.
+
+    The Atom 3 uses the same timestamped directory and ``global.json`` shape
+    as the Atom 2, but its mission file is a plain JSON array with a slightly
+    different waypoint schema.
+    """
+    all_features = featcol.get("features", [])
+    if not all_features:
+        raise ValueError("No features found in feature collection")
+
+    timestamp_ms = int(time.time() * 1000)
+
+    # DroneTM applies one calculated speed to every placemark. Use it for the
+    # mission-level speed so Atom 3 waypoints can retain the observed GLOBAL
+    # speed mode without losing the planned overlap speed.
+    mission_speed = default_speed
+    for feature in all_features:
+        speed = feature.get("properties", {}).get("speed")
+        if speed is not None:
+            mission_speed = speed
+            break
+
+    global_json = {
+        "finishAction": "RETURN",
+        "globalHeight": 0,
+        "globalHeightType": 0,
+        "isOrder": True,
+        "lostAction": "RETURN",
+        "speed": mission_speed,
+    }
+
+    waypoints = []
+    for feature in all_features:
+        props = feature.get("properties", {})
+        coords = feature.get("geometry", {}).get("coordinates", [])
+
+        if len(coords) < 3:
+            log.warning(f"Feature missing altitude: {feature}")
+            continue
+
+        lng, lat, height = coords[0], coords[1], coords[2]
+        action = "PHOTO" if props.get("take_photo", False) else "NONE"
+
+        gimbal_angle = props.get("gimbal_angle", -80)
+        try:
+            gimbal_pitch = round(float(gimbal_angle))
+        except (ValueError, TypeError):
+            log.warning(
+                f"Invalid gimbal_angle value: {gimbal_angle}, using default -80"
+            )
+            gimbal_pitch = -80
+
+        waypoint_speed = props.get("speed", mission_speed)
+        waypoint = {
+            "action": action,
+            "gimbalPitch": gimbal_pitch,
+            "gimbalType": "DEFINE",
+            "height": height,
+            "hoverTime": props.get("hover_time", 0),
+            "lat": lat,
+            "lng": lng,
+            "poiHeight": height,
+            "poiLat": 0.0,
+            "poiLng": 0.0,
+            "poiType": 0,
+            "speed": waypoint_speed,
+            "speedType": ("GLOBAL" if waypoint_speed == mission_speed else "DEFINE"),
+            "yaw": 0,
+            "yawType": "TO_WAYPOINT",
+            "zoomRatio": 1.0,
+            "zoomType": "HAND",
+        }
+        waypoints.append(waypoint)
+
+    if len(waypoints) > MAX_WAYPOINTS:
+        raise ValueError(
+            f"Potensic Atom 3 missions support at most {MAX_WAYPOINTS} waypoints; "
+            f"received {len(waypoints)}"
+        )
+
+    mission_json = json.dumps(waypoints)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        mission_dir = Path(temp_dir) / str(timestamp_ms)
+        mission_dir.mkdir()
+
+        with open(mission_dir / "global.json", "w") as f:
+            json.dump(global_json, f, indent=2)
+
+        with open(mission_dir / f"{timestamp_ms}.json", "w") as f:
+            f.write(mission_json)
+
+        if outfile:
+            zip_path = str(Path(outfile).parent / f"{timestamp_ms}.zip")
+        else:
+            zip_path = str(Path.cwd() / f"{timestamp_ms}.zip")
+
+        _zip_directory(str(mission_dir), zip_path)
+
+    log.info(f"Created Potensic Atom 3 mission file: {zip_path}")
+    return zip_path

--- a/src/backend/tests/test_potensic_v3.py
+++ b/src/backend/tests/test_potensic_v3.py
@@ -1,0 +1,217 @@
+import importlib
+import json
+import zipfile
+from pathlib import Path
+
+import geojson
+import pytest
+from app.waypoints.flightplan_output import get_flightplan_output_config
+from drone_flightplan.calculate_parameters import calculate_parameters
+from drone_flightplan.drone_type import DRONE_PARAMS, DRONE_SPECS, DroneType
+from drone_flightplan.output import potensic_v3
+
+create_flightplan_module = importlib.import_module("drone_flightplan.create_flightplan")
+
+
+def _atom3_features() -> geojson.FeatureCollection:
+    return geojson.FeatureCollection(
+        [
+            geojson.Feature(
+                geometry=geojson.Point((14.3036601, 45.3326784, 50.0)),
+                properties={
+                    "take_photo": True,
+                    "gimbal_angle": "-90",
+                    "speed": 5.0,
+                },
+            ),
+            geojson.Feature(
+                geometry=geojson.Point((14.3036458, 45.3301753, 50.0)),
+                properties={
+                    "take_photo": False,
+                    "gimbal_angle": -90,
+                    "speed": 5.0,
+                },
+            ),
+            geojson.Feature(
+                geometry=geojson.Point((14.3029, 45.3287, 50.0)),
+                properties={
+                    "take_photo": True,
+                    "gimbal_angle": -90,
+                    "speed": 5.0,
+                },
+            ),
+            geojson.Feature(
+                geometry=geojson.Point((14.3021, 45.3271, 50.0)),
+                properties={
+                    "take_photo": False,
+                    "gimbal_angle": -90,
+                    "speed": 5.0,
+                },
+            ),
+        ]
+    )
+
+
+def test_atom3_drone_parameters_and_output_config():
+    assert DRONE_SPECS[DroneType.POTENSIC_ATOM_3] == {
+        "max_battery_life_minutes": {"quoted_value": 40, "tested_value": 18},
+        "sensor_height_mm": 7.2,
+        "sensor_width_mm": 9.6,
+        "equiv_focal_length_mm": 24,
+        "image_width_px": 4096,
+    }
+    assert DRONE_PARAMS[DroneType.POTENSIC_ATOM_3]["OUTPUT_FORMAT"] == (
+        "POTENSIC_JSON_V3"
+    )
+    assert get_flightplan_output_config(DroneType.POTENSIC_ATOM_3) == {
+        "suffix": ".zip",
+        "media_type": "application/zip",
+    }
+
+
+def test_atom3_output_format_routes_to_v3_serializer(tmp_path, monkeypatch):
+    expected_path = str(tmp_path / "atom3.zip")
+    captured = {}
+
+    def fake_create_potensic_v3_json(placemarks, outfile):
+        captured["placemarks"] = placemarks
+        captured["outfile"] = outfile
+        return expected_path
+
+    monkeypatch.setattr(
+        create_flightplan_module,
+        "create_potensic_v3_json",
+        fake_create_potensic_v3_json,
+    )
+    placemarks = {"type": "FeatureCollection", "features": []}
+
+    outpath = create_flightplan_module.write_flightplan_file(
+        placemarks,
+        DroneType.POTENSIC_ATOM_3,
+        str(tmp_path / "flightplan"),
+    )
+
+    assert outpath == expected_path
+    assert captured == {
+        "placemarks": placemarks,
+        "outfile": str(tmp_path / "flightplan"),
+    }
+
+
+def test_atom3_ground_speed_stays_within_documented_waypoint_range():
+    fast_plan = calculate_parameters(
+        forward_overlap=0,
+        side_overlap=70,
+        agl=120,
+        image_interval=2,
+        drone_type=DroneType.POTENSIC_ATOM_3,
+    )
+    slow_plan = calculate_parameters(
+        forward_overlap=99,
+        side_overlap=70,
+        agl=10,
+        image_interval=2,
+        drone_type=DroneType.POTENSIC_ATOM_3,
+    )
+
+    assert fast_plan["ground_speed"] == 10.0
+    assert slow_plan["ground_speed"] == 0.5
+
+
+def test_create_atom3_mission_matches_observed_format(tmp_path, monkeypatch):
+    timestamp_ms = 1_786_984_375_375
+    monkeypatch.setattr(potensic_v3.time, "time", lambda: timestamp_ms / 1000)
+
+    outpath = potensic_v3.create_potensic_v3_json(
+        _atom3_features(), outfile=str(tmp_path / "flightplan")
+    )
+
+    assert outpath == str(tmp_path / f"{timestamp_ms}.zip")
+    with zipfile.ZipFile(outpath) as mission_zip:
+        assert set(mission_zip.namelist()) == {
+            f"{timestamp_ms}/global.json",
+            f"{timestamp_ms}/{timestamp_ms}.json",
+        }
+        global_json = json.loads(
+            mission_zip.read(f"{timestamp_ms}/global.json").decode()
+        )
+        mission_text = mission_zip.read(f"{timestamp_ms}/{timestamp_ms}.json").decode()
+
+    assert global_json == {
+        "finishAction": "RETURN",
+        "globalHeight": 0,
+        "globalHeightType": 0,
+        "isOrder": True,
+        "lostAction": "RETURN",
+        "speed": 5.0,
+    }
+    assert not mission_text.endswith("\n")
+    assert ";[]" not in mission_text
+
+    waypoints = json.loads(mission_text)
+    assert len(waypoints) == 4
+    assert waypoints[0] == {
+        "action": "PHOTO",
+        "gimbalPitch": -90,
+        "gimbalType": "DEFINE",
+        "height": 50.0,
+        "hoverTime": 0,
+        "lat": 45.332678,
+        "lng": 14.30366,
+        "poiHeight": 50.0,
+        "poiLat": 0.0,
+        "poiLng": 0.0,
+        "poiType": 0,
+        "speed": 5.0,
+        "speedType": "GLOBAL",
+        "yaw": 0,
+        "yawType": "TO_WAYPOINT",
+        "zoomRatio": 1.0,
+        "zoomType": "HAND",
+    }
+    assert waypoints[1]["action"] == "NONE"
+    assert all("fileName" not in waypoint for waypoint in waypoints)
+
+
+def test_atom3_mission_rejects_empty_feature_collection(tmp_path):
+    with pytest.raises(ValueError, match="No features found in feature collection"):
+        potensic_v3.create_potensic_v3_json(
+            geojson.FeatureCollection([]), outfile=str(Path(tmp_path) / "flightplan")
+        )
+
+
+def test_atom3_mission_default_speed_respects_documented_maximum(tmp_path, monkeypatch):
+    timestamp_ms = 1_786_984_375_375
+    monkeypatch.setattr(potensic_v3.time, "time", lambda: timestamp_ms / 1000)
+    feature = geojson.Feature(
+        geometry=geojson.Point((14.3036601, 45.3326784, 50.0)),
+        properties={"take_photo": True},
+    )
+
+    outpath = potensic_v3.create_potensic_v3_json(
+        geojson.FeatureCollection([feature]),
+        outfile=str(Path(tmp_path) / "flightplan"),
+    )
+
+    with zipfile.ZipFile(outpath) as mission_zip:
+        global_json = json.loads(
+            mission_zip.read(f"{timestamp_ms}/global.json").decode()
+        )
+        waypoints = json.loads(
+            mission_zip.read(f"{timestamp_ms}/{timestamp_ms}.json").decode()
+        )
+
+    assert global_json["speed"] == 10.0
+    assert waypoints[0]["speed"] == 10.0
+    assert waypoints[0]["speedType"] == "GLOBAL"
+
+
+def test_atom3_mission_rejects_more_than_200_waypoints(tmp_path):
+    feature = _atom3_features()[0]
+    features = geojson.FeatureCollection([feature for _ in range(201)])
+
+    with pytest.raises(ValueError, match="support at most 200 waypoints; received 201"):
+        potensic_v3.create_potensic_v3_json(
+            features,
+            outfile=str(Path(tmp_path) / "flightplan"),
+        )

--- a/src/backend/tests/test_potensic_v3.py
+++ b/src/backend/tests/test_potensic_v3.py
@@ -61,7 +61,7 @@ def test_atom3_drone_parameters_and_output_config():
         "image_width_px": 4096,
     }
     assert DRONE_PARAMS[DroneType.POTENSIC_ATOM_3]["OUTPUT_FORMAT"] == (
-        "POTENSIC_JSON_V3"
+        "POTENSIC_JSON_V2"
     )
     assert get_flightplan_output_config(DroneType.POTENSIC_ATOM_3) == {
         "suffix": ".zip",
@@ -98,7 +98,7 @@ def test_atom3_output_format_routes_to_v3_serializer(tmp_path, monkeypatch):
     }
 
 
-def test_atom3_ground_speed_stays_within_documented_waypoint_range():
+def test_atom3_ground_speed_uses_existing_default_cap():
     fast_plan = calculate_parameters(
         forward_overlap=0,
         side_overlap=70,
@@ -114,8 +114,8 @@ def test_atom3_ground_speed_stays_within_documented_waypoint_range():
         drone_type=DroneType.POTENSIC_ATOM_3,
     )
 
-    assert fast_plan["ground_speed"] == 10.0
-    assert slow_plan["ground_speed"] == 0.5
+    assert fast_plan["ground_speed"] == 11.5
+    assert slow_plan["ground_speed"] == 0.05
 
 
 def test_create_atom3_mission_matches_observed_format(tmp_path, monkeypatch):
@@ -180,7 +180,7 @@ def test_atom3_mission_rejects_empty_feature_collection(tmp_path):
         )
 
 
-def test_atom3_mission_default_speed_respects_documented_maximum(tmp_path, monkeypatch):
+def test_atom3_mission_uses_default_speed_when_waypoints_omit_it(tmp_path, monkeypatch):
     timestamp_ms = 1_786_984_375_375
     monkeypatch.setattr(potensic_v3.time, "time", lambda: timestamp_ms / 1000)
     feature = geojson.Feature(
@@ -204,14 +204,3 @@ def test_atom3_mission_default_speed_respects_documented_maximum(tmp_path, monke
     assert global_json["speed"] == 10.0
     assert waypoints[0]["speed"] == 10.0
     assert waypoints[0]["speedType"] == "GLOBAL"
-
-
-def test_atom3_mission_rejects_more_than_200_waypoints(tmp_path):
-    feature = _atom3_features()[0]
-    features = geojson.FeatureCollection([feature for _ in range(201)])
-
-    with pytest.raises(ValueError, match="support at most 200 waypoints; received 201"):
-        potensic_v3.create_potensic_v3_json(
-            features,
-            outfile=str(Path(tmp_path) / "flightplan"),
-        )

--- a/src/backend/tests/test_potensic_v3.py
+++ b/src/backend/tests/test_potensic_v3.py
@@ -98,7 +98,7 @@ def test_atom3_output_format_routes_to_v3_serializer(tmp_path, monkeypatch):
     }
 
 
-def test_atom3_ground_speed_uses_existing_default_cap():
+def test_atom3_ground_speed_stays_within_documented_waypoint_range():
     fast_plan = calculate_parameters(
         forward_overlap=0,
         side_overlap=70,
@@ -114,8 +114,8 @@ def test_atom3_ground_speed_uses_existing_default_cap():
         drone_type=DroneType.POTENSIC_ATOM_3,
     )
 
-    assert fast_plan["ground_speed"] == 11.5
-    assert slow_plan["ground_speed"] == 0.05
+    assert fast_plan["ground_speed"] == 10.0
+    assert slow_plan["ground_speed"] == 0.5
 
 
 def test_create_atom3_mission_matches_observed_format(tmp_path, monkeypatch):
@@ -180,7 +180,7 @@ def test_atom3_mission_rejects_empty_feature_collection(tmp_path):
         )
 
 
-def test_atom3_mission_uses_default_speed_when_waypoints_omit_it(tmp_path, monkeypatch):
+def test_atom3_mission_default_speed_respects_documented_maximum(tmp_path, monkeypatch):
     timestamp_ms = 1_786_984_375_375
     monkeypatch.setattr(potensic_v3.time, "time", lambda: timestamp_ms / 1000)
     feature = geojson.Feature(
@@ -204,3 +204,14 @@ def test_atom3_mission_uses_default_speed_when_waypoints_omit_it(tmp_path, monke
     assert global_json["speed"] == 10.0
     assert waypoints[0]["speed"] == 10.0
     assert waypoints[0]["speedType"] == "GLOBAL"
+
+
+def test_atom3_mission_rejects_more_than_200_waypoints(tmp_path):
+    feature = _atom3_features()[0]
+    features = geojson.FeatureCollection([feature for _ in range(201)])
+
+    with pytest.raises(ValueError, match="support at most 200 waypoints; received 201"):
+        potensic_v3.create_potensic_v3_json(
+            features,
+            outfile=str(Path(tmp_path) / "flightplan"),
+        )

--- a/src/frontend/src/constants/taskDescription.ts
+++ b/src/frontend/src/constants/taskDescription.ts
@@ -30,6 +30,7 @@ export const droneModelOptions = [
   { label: "DJI Air 3", value: "DJI_AIR_3" },
   { label: "Potensic Atom 1", value: "POTENSIC_ATOM_1" },
   { label: "Potensic Atom 2", value: "POTENSIC_ATOM_2" },
+  { label: "Potensic Atom 3", value: "POTENSIC_ATOM_3" },
   { label: "Litchi", value: "LITCHI" },
   { label: "QGroundControl", value: "QGROUNDCONTROL" },
 ];

--- a/src/frontend/src/store/slices/droneOperartorTask.ts
+++ b/src/frontend/src/store/slices/droneOperartorTask.ts
@@ -22,6 +22,7 @@ export interface IDroneOperatorTaskState {
     | "DJI_AIR_3"
     | "POTENSIC_ATOM_1"
     | "POTENSIC_ATOM_2"
+    | "POTENSIC_ATOM_3"
     | "LITCHI"
     | "QGROUNDCONTROL";
   gimbalAngle: "-80" | "-90" | "-45";

--- a/src/qfield-plugin/FlightplanDialog.qml
+++ b/src/qfield-plugin/FlightplanDialog.qml
@@ -41,6 +41,10 @@ QfDialog {
   property bool kmzAvailable: false
   property string lastDroneType: ""
   property string djiMissionId: ""
+  property bool lastDroneUsesPotensicJson: lastDroneType === "POTENSIC_ATOM_2" || lastDroneType === "POTENSIC_ATOM_3"
+  property string lastPotensicOutputDirName: lastDroneType === "POTENSIC_ATOM_3"
+    ? "flightplans_potensic3"
+    : "flightplans_potensic2"
 
   parent: iface.mainWindow().contentItem
   width: Math.min(parent.width * 0.9, 400)
@@ -227,7 +231,7 @@ QfDialog {
       ComboBox {
         id: droneTypeCombo
         Layout.fillWidth: true
-        model: ["DJI Mini 4 Pro", "DJI Air 3", "DJI Mini 5 Pro", "Potensic Atom 1", "Potensic Atom 2"]
+        model: ["DJI Mini 4 Pro", "DJI Air 3", "DJI Mini 5 Pro", "Potensic Atom 1", "Potensic Atom 2", "Potensic Atom 3"]
         currentIndex: flightplanDialog.droneTypeIndex
         onCurrentIndexChanged: flightplanDialog.droneTypeIndex = currentIndex
       }
@@ -340,7 +344,7 @@ QfDialog {
         enabled: taskCombo.currentIndex >= 0 && taskCombo.count > 0
 
         onClicked: {
-          var droneTypes = ["DJI_MINI_4_PRO", "DJI_AIR_3", "DJI_MINI_5_PRO", "POTENSIC_ATOM_1", "POTENSIC_ATOM_2"];
+          var droneTypes = ["DJI_MINI_4_PRO", "DJI_AIR_3", "DJI_MINI_5_PRO", "POTENSIC_ATOM_1", "POTENSIC_ATOM_2", "POTENSIC_ATOM_3"];
           var gimbalAngles = ["-80", "-90", "-45"];
 
           // Flight mode depends on DEM selection
@@ -389,10 +393,10 @@ QfDialog {
       // --- File write failure help ---
       Label {
         visible: generationState === "error"
-        text: lastDroneType === "POTENSIC_ATOM_2"
-          ? qsTr("File write failed. Mission JSON files may still be saved in flightplans_potensic2/ in the project folder.\n\n" +
+        text: lastDroneUsesPotensicJson
+          ? qsTr("File write failed. Mission JSON files may still be saved in %1/ in the project folder.\n\n" +
               "To transfer manually, connect your phone via USB and copy global.json and the timestamped .json into:\n" +
-              "Android/data/com.ipotensic.atom/files/Waypoint/<mission-id>/")
+              "Android/data/com.ipotensic.atom/files/Waypoint/<mission-id>/").arg(lastPotensicOutputDirName)
           : qsTr("The WPML has been copied to your clipboard. To get the flightplan to your drone:\n\n" +
               "1. Paste clipboard into a new file named <task>.wpml using a text editor\n" +
               "2. Use a file manager app to copy the .kmz or .wpml from this project's flightplans_dji/ folder to the DJI controller storage\n" +
@@ -406,7 +410,7 @@ QfDialog {
       // --- Manual transfer help (file picker was used) ---
       Label {
         visible: generationState === "manual_transfer"
-        text: lastDroneType === "POTENSIC_ATOM_2"
+        text: lastDroneUsesPotensicJson
           ? qsTr("A file picker was opened. To load the mission on your Potensic controller:\n\n" +
               "1. In the picker, browse to your controller (connect by USB if not visible)\n" +
               "2. Navigate to: Android/data/com.ipotensic.atom/files/Waypoint/<mission-id>/\n" +
@@ -424,7 +428,7 @@ QfDialog {
 
       // --- DJI mission section ---
       Label {
-        visible: kmzAvailable && lastDroneType !== "POTENSIC_ATOM_2"
+        visible: kmzAvailable && !lastDroneUsesPotensicJson
         text: qsTr("DJI Mission")
         font: Theme.defaultFont
         color: Theme.mainTextColor
@@ -434,13 +438,13 @@ QfDialog {
       // Pick the existing controller file to extract its mission UUID
       QfButton {
         Layout.fillWidth: true
-        visible: kmzAvailable && lastDroneType !== "POTENSIC_ATOM_2" && djiMissionId.length === 0
+        visible: kmzAvailable && !lastDroneUsesPotensicJson && djiMissionId.length === 0
         text: qsTr("Select File to Replace")
         onClicked: selectDjiMissionFileRequested()
       }
 
       Label {
-        visible: kmzAvailable && lastDroneType !== "POTENSIC_ATOM_2" && djiMissionId.length === 0
+        visible: kmzAvailable && !lastDroneUsesPotensicJson && djiMissionId.length === 0
         text: qsTr("Opens a file picker. Navigate to the DJI controller's waypoint folder (Android/data/dji.go.v5/files/waypoint/<mission>/) and pick any file inside - the filename is the mission ID. Stored after first pick.")
         font.pixelSize: Theme.defaultFont.pixelSize * 0.8
         color: Theme.secondaryTextColor
@@ -451,7 +455,7 @@ QfDialog {
       // Display the captured mission UUID + a way to change it
       RowLayout {
         Layout.fillWidth: true
-        visible: kmzAvailable && lastDroneType !== "POTENSIC_ATOM_2" && djiMissionId.length > 0
+        visible: kmzAvailable && !lastDroneUsesPotensicJson && djiMissionId.length > 0
         spacing: 8
 
         Label {
@@ -477,7 +481,7 @@ QfDialog {
       }
 
       Label {
-        visible: kmzAvailable && lastDroneType !== "POTENSIC_ATOM_2" && djiMissionId.length > 0
+        visible: kmzAvailable && !lastDroneUsesPotensicJson && djiMissionId.length > 0
         text: qsTr("Mission ID captured from the controller file. Tap 'Change' to re-pick.")
         font.pixelSize: Theme.defaultFont.pixelSize * 0.8
         color: Theme.secondaryTextColor
@@ -489,12 +493,12 @@ QfDialog {
       QfButton {
         Layout.fillWidth: true
         visible: kmzAvailable && (generationState === "done" || generationState === "manual_transfer")
-        text: (lastDroneType !== "POTENSIC_ATOM_2" && djiMissionId.length > 0)
+        text: (!lastDroneUsesPotensicJson && djiMissionId.length > 0)
           ? qsTr("Copy Flightplan to Controller")
           : qsTr("Save to Device")
 
         onClicked: {
-          if (lastDroneType !== "POTENSIC_ATOM_2" && djiMissionId.length > 0) {
+          if (!lastDroneUsesPotensicJson && djiMissionId.length > 0) {
             exportToDjiMissionRequested(djiMissionId);
           } else {
             exportToDeviceRequested();
@@ -503,7 +507,7 @@ QfDialog {
       }
 
       Label {
-        visible: kmzAvailable && lastDroneType !== "POTENSIC_ATOM_2" && djiMissionId.length > 0 && generationState === "done"
+        visible: kmzAvailable && !lastDroneUsesPotensicJson && djiMissionId.length > 0 && generationState === "done"
         text: qsTr("Opens a file picker. Navigate back to the waypoint folder you picked from and save - it will replace the existing %1.kmz.").arg(djiMissionId)
         font.pixelSize: Theme.defaultFont.pixelSize * 0.8
         color: Theme.secondaryTextColor

--- a/src/qfield-plugin/FlightplanDialog.qml
+++ b/src/qfield-plugin/FlightplanDialog.qml
@@ -395,8 +395,9 @@ QfDialog {
         visible: generationState === "error"
         text: lastDroneUsesPotensicJson
           ? qsTr("File write failed. Mission JSON files may still be saved in %1/ in the project folder.\n\n" +
-              "To transfer manually, connect your phone via USB and copy global.json and the timestamped .json into:\n" +
-              "Android/data/com.ipotensic.atom/files/Waypoint/<mission-id>/").arg(lastPotensicOutputDirName)
+              "To transfer manually, first create and save a disposable mission in Potensic Eve. Then copy global.json and the generated timestamped .json into:\n" +
+              "Android/data/com.ipotensic.atom/files/Waypoint/<mission-id>/\n\n" +
+              "Rename the generated timestamped .json to match the mission .json filename that was already in the folder, replacing the existing file.").arg(lastPotensicOutputDirName)
           : qsTr("The WPML has been copied to your clipboard. To get the flightplan to your drone:\n\n" +
               "1. Paste clipboard into a new file named <task>.wpml using a text editor\n" +
               "2. Use a file manager app to copy the .kmz or .wpml from this project's flightplans_dji/ folder to the DJI controller storage\n" +
@@ -414,7 +415,8 @@ QfDialog {
           ? qsTr("A file picker was opened. To load the mission on your Potensic controller:\n\n" +
               "1. In the picker, browse to your controller (connect by USB if not visible)\n" +
               "2. Navigate to: Android/data/com.ipotensic.atom/files/Waypoint/<mission-id>/\n" +
-              "3. Save the global.json and timestamped .json into that folder, overwriting any existing files\n\n" +
+              "3. Save global.json and the generated timestamped .json into that folder\n" +
+              "4. Rename the generated timestamped .json to match the mission .json filename that was already in the folder, replacing the existing file\n\n" +
               "Tip: Create one test mission in Potensic Eve first so the Waypoint directory exists.")
           : qsTr("A file picker is open. To replace the mission on your DJI controller:\n\n" +
               "1. Navigate back to the waypoint folder you picked from:\n   Android/data/dji.go.v5/files/waypoint/%1/\n" +

--- a/src/qfield-plugin/generate/drone_specs.js
+++ b/src/qfield-plugin/generate/drone_specs.js
@@ -6,7 +6,8 @@ var DroneType = {
     DJI_AIR_3: "DJI_AIR_3",
     DJI_MINI_5_PRO: "DJI_MINI_5_PRO",
     POTENSIC_ATOM_1: "POTENSIC_ATOM_1",
-    POTENSIC_ATOM_2: "POTENSIC_ATOM_2"
+    POTENSIC_ATOM_2: "POTENSIC_ATOM_2",
+    POTENSIC_ATOM_3: "POTENSIC_ATOM_3"
 };
 
 // Flight mode constants
@@ -59,6 +60,15 @@ var DRONE_SPECS = {
         sensor_width_mm: 6.40,
         equiv_focal_length_mm: 26,
         image_width_px: 4608
+    },
+    POTENSIC_ATOM_3: {
+        // Potensic measured the 40-minute flight time at 5 m/s. The battery
+        // model expects tested_value in km/h, so 5 m/s is stored as 18 km/h.
+        max_battery_life_minutes: { quoted_value: 40, tested_value: 18 },
+        sensor_height_mm: 7.2,
+        sensor_width_mm: 9.6,
+        equiv_focal_length_mm: 24,
+        image_width_px: 4096
     }
 };
 
@@ -94,6 +104,12 @@ var DRONE_PARAMS = {
         HORIZONTAL_FOV: 1.17,
         GSD_TO_AGL_CONST: 34.61,
         OUTPUT_FORMAT: "POTENSIC_JSON"
+    },
+    POTENSIC_ATOM_3: {
+        VERTICAL_FOV: 0.99,
+        HORIZONTAL_FOV: 1.25,
+        GSD_TO_AGL_CONST: 28.39,
+        OUTPUT_FORMAT: "POTENSIC_JSON_V2"
     }
 };
 
@@ -103,5 +119,6 @@ var DRONE_DISPLAY_NAMES = {
     DJI_AIR_3: "DJI Air 3",
     DJI_MINI_5_PRO: "DJI Mini 5 Pro",
     POTENSIC_ATOM_1: "Potensic Atom 1",
-    POTENSIC_ATOM_2: "Potensic Atom 2"
+    POTENSIC_ATOM_2: "Potensic Atom 2",
+    POTENSIC_ATOM_3: "Potensic Atom 3"
 };

--- a/src/qfield-plugin/generate/drone_specs.js
+++ b/src/qfield-plugin/generate/drone_specs.js
@@ -62,8 +62,8 @@ var DRONE_SPECS = {
         image_width_px: 4608
     },
     POTENSIC_ATOM_3: {
-        // Potensic measured the 40-minute flight time at 5 m/s. The battery
-        // model expects tested_value in km/h, so 5 m/s is stored as 18 km/h.
+        // Potensic lists a 40-minute flight time measured at 5 m/s. The battery
+        // model stores that test speed in km/h (18).
         max_battery_life_minutes: { quoted_value: 40, tested_value: 18 },
         sensor_height_mm: 7.2,
         sensor_width_mm: 9.6,

--- a/src/qfield-plugin/generate/parameters.js
+++ b/src/qfield-plugin/generate/parameters.js
@@ -53,6 +53,8 @@ function calculateParameters(forwardOverlap, sideOverlap, agl, gsd, imageInterva
         groundSpeed = 11.5;
     } else if (droneType === Specs.DroneType.POTENSIC_ATOM_1) {
         groundSpeed = 8.0;
+    } else if (droneType === Specs.DroneType.POTENSIC_ATOM_3) {
+        groundSpeed = Math.max(0.5, Math.min(groundSpeed, 10.0));
     } else if (groundSpeed > 12) {
         groundSpeed = 11.5;
     }

--- a/src/qfield-plugin/main.qml
+++ b/src/qfield-plugin/main.qml
@@ -458,7 +458,8 @@ Item {
     flightplanDialog.lastDroneType = droneType
 
     // GeoJSONs live under workspace/ so operators only see the
-    // drone-specific output dirs (flightplans_dji, flightplans_potensic2/3)
+    // drone-specific output dirs (flightplans_dji, flightplans_potensic2,
+    // and flightplans_potensic3)
     // when browsing the project folder. platformUtilities.createDir is
     // non-recursive (QDir::mkdir), so create the parent first.
     var geojsonDir = qgisProject.homePath + '/workspace/flightplans'

--- a/src/qfield-plugin/main.qml
+++ b/src/qfield-plugin/main.qml
@@ -9,6 +9,7 @@ import "generate/drone_specs.js" as Specs
 import "output/dji.js" as DjiOutput
 import "output/kmz.js" as Kmz
 import "output/potensic_v2.js" as PotensicV2Output
+import "output/potensic_v3.js" as PotensicV3Output
 
 Item {
   id: plugin
@@ -27,13 +28,14 @@ Item {
   // needing extra arguments through _outputDji / _outputPotensicV2.
   property string lastPathGeojsonPath: ""
 
-  // Potensic Atom 2 output state
+  // Potensic output state
   property string lastPotensicZipPath: ""
   property var lastPotensicZipData: null
   property string lastPotensicGlobalJson: ""
   property string lastPotensicMissionJson: ""
   property string lastPotensicMissionDirName: ""
   property string lastPotensicTsSubDir: ""
+  property string lastPotensicOutputDirName: ""
 
   // Last generated drone type (persists until next generation, used by export logic)
   property string lastDroneType: ""
@@ -188,6 +190,10 @@ Item {
 
   function log(msg) {
     iface.logMessage("DroneTM: " + msg)
+  }
+
+  function isPotensicJsonDrone(droneType) {
+    return droneType === "POTENSIC_ATOM_2" || droneType === "POTENSIC_ATOM_3"
   }
 
   function discoverPointHandler() {
@@ -452,7 +458,7 @@ Item {
     flightplanDialog.lastDroneType = droneType
 
     // GeoJSONs live under workspace/ so operators only see the
-    // drone-specific output dirs (flightplans_dji, flightplans_potensic2)
+    // drone-specific output dirs (flightplans_dji, flightplans_potensic2/3)
     // when browsing the project folder. platformUtilities.createDir is
     // non-recursive (QDir::mkdir), so create the parent first.
     var geojsonDir = qgisProject.homePath + '/workspace/flightplans'
@@ -490,6 +496,11 @@ Item {
       platformUtilities.createDir(qgisProject.homePath, 'flightplans_potensic2')
       log("Saving Potensic files to " + potensicDir)
       _outputPotensicV2(placemarks, filename, potensicDir, geojsonPath, geojsonOk, taskId)
+    } else if (droneType === "POTENSIC_ATOM_3") {
+      var potensicV3Dir = qgisProject.homePath + '/flightplans_potensic3'
+      platformUtilities.createDir(qgisProject.homePath, 'flightplans_potensic3')
+      log("Saving Potensic files to " + potensicV3Dir)
+      _outputPotensicV3(placemarks, filename, potensicV3Dir, geojsonPath, geojsonOk, taskId)
     } else {
       var djiDir = qgisProject.homePath + '/flightplans_dji'
       platformUtilities.createDir(qgisProject.homePath, 'flightplans_dji')
@@ -557,7 +568,23 @@ Item {
   }
 
   function _outputPotensicV2(placemarks, filename, outputDir, geojsonPath, geojsonOk, taskId) {
-    var defaultSpeed = 11.5
+    _outputPotensicJson(
+      placemarks, filename, outputDir, geojsonPath, geojsonOk, taskId,
+      false, 11.5, "Potensic Atom 2", "flightplans_potensic2"
+    )
+  }
+
+  function _outputPotensicV3(placemarks, filename, outputDir, geojsonPath, geojsonOk, taskId) {
+    _outputPotensicJson(
+      placemarks, filename, outputDir, geojsonPath, geojsonOk, taskId,
+      true, 10.0, "Potensic Atom 3", "flightplans_potensic3"
+    )
+  }
+
+  function _outputPotensicJson(placemarks, filename, outputDir, geojsonPath, geojsonOk,
+                               taskId, isAtom3, fallbackSpeed, formatLabel,
+                               outputDirName) {
+    var defaultSpeed = fallbackSpeed
     if (placemarks.features.length > 0) {
       var s = placemarks.features[0].properties.speed
       if (s) defaultSpeed = s
@@ -566,9 +593,11 @@ Item {
     var tsMs = Date.now()
     var potensic
     try {
-      potensic = PotensicV2Output.createPotensicZip(placemarks, defaultSpeed, tsMs)
+      potensic = isAtom3
+        ? PotensicV3Output.createPotensicZip(placemarks, defaultSpeed, tsMs)
+        : PotensicV2Output.createPotensicZip(placemarks, defaultSpeed, tsMs)
     } catch (e) {
-      log("Potensic V2 ZIP creation error: " + e)
+      log(formatLabel + " ZIP creation error: " + e)
       flightplanDialog.generationState = "error"
       flightplanDialog.resultMessage = qsTr('Flightplan generation failed: %1').arg(e)
       return
@@ -605,6 +634,7 @@ Item {
       lastPotensicMissionJson = potensic.missionJson
       lastPotensicMissionDirName = tsStr
       lastPotensicTsSubDir = tsSubDir
+      lastPotensicOutputDirName = outputDirName
 
       var msg = qsTr('Saved: %1').arg(filename)
       mainWindow.displayToast(msg)
@@ -893,7 +923,7 @@ Item {
   }
 
   function exportFlightplanToDevice() {
-    if (lastDroneType === "POTENSIC_ATOM_2") {
+    if (isPotensicJsonDrone(lastDroneType)) {
       _exportPotensicToDevice()
       return
     }
@@ -1096,7 +1126,9 @@ Item {
     // Last resort: point user at the saved JSON files
     mainWindow.displayToast(qsTr('File picker not available'))
     flightplanDialog.generationState = "manual_transfer"
-    flightplanDialog.resultMessage = qsTr('Find mission files in flightplans_potensic2/%1/ in the project folder').arg(lastPotensicMissionDirName)
+    flightplanDialog.resultMessage = qsTr('Find mission files in %1/%2/ in the project folder')
+      .arg(lastPotensicOutputDirName)
+      .arg(lastPotensicMissionDirName)
   }
 
 }

--- a/src/qfield-plugin/output/potensic_v3.js
+++ b/src/qfield-plugin/output/potensic_v3.js
@@ -1,0 +1,95 @@
+.pragma library
+
+.import "potensic_v2.js" as PotensicV2Output
+
+// Potensic Atom 3 JSON waypoint output format.
+// The ZIP container and global.json layout match Atom 2, while the mission
+// file is a plain JSON array with the owner-supplied Atom 3 waypoint schema.
+
+function _missionSpeed(featcol, defaultSpeed) {
+    var features = featcol.features || []
+    for (var i = 0; i < features.length; i++) {
+        var props = features[i].properties || {}
+        if (props.speed !== undefined && props.speed !== null) return props.speed
+    }
+    return defaultSpeed
+}
+
+function createGlobalJson(speed) {
+    return JSON.stringify({
+        finishAction: "RETURN",
+        globalHeight: 0,
+        globalHeightType: 0,
+        isOrder: true,
+        lostAction: "RETURN",
+        speed: speed
+    }, null, 2)
+}
+
+function createMissionJson(featcol, missionSpeed) {
+    var features = featcol.features || []
+    var waypoints = []
+
+    for (var i = 0; i < features.length; i++) {
+        var feature = features[i]
+        var props = feature.properties || {}
+        var geometry = feature.geometry || {}
+        var coords = geometry.coordinates || []
+
+        if (coords.length < 3) continue
+
+        var gimbalAngle = (props.gimbal_angle !== undefined) ? props.gimbal_angle : -80
+        var gimbalPitch = Math.round(parseFloat(gimbalAngle))
+        if (isNaN(gimbalPitch)) gimbalPitch = -80
+
+        var waypointSpeed = (props.speed !== undefined) ? props.speed : missionSpeed
+        waypoints.push({
+            action: props.take_photo ? "PHOTO" : "NONE",
+            gimbalPitch: gimbalPitch,
+            gimbalType: "DEFINE",
+            height: coords[2],
+            hoverTime: (props.hover_time !== undefined) ? props.hover_time : 0,
+            lat: coords[1],
+            lng: coords[0],
+            poiHeight: coords[2],
+            poiLat: 0.0,
+            poiLng: 0.0,
+            poiType: 0,
+            speed: waypointSpeed,
+            speedType: (waypointSpeed === missionSpeed) ? "GLOBAL" : "DEFINE",
+            yaw: 0,
+            yawType: "TO_WAYPOINT",
+            zoomRatio: 1.0,
+            zoomType: "HAND"
+        })
+    }
+
+    return JSON.stringify(waypoints)
+}
+
+// Returns {zipData, globalJson, missionJson, timestampMs}.
+function createPotensicZip(featcol, defaultSpeed, timestampMs) {
+    var features = featcol.features || []
+    if (features.length === 0) {
+        throw new Error("No features found in feature collection")
+    }
+
+    if (defaultSpeed === undefined || defaultSpeed === null) defaultSpeed = 10.0
+    if (!timestampMs) timestampMs = Date.now()
+
+    var speed = _missionSpeed(featcol, defaultSpeed)
+    var globalJson = createGlobalJson(speed)
+    var missionJson = createMissionJson(featcol, speed)
+    var ts = String(timestampMs)
+    var zipData = PotensicV2Output.buildZip([
+        { name: ts + "/global.json", data: globalJson },
+        { name: ts + "/" + ts + ".json", data: missionJson }
+    ])
+
+    return {
+        zipData: zipData,
+        globalJson: globalJson,
+        missionJson: missionJson,
+        timestampMs: timestampMs
+    }
+}

--- a/src/qfield-plugin/output/potensic_v3.js
+++ b/src/qfield-plugin/output/potensic_v3.js
@@ -5,6 +5,8 @@
 // Atom 3 keeps the Atom 2 ZIP and global.json layout, but stores the mission
 // as a plain JSON waypoint array.
 
+var MAX_WAYPOINTS = 200
+
 function _missionSpeed(featcol, defaultSpeed) {
     var features = featcol.features || []
     for (var i = 0; i < features.length; i++) {
@@ -61,6 +63,11 @@ function createMissionJson(featcol, missionSpeed) {
             zoomRatio: 1.0,
             zoomType: "HAND"
         })
+    }
+
+    if (waypoints.length > MAX_WAYPOINTS) {
+        throw new Error("Potensic Atom 3 missions support at most " + MAX_WAYPOINTS +
+            " waypoints; received " + waypoints.length)
     }
 
     return JSON.stringify(waypoints)

--- a/src/qfield-plugin/output/potensic_v3.js
+++ b/src/qfield-plugin/output/potensic_v3.js
@@ -2,9 +2,8 @@
 
 .import "potensic_v2.js" as PotensicV2Output
 
-// Potensic Atom 3 JSON waypoint output format.
-// The ZIP container and global.json layout match Atom 2, while the mission
-// file is a plain JSON array with the owner-supplied Atom 3 waypoint schema.
+// Atom 3 keeps the Atom 2 ZIP and global.json layout, but stores the mission
+// as a plain JSON waypoint array.
 
 function _missionSpeed(featcol, defaultSpeed) {
     var features = featcol.features || []

--- a/src/qfield-plugin/test_potensic_v3.mjs
+++ b/src/qfield-plugin/test_potensic_v3.mjs
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadQmlJs(relPath) {
+  return readFileSync(join(__dirname, relPath), 'utf8')
+    .replace(/^\.pragma\s+library\s*$/m, '')
+    .replace(/^\.import\s+.+$/gm, '');
+}
+
+function buildModule(source, dependencies = {}) {
+  const functionNames = [...source.matchAll(/^function\s+(\w+)\s*\(/gm)].map(match => match[1]);
+  const variableNames = [...source.matchAll(/^var\s+(\w+)\s*=/gm)].map(match => match[1]);
+  const exports = [...functionNames, ...variableNames]
+    .map(name => `${name}: typeof ${name} !== 'undefined' ? ${name} : undefined`)
+    .join(',\n');
+  const names = Object.keys(dependencies);
+  const values = Object.values(dependencies);
+  return new Function(...names, `${source}\nreturn {${exports}};`)(...values);
+}
+
+const PotensicV2Output = buildModule(loadQmlJs('output/potensic_v2.js'));
+const PotensicV3Output = buildModule(
+  loadQmlJs('output/potensic_v3.js'),
+  { PotensicV2Output },
+);
+const Specs = buildModule(loadQmlJs('generate/drone_specs.js'));
+const Params = buildModule(loadQmlJs('generate/parameters.js'), { Specs });
+const mainQml = readFileSync(join(__dirname, 'main.qml'), 'utf8');
+const dialogQml = readFileSync(join(__dirname, 'FlightplanDialog.qml'), 'utf8');
+
+const features = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [14.3036601, 45.3326784, 50] },
+      properties: { take_photo: true, gimbal_angle: '-90', speed: 5 },
+    },
+    {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [14.3036458, 45.3301753, 50] },
+      properties: { take_photo: false, gimbal_angle: -90, speed: 5 },
+    },
+  ],
+};
+
+const timestamp = 1786984375375;
+const result = PotensicV3Output.createPotensicZip(features, 10, timestamp);
+const globalJson = JSON.parse(result.globalJson);
+const waypoints = JSON.parse(result.missionJson);
+
+assert.equal(globalJson.speed, 5);
+assert.equal(result.missionJson.includes(';[]'), false);
+assert.equal(waypoints.length, 2);
+assert.deepEqual(waypoints[0], {
+  action: 'PHOTO',
+  gimbalPitch: -90,
+  gimbalType: 'DEFINE',
+  height: 50,
+  hoverTime: 0,
+  lat: 45.3326784,
+  lng: 14.3036601,
+  poiHeight: 50,
+  poiLat: 0,
+  poiLng: 0,
+  poiType: 0,
+  speed: 5,
+  speedType: 'GLOBAL',
+  yaw: 0,
+  yawType: 'TO_WAYPOINT',
+  zoomRatio: 1,
+  zoomType: 'HAND',
+});
+assert.equal('fileName' in waypoints[0], false);
+assert.equal(waypoints[1].action, 'NONE');
+assert.equal(new Uint8Array(result.zipData).slice(0, 4).join(','), '80,75,3,4');
+
+assert.throws(
+  () => PotensicV3Output.createPotensicZip({ type: 'FeatureCollection', features: [] }),
+  /No features found/,
+);
+assert.equal(Specs.DroneType.POTENSIC_ATOM_3, 'POTENSIC_ATOM_3');
+assert.equal(Specs.DRONE_PARAMS.POTENSIC_ATOM_3.OUTPUT_FORMAT, 'POTENSIC_JSON_V2');
+assert.equal(
+  Params.calculateParameters(0, 70, 120, null, 2, 'POTENSIC_ATOM_3').ground_speed,
+  11.5,
+);
+assert.equal(
+  Params.calculateParameters(99, 70, 10, null, 2, 'POTENSIC_ATOM_3').ground_speed,
+  0.05,
+);
+assert.match(mainQml, /import "output\/potensic_v3\.js" as PotensicV3Output/);
+assert.match(mainQml, /droneType === "POTENSIC_ATOM_3"/);
+assert.match(mainQml, /PotensicV3Output\.createPotensicZip/);
+assert.match(dialogQml, /"Potensic Atom 3"/);
+assert.match(dialogQml, /"POTENSIC_ATOM_3"/);
+
+console.log('Potensic Atom 3 QField serializer: PASS');

--- a/src/qfield-plugin/test_potensic_v3.mjs
+++ b/src/qfield-plugin/test_potensic_v3.mjs
@@ -87,16 +87,26 @@ assert.equal(Specs.DroneType.POTENSIC_ATOM_3, 'POTENSIC_ATOM_3');
 assert.equal(Specs.DRONE_PARAMS.POTENSIC_ATOM_3.OUTPUT_FORMAT, 'POTENSIC_JSON_V2');
 assert.equal(
   Params.calculateParameters(0, 70, 120, null, 2, 'POTENSIC_ATOM_3').ground_speed,
-  11.5,
+  10,
 );
 assert.equal(
   Params.calculateParameters(99, 70, 10, null, 2, 'POTENSIC_ATOM_3').ground_speed,
-  0.05,
+  0.5,
+);
+
+const tooManyWaypoints = {
+  type: 'FeatureCollection',
+  features: Array.from({ length: 201 }, () => features.features[0]),
+};
+assert.throws(
+  () => PotensicV3Output.createPotensicZip(tooManyWaypoints, 5, timestamp),
+  /support at most 200 waypoints; received 201/,
 );
 assert.match(mainQml, /import "output\/potensic_v3\.js" as PotensicV3Output/);
 assert.match(mainQml, /droneType === "POTENSIC_ATOM_3"/);
 assert.match(mainQml, /PotensicV3Output\.createPotensicZip/);
 assert.match(dialogQml, /"Potensic Atom 3"/);
 assert.match(dialogQml, /"POTENSIC_ATOM_3"/);
+assert.match(dialogQml, /Rename the generated timestamped \.json/);
 
 console.log('Potensic Atom 3 QField serializer: PASS');


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [x] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other

## Related Issue

Part of #870

## Describe this PR

Adds Potensic Atom 3 flight-plan support to the main app and the QField plugin.

The Atom 3 mission file is close to the Atom 2 format, but it is a plain JSON array, omits `fileName`, and uses different yaw and zoom values. This PR adds a separate serializer for that format, exposes Atom 3 in both drone selectors, and reuses the existing Potensic save/export flow in QField. Atom 2 still uses its original serializer. Atom 3 waypoint missions are limited to 0.5 to 10 m/s and 200 waypoints; both backend and QField enforce the same limits.

The generated files match the owner-supplied Atom 3 example. An Atom 3 owner has now imported the exact generated mission into Potensic Eve on the PTD2 while grounded, and the displayed route and settings match the test file. Aircraft execution remains unverified, and whether a flight is required before merge is a maintainer decision.

## AI Tool Usage

- [ ] No AI tools were used
- [x] AI tools were used (complete below)

**If AI-assisted:**

- Tool used: OpenAI Codex
- What it helped with: first-pass implementation, tests, documentation, and review checks
- What I reviewed: the generated output against the supplied Atom 3 files, the web and QField call paths, the existing Atom 2 behavior, and the automated test results

## Screenshots

Not included. The visible change is one additional drone option in the existing web and QField selectors.

## Alternative Approaches Considered

Reusing the Atom 2 serializer unchanged would produce the wrong mission structure, so Atom 3 has its own serializer. The Python and JavaScript implementations remain separate because QField generates missions offline; both are covered by focused tests.

QField was initially left out of the draft, then added after maintainer feedback that it would be a useful bonus for this issue.

## Review Guide

1. Select Potensic Atom 3 and generate a small plan.
2. Confirm the ZIP contains a timestamp directory with `global.json` and a timestamp-named mission JSON.
3. Confirm the mission JSON is a plain array with no `;[]` suffix or `fileName`.
4. For QField, select Atom 3 and confirm it uses the Potensic save/export flow rather than the DJI flow.
5. If an Atom 3 is available, replace the files in a disposable Potensic Eve mission and inspect the route, height, gimbal angle, speed, and finish action while grounded before a controlled flight.

Local verification:

- focused backend speed and waypoint-limit check passed
- QField Atom 3 serializer and wiring test passed
- existing Atom 2 comparison script passed
- frontend TypeScript compilation passed
- MkDocs build passed
- pre-commit hooks passed on all changed files

Not verified locally:

- full backend suite, because native GDAL is unavailable
- full Vite bundle, because the local `@hotosm/gcp-editor` workspace package is not built and its dependency scripts are not approved in this checkout
- QField on a phone or tablet
- aircraft execution

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/hotosm/drone-tm/blob/dev/CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](https://docs.hotosm.org/code-of-conduct)
- [x] PR is focused and small
- [x] Tests are included or updated
- [x] I understand all code in this PR and can answer questions about it
- [x] No secrets, credentials, or sensitive data are included
- [x] Commit messages are descriptive
- [x] Related docs and screenshots are updated

