### PR TITLE
fix(waypoints): persist the default take off point instead of leaving NULL

### DIFF
--- a/src/backend/app/waypoints/waypoint_routes.py
+++ b/src/backend/app/waypoints/waypoint_routes.py
@@ -101,9 +101,16 @@ async def get_task_flightplan(
         if take_off_point_from_db:
             take_off_point = take_off_point_from_db["coordinates"]
         else:
+            # No take off point supplied and none stored: default to the task
+            # centroid. Persist it so the task always carries a take off point
+            # (used to look up the DEM elevation during processing and included
+            # in task exports), instead of leaving NULL in the database.
             task_polygon = shape(task_geojson["features"][0]["geometry"])
             task_centroid = task_polygon.centroid
             take_off_point = [task_centroid.x, task_centroid.y]
+
+            geojson_point = {"type": "Point", "coordinates": take_off_point}
+            await update_take_off_point_in_db(db, task_id, geojson_point)
 
     # Flight params from project
     forward_overlap = project.front_overlap or 70

--- a/src/backend/tests/test_waypoint_routes.py
+++ b/src/backend/tests/test_waypoint_routes.py
@@ -2,24 +2,40 @@ import json
 import uuid
 
 import pytest
+from app.tasks.task_logic import get_take_off_point_from_db
 from app.waypoints import waypoint_routes
+from shapely.geometry import shape
+
+_TASK_OUTLINE = {
+    "type": "Polygon",
+    "coordinates": [
+        [
+            [-69.49779538720068, 18.629654277305633],
+            [-69.48497355306813, 18.616997544638636],
+            [-69.54053483430786, 18.608390428368665],
+            [-69.5410690773959, 18.614466085056165],
+            [-69.49779538720068, 18.629654277305633],
+        ]
+    ],
+}
+
+
+async def _setup_task(db, project_id: str) -> str:
+    """Insert a task with the shared test outline and no take off point."""
+    task_id = str(uuid.uuid4())
+    async with db.cursor() as cur:
+        await cur.execute(
+            """
+            INSERT INTO tasks (id, project_id, outline, project_task_index)
+            VALUES (%s, %s, ST_SetSRID(ST_GeomFromGeoJSON(%s), 4326), %s)
+            """,
+            (task_id, project_id, json.dumps(_TASK_OUTLINE), 1),
+        )
+    await db.commit()
+    return task_id
 
 
 async def _setup_terrain_follow_task(db, project_id: str) -> str:
-    task_id = str(uuid.uuid4())
-    outline = {
-        "type": "Polygon",
-        "coordinates": [
-            [
-                [-69.49779538720068, 18.629654277305633],
-                [-69.48497355306813, 18.616997544638636],
-                [-69.54053483430786, 18.608390428368665],
-                [-69.5410690773959, 18.614466085056165],
-                [-69.49779538720068, 18.629654277305633],
-            ]
-        ],
-    }
-
     async with db.cursor() as cur:
         await cur.execute(
             """
@@ -29,15 +45,91 @@ async def _setup_terrain_follow_task(db, project_id: str) -> str:
             """,
             (project_id,),
         )
-        await cur.execute(
-            """
-            INSERT INTO tasks (id, project_id, outline, project_task_index)
-            VALUES (%s, %s, ST_SetSRID(ST_GeomFromGeoJSON(%s), 4326), %s)
-            """,
-            (task_id, project_id, json.dumps(outline), 1),
-        )
     await db.commit()
-    return task_id
+    return await _setup_task(db, project_id)
+
+
+def _capturing_build_placemarks(captured: dict):
+    """Stand in for build_placemarks that records the take off point it got."""
+
+    def fake_build_placemarks(**kwargs):
+        captured["take_off_point"] = kwargs.get("take_off_point")
+        return {"type": "FeatureCollection", "features": []}, {
+            "battery_warning": False,
+            "estimated_flight_time_minutes": 0,
+        }
+
+    return fake_build_placemarks
+
+
+@pytest.mark.asyncio
+async def test_default_take_off_point_is_persisted(
+    client, db, create_test_project, monkeypatch
+):
+    """Keeping the default take off point must still write it to the db.
+
+    Regression for #826: when the user does not pick a take off point the
+    task centroid is used, but it was only computed in memory and the task
+    row kept a NULL take_off_point, so exports had no coordinate.
+    """
+    project_id = create_test_project
+    task_id = await _setup_task(db, project_id)
+    assert await get_take_off_point_from_db(db, task_id) is None
+
+    captured = {}
+    monkeypatch.setattr(
+        waypoint_routes, "build_placemarks", _capturing_build_placemarks(captured)
+    )
+
+    response = await client.post(
+        f"/api/waypoint/task/{task_id}/?project_id={project_id}&download=false"
+    )
+    assert response.status_code == 200
+
+    centroid = shape(_TASK_OUTLINE).centroid
+    stored = await get_take_off_point_from_db(db, task_id)
+    assert stored is not None
+    assert stored["type"] == "Point"
+    assert stored["coordinates"] == pytest.approx([centroid.x, centroid.y])
+    # The flight plan was generated with the very point that got persisted
+    assert captured["take_off_point"] == pytest.approx(stored["coordinates"])
+
+
+@pytest.mark.asyncio
+async def test_supplied_take_off_point_replaces_persisted_default(
+    client, db, create_test_project, monkeypatch
+):
+    """A user supplied point must win over a previously persisted default."""
+    project_id = create_test_project
+    task_id = await _setup_task(db, project_id)
+
+    captured = {}
+    monkeypatch.setattr(
+        waypoint_routes, "build_placemarks", _capturing_build_placemarks(captured)
+    )
+
+    # First call without a point persists the centroid default
+    response = await client.post(
+        f"/api/waypoint/task/{task_id}/?project_id={project_id}&download=false"
+    )
+    assert response.status_code == 200
+    default_point = await get_take_off_point_from_db(db, task_id)
+    assert default_point is not None
+
+    # Second call with an explicit point inside the task replaces it
+    manual_point = {"longitude": -69.51, "latitude": 18.62}
+    response = await client.post(
+        f"/api/waypoint/task/{task_id}/?project_id={project_id}&download=false",
+        json=manual_point,
+    )
+    assert response.status_code == 200
+
+    stored = await get_take_off_point_from_db(db, task_id)
+    assert stored["coordinates"] == pytest.approx(
+        [manual_point["longitude"], manual_point["latitude"]]
+    )
+    assert stored["coordinates"] != pytest.approx(default_point["coordinates"])
+    assert captured["take_off_point"] == pytest.approx(stored["coordinates"])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [x] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #826

## Describe this PR

When a task's flight plan is generated without an explicit take off point, `get_task_flightplan` falls back to the task centroid, but only in memory: the task row kept `take_off_point = NULL`, so the task summary/export had no coordinate for flights that used the default (see #826).

This PR persists the centroid default with the existing `update_take_off_point_in_db` helper, the same way a user-supplied point is already persisted a few lines above. The precedence is unchanged: a supplied point wins and replaces whatever is stored, a stored point is reused, and only when neither exists is the centroid computed, and now saved.

As noted in the issue, this gives no guarantee the user actually flew that plan; it only guarantees the exported task always carries a take off point.

## AI Tool Usage

- [ ] No AI tools were used
- [x] AI tools were used (complete below)

**If AI-assisted:**

- Tool(s) used: Claude Code
- What was generated: the first draft of the `else` branch change in `waypoint_routes.py` and of the two regression tests.
- What you reviewed and changed: I traced the take off point flow myself (`update_take_off_point_in_db` / `get_take_off_point_from_db` in `task_logic.py`, the `waypoint_routes.py` branches, the `task_schemas.py` summary query) to confirm the fallback was the only place the default was left unsaved, checked the precedence between supplied, stored and default points, and ran the tests against the compose test stack.

## Screenshots

N/A (backend only).

## Alternative Approaches Considered

- **Set the centroid at task creation (task splitting).** Would guarantee no NULL ever exists, but it writes a value before any flight plan is generated and would need a data migration for existing tasks. The issue explicitly ties the take off point to "each flight", so persisting at flight plan generation matches the intent with a much smaller change.
- **Compute the centroid in SQL (`ST_Centroid`) inside the update.** Works, but the route already has the shapely centroid in hand for `build_placemarks`; reusing that value guarantees the plan and the stored point are identical.

## Review Guide

- `src/backend/app/waypoints/waypoint_routes.py`: only the `else` branch of the take off point fallback changed (persist the centroid).
- `src/backend/tests/test_waypoint_routes.py`:
  - the task outline is now a module constant shared by a small `_setup_task` helper (the terrain follow helper reuses it, behaviour unchanged);
  - `test_default_take_off_point_is_persisted`: task starts with NULL, one call without a point, the stored point equals the shapely centroid and equals what `build_placemarks` received;
  - `test_supplied_take_off_point_replaces_persisted_default`: a persisted default is replaced by an explicit point.
- To run: `just test backend` (or `podman compose -f compose.test.yaml exec -T backend pytest tests/test_waypoint_routes.py -v`).

## How I tested it

I ran this branch on my local stack and tried it from the browser, as a drone operator would:

1. Opened a test project (582 tasks, all with `take_off_point = NULL`).
2. Locked task 1 and opened it. The map requested the flight plan on its own (`POST /api/waypoint/task/{id}/?download=false`, no `take_off_point` sent). I did not pick a take-off point: this is the #826 case.
3. Checked the DB: task 1 `take_off_point` is now set and equals `ST_Centroid(outline)`. Before it was NULL. Project count went from 0 to 1.

Note: the point is saved on the first request, so already on the map preview and even if that request then fails the DEM check (mine returned 409). The manual take-off point already works this way. If you'd rather save only after a successful download, it's a one-line change.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/hotosm/drone-tm/blob/dev/CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](https://docs.hotosm.org/code-of-conduct)
- [x] PR is focused and small
- [x] Tests are included or updated
- [x] I understand all code in this PR and can answer questions about it
- [x] No secrets, credentials, or sensitive data are included
- [x] Commit messages are descriptive
- [x] Related docs and screenshots are updated

