### PR TITLE
feat: replace Nominatim reverse geocoding with pg-nearest-city

### DIFF
--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -64,6 +64,7 @@ from fastapi import (
 from fastapi.responses import StreamingResponse
 from geojson_pydantic import FeatureCollection
 from loguru import logger as log
+from pg_nearest_city import AsyncNearestCity
 from psycopg import Connection
 from stream_zip import NO_COMPRESSION_64, stream_zip
 
@@ -109,6 +110,32 @@ async def read_project_centroids(
     return await project_logic.get_centroids(
         db,
     )
+
+
+@router.get("/nearest-city/", tags=["Projects"])
+async def get_nearest_city(
+    lon: float,
+    lat: float,
+    db: Annotated[Connection, Depends(database.get_db)],
+    user_data: Annotated[AuthUser, Depends(login_required)],
+):
+    """Reverse geocode a point to the nearest city and country.
+
+    Runs entirely offline against the PostGIS database via pg-nearest-city,
+    replacing the previous Nominatim-based lookup (reducing load on the
+    OSM-hosted service). The underlying dataset is loaded into the database
+    on the first call, which can take a little longer.
+    """
+    async with AsyncNearestCity(db) as geocoder:
+        location = await geocoder.query(lon, lat)
+
+    if location is None:
+        return {"city": None, "country": None}
+
+    return {
+        "city": location.city,
+        "country": location.country_name or location.country,
+    }
 
 
 @router.get("/{project_id}/download-boundaries", tags=["Projects"])

--- a/src/backend/app/utils.py
+++ b/src/backend/app/utils.py
@@ -12,7 +12,6 @@ from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import geojson
-import requests
 import shapely
 from aiosmtplib import send as send_email
 from app.config import settings
@@ -292,45 +291,6 @@ def parse_featcol(features: Feature | FeatCol | MultiPolygon | Polygon):
     elif isinstance(features, Feature):
         feat_col = geojson.FeatureCollection([feat_col])
     return feat_col
-
-
-def get_address_from_lat_lon(latitude, longitude):
-    """Get address using Nominatim, using lat,lon."""
-    base_url = "https://nominatim.openstreetmap.org/reverse"
-
-    params = {
-        "format": "json",
-        "lat": latitude,
-        "lon": longitude,
-        "zoom": 18,
-    }
-    headers = {"Accept-Language": "en"}  # Set the language to English
-
-    log.debug("Getting Nominatim address from project centroid")
-    response = requests.get(base_url, params=params, headers=headers)
-    if (status_code := response.status_code) != 200:
-        log.error(f"Getting address string failed: {status_code}")
-        return None
-
-    data = response.json()
-    log.debug(f"Nominatim response: {data}")
-
-    address = data.get("address", None)
-    if not address:
-        log.error(f"Getting address string failed: {status_code}")
-        return None
-
-    country = address.get("country", "")
-    city = address.get("city", "")
-    state = address.get("state", "")
-
-    address_str = f"{city},{country}" if city else f"{state},{country}"
-
-    if not address_str or address_str == ",":
-        log.error("Getting address string failed")
-        return None
-
-    return address_str
 
 
 def multipolygon_to_polygon(features: Feature | FeatCol | MultiPolygon | Polygon):

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "sqlalchemy==2.0.23",
   "geoalchemy2==0.14.2",
   "psycopg[c,pool]==3.2.1",
+  "pg-nearest-city==2.0.0",
   "requests==2.32.3",
   "requests-oauthlib==2.0.0",
   "loguru==0.7.2",

--- a/src/backend/tests/test_projects_routes.py
+++ b/src/backend/tests/test_projects_routes.py
@@ -1239,6 +1239,61 @@ async def test_process_all_imagery_blocks_when_ready_tasks_are_mixed_transfer_st
     assert fake_redis.jobs == []
 
 
+class FakeNearestCity:
+    """Stand-in for AsyncNearestCity, avoiding the dataset initialisation."""
+
+    def __init__(self, location):
+        self.location = location
+
+    def __call__(self, db):
+        return self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        return False
+
+    async def query(self, lon, lat):
+        return self.location
+
+
+@pytest.mark.asyncio
+async def test_get_nearest_city(client, monkeypatch):
+    """Reverse geocoding a point returns the nearest city and country."""
+    from pg_nearest_city import Location
+
+    location = Location(
+        city="Freetown",
+        country="Sierra Leone",
+        lat=8.4657,
+        lon=-13.2317,
+        country_alpha3="SLE",
+        country_name="Sierra Leone",
+    )
+    monkeypatch.setattr(project_routes, "AsyncNearestCity", FakeNearestCity(location))
+
+    response = await client.get(
+        "/api/projects/nearest-city/", params={"lon": -13.2317, "lat": 8.4657}
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"city": "Freetown", "country": "Sierra Leone"}
+
+
+@pytest.mark.asyncio
+async def test_get_nearest_city_no_match(client, monkeypatch):
+    """A point with no nearby city returns null fields instead of an error."""
+    monkeypatch.setattr(project_routes, "AsyncNearestCity", FakeNearestCity(None))
+
+    response = await client.get(
+        "/api/projects/nearest-city/", params={"lon": 0, "lat": 0}
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"city": None, "country": None}
+
+
 if __name__ == "__main__":
     """Main func if file invoked directly."""
     pytest.main()

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -812,6 +812,7 @@ dependencies = [
     { name = "minio" },
     { name = "numpy" },
     { name = "opencv-python-headless" },
+    { name = "pg-nearest-city" },
     { name = "pillow" },
     { name = "psycopg", extra = ["c", "pool"] },
     { name = "pydantic", extra = ["email"] },
@@ -888,6 +889,7 @@ requires-dist = [
     { name = "minio", specifier = "==7.2.0" },
     { name = "numpy", specifier = "==2.2.6" },
     { name = "opencv-python-headless", specifier = "==4.12.0.88" },
+    { name = "pg-nearest-city", specifier = "==2.0.0" },
     { name = "pillow", specifier = "==12.1.0" },
     { name = "psycopg", extras = ["c", "pool"], specifier = "==3.2.1" },
     { name = "pydantic", extras = ["email"], specifier = "==2.8.2" },
@@ -2436,6 +2438,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+]
+
+[[package]]
+name = "pg-nearest-city"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "psycopg" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/43/e01d67392300de0650a305b553f6cb2bb842fb89996d214a4709d982e704/pg_nearest_city-2.0.0.tar.gz", hash = "sha256:43b9a729ab1e230073734f2034d151593ae3aa075128852fd33755c2f01999f8", size = 6619548, upload-time = "2026-03-23T22:07:33.968Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/84/88f907e44be18048d77080ed1a67fb678edcf24fe93cefa094bd2cce974e/pg_nearest_city-2.0.0-py3-none-any.whl", hash = "sha256:51df615e5ffe080e0fce2ec2b251b852e9e08855852c2e29796a65aa0346b21a", size = 6549112, upload-time = "2026-03-23T22:07:31.585Z" },
 ]
 
 [[package]]

--- a/src/frontend/src/components/CreateProject/CreateprojectLayout/index.tsx
+++ b/src/frontend/src/components/CreateProject/CreateprojectLayout/index.tsx
@@ -26,7 +26,7 @@ import prepareFormData from "@Utils/prepareFormData";
 import hasErrorBoundary from "@Utils/hasErrorBoundary";
 import { getFrontOverlap, getSideOverlap, gsdToAltitude, m2ToKm2 } from "@Utils/index";
 import { useEffect, useState } from "react";
-import { getCountry } from "@Services/common";
+import { getNearestCity } from "@Services/common";
 import { setCommonState } from "@Store/actions/common";
 import { m } from "@/paraglide/messages";
 
@@ -205,19 +205,18 @@ const CreateprojectLayout = () => {
 
   const { data: countryResponse, isFetching: isFetchingCountry } = useQuery({
     queryFn: () =>
-      getCountry({
+      getNearestCity({
         lon: projectCentroid?.[0] || 0,
         lat: projectCentroid?.[1] || 0,
-        format: "json",
       }),
-    queryKey: ["country", projectCentroid?.[0], projectCentroid?.[1]],
+    queryKey: ["nearest-city", projectCentroid?.[0], projectCentroid?.[1]],
     enabled: !!projectCentroid,
   });
 
   useEffect(() => {
     dispatch(
       setCommonState({
-        projectCountry: countryResponse?.data?.address?.country || null,
+        projectCountry: countryResponse?.data?.country || null,
       }),
     );
   }, [countryResponse, dispatch]);

--- a/src/frontend/src/services/common.ts
+++ b/src/frontend/src/services/common.ts
@@ -1,8 +1,5 @@
 import { UserProfileDetailsType } from "@Components/GoogleAuth/types";
-import axios from "axios";
 import { api, authenticated } from ".";
-
-const OSM_NOMINATIM_URL = "https://nominatim.openstreetmap.org";
 
 export const signInUser = (data: any) => api.post("/users/login/", data);
 
@@ -34,5 +31,5 @@ export const patchUserProfile = ({ userId, data }: Record<string, any>) =>
     headers: { "Content-Type": "application/json" },
   });
 
-export const getCountry = (params: { lat: number; lon: number; format: string }) =>
-  axios.get(`${OSM_NOMINATIM_URL}/reverse`, { params });
+export const getNearestCity = (params: { lat: number; lon: number }) =>
+  authenticated(api).get("/projects/nearest-city/", { params });


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #554

## Describe this PR

Removes the dependency on the OSM-hosted Nominatim service for reverse geocoding during project creation, as requested in #554:

- **Backend**: new `GET /api/projects/nearest-city/?lon=&lat=` endpoint (login required) that reverse geocodes the project centroid to `{city, country}` using [pg-nearest-city](https://github.com/hotosm/pg-nearest-city) (v2.0.0) over the existing psycopg PostGIS connection — fully offline. Returns `{city: null, country: null}` when no match, mirroring how Field-TM/Tasking Manager adopted the package.
- **Frontend**: `getCountry()` (axios call to `nominatim.openstreetmap.org/reverse`) is replaced by `getNearestCity()` calling the new endpoint; the create-project flow keeps populating `projectCountry` (used for the drone-altitude lookup) from the response.
- **Cleanup**: the dead `get_address_from_lat_lon` Nominatim helper in `app/utils.py` (no callers) is removed together with its `requests` import.

Note: on the very first call after deploy, pg-nearest-city loads its bundled dataset into the database (one-time, ~30s+); subsequent calls are sub-millisecond.

## AI Tool Usage

- [ ] No AI tools were used
- [x] AI tools were used (complete below)

**If AI-assisted:**

- Tool(s) used: Claude Code (Anthropic)
- What was generated: initial implementation of the endpoint, frontend service swap, and the two route tests
- What you reviewed and changed: reviewed every change; verified the pg-nearest-city 2.0.0 API (Location fields, AsyncNearestCity accepting an existing psycopg connection) against the package source; ran the full backend test suite in the compose test stack and the frontend typecheck locally

## Screenshots

No UI change — `projectCountry` is populated exactly as before, from the new endpoint.

## Alternative Approaches Considered

- Keeping the lookup in the frontend (status quo) means every project creation hits the shared OSM Nominatim server — the thing #554 wants to avoid.
- Computing city/country server-side only at project creation time wouldn't work here: the frontend needs the country *during* the create form (drone-altitude regulations lookup), so a small lookup endpoint fits better.

## Review Guide

- `pytest tests/test_projects_routes.py` — includes 2 new tests for the endpoint (`test_get_nearest_city`, `test_get_nearest_city_no_match`, geocoder faked to avoid dataset initialisation in CI).
- Full suite in the compose test stack: 341 passing locally (the two `test_batch_delete` jobs need `arq-worker` up).
- Manual: create a project and watch `/api/projects/nearest-city/` be called instead of `nominatim.openstreetmap.org`; first-ever call initialises the dataset.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/hotosm/drone-tm/blob/dev/CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](https://docs.hotosm.org/code-of-conduct)
- [x] PR is focused and small
- [x] Tests are included or updated
- [x] I understand all code in this PR and can answer questions about it
- [x] No secrets, credentials, or sensitive data are included
- [x] Commit messages are descriptive