### PR TITLE
fix(s3): add_obj_to_bucket drops content_type, storing every upload as octet-stream

### DIFF
--- a/src/backend/app/s3.py
+++ b/src/backend/app/s3.py
@@ -340,7 +340,12 @@ def add_obj_to_bucket(
     file_obj.seek(0)
 
     result = client.put_object(
-        bucket_name, s3_path, file_obj, file_obj.getbuffer().nbytes, **kwargs
+        bucket_name,
+        s3_path,
+        file_obj,
+        file_obj.getbuffer().nbytes,
+        content_type=content_type,
+        **kwargs,
     )
     log.debug(
         f"Created {result.object_name} object; etag: {result.etag}, "

--- a/src/backend/tests/test_s3_content_type.py
+++ b/src/backend/tests/test_s3_content_type.py
@@ -1,0 +1,65 @@
+"""add_obj_to_bucket declares a content_type, so it has to send one.
+
+The call it makes passes four positional arguments and then **kwargs. Because
+content_type is an explicit named parameter it is bound there rather than left
+in kwargs, so it never reached minio and every BytesIO upload was stored with
+the SDK's own application/octet-stream default.
+
+Arguments are recorded by binding them through the real Minio.put_object
+signature, so what is asserted is what the SDK would have put on the wire.
+"""
+
+import inspect
+from io import BytesIO
+
+from minio import Minio
+
+from app import s3
+
+
+class _Result:
+    object_name = "object"
+    etag = "etag"
+    version_id = None
+
+
+class _RecordingClient:
+    def __init__(self):
+        self.calls = []
+
+    def put_object(self, *args, **kwargs):
+        bound = inspect.signature(Minio.put_object).bind(self, *args, **kwargs)
+        bound.apply_defaults()
+        self.calls.append(bound.arguments)
+        return _Result()
+
+
+def test_add_obj_to_bucket_forwards_content_type(monkeypatch):
+    client = _RecordingClient()
+    monkeypatch.setattr(s3, "s3_client", lambda: client)
+
+    s3.add_obj_to_bucket(
+        "test-bucket",
+        BytesIO(b"fake-image-bytes"),
+        "projects/1/photo.jpg",
+        content_type="image/jpeg",
+    )
+
+    assert client.calls[0]["content_type"] == "image/jpeg"
+
+
+def test_add_obj_to_bucket_keeps_forwarding_other_kwargs(monkeypatch):
+    """The QField export passes both, so the fix must not displace metadata."""
+    client = _RecordingClient()
+    monkeypatch.setattr(s3, "s3_client", lambda: client)
+
+    s3.add_obj_to_bucket(
+        "test-bucket",
+        BytesIO(b"fake-zip-bytes"),
+        "projects/1/qfield.zip",
+        content_type="application/zip",
+        metadata={"Cache-Control": "no-cache"},
+    )
+
+    assert client.calls[0]["content_type"] == "application/zip"
+    assert client.calls[0]["metadata"] == {"Cache-Control": "no-cache"}

--- a/src/backend/tests/test_s3_content_type.py
+++ b/src/backend/tests/test_s3_content_type.py
@@ -12,9 +12,8 @@ signature, so what is asserted is what the SDK would have put on the wire.
 import inspect
 from io import BytesIO
 
-from minio import Minio
-
 from app import s3
+from minio import Minio
 
 
 class _Result:


### PR DESCRIPTION
`add_obj_to_bucket` declares and documents a `content_type`, but never sends it. The `put_object` call passes four positional arguments and then `**kwargs`, and because `content_type` is an explicit named parameter it binds there rather than staying in `kwargs`, so it cannot reach minio that way. Every BytesIO upload was therefore stored with the SDK's own `application/octet-stream` default.

Both callers are affected:

- `arq/tasks.py:1451` uploads the QField export as `application/zip`
- `projects/project_logic.py:146` passes the browser's `file.content_type` for user uploads

`metadata` was unaffected, since it does travel through `**kwargs`. The sibling `add_file_to_bucket` twelve lines above already forwards `content_type=` to `fput_object`.

The fix is one argument. The two tests record what `put_object` receives by binding the call through the real `Minio.put_object` signature, so what they assert is what the SDK would have put on the wire rather than what the wrapper thinks it sent. The second one pins that `metadata` still arrives, since the QField caller passes both.

Both fail on the current code and pass with the change. `ruff check` and `ruff format --check` are clean.

One note on how I ran them: this machine cannot install the full backend (GDAL and Scrapy do not build here), so I ran them with `--noconftest`, which is enough because these two touch nothing but `app.s3` and `minio`. They need no database, Redis or docker, so they should run normally in CI. If you would rather have this as an integration test against the real client, the equivalent assertion is `client.stat_object(bucket, key).content_type`, but I could not run that variant here and would not want to claim it verified.
