### PR TITLE
Add GLO-30 DEM

### DIFF
--- a/docs/decisions/0008-browser-dem-sampling.md
+++ b/docs/decisions/0008-browser-dem-sampling.md
@@ -47,8 +47,12 @@ in front of it today; adding one would help the browser tile path but the
 backend does not need it.
 
 - The backend will request a GeoTIFF crop for the project area and pass it to
-  the existing elevation code. This replaces the JAXA scraper, its background
-  job, and the stored per-project `dem.tif` files.
+  the existing elevation code, writing it to the same per-project `dem.tif` so
+  every downstream consumer is unchanged and still works offline.
+- GLO-30 becomes the default rather than the only option. Project creation
+  takes a `dem_source` of `GLO30`, `JAXA` or `UPLOAD`, with the last two behind
+  the advanced toggle. The JAXA scraper has served us well and is kept as a
+  fallback for as long as it keeps working.
 - The browser will request Terrarium tiles and cache them per project. The same
   tiles can be used by MapLibre for terrain display.
 
@@ -66,7 +70,9 @@ once-per-project request.
 
 ## Consequences
 
-- GLO-30 replaces AW3D30 as the elevation source and should improve accuracy.
+- GLO-30 becomes the default elevation source and should improve accuracy.
+  AW3D30 stays selectable, so a project can fall back if GLO-30 has a void
+  or the OAM raster service is down.
 - Generated flightplans may differ slightly from existing plans. Elevation is
   measured relative to the takeoff point, so datum differences should mostly
   cancel and remain within the current 5 m AGL threshold.

--- a/src/backend/app/arq/tasks.py
+++ b/src/backend/app/arq/tasks.py
@@ -24,6 +24,7 @@ from app.arq.cloudnative import (
 )
 from app.config import settings
 from app.db.database import get_db_connection_pool
+from app.dem.glo30 import download_and_upload_glo30_dem
 from app.images.flight_gimbal_deviation import mark_and_remove_off_axis_imagery
 from app.images.flight_stationary_removal import mark_and_remove_stationary_imagery
 from app.images.flight_tail_removal import mark_and_remove_flight_tail_imagery
@@ -2120,6 +2121,7 @@ class WorkerSettings:
         delete_invalid_images,
         process_project_task_metrics,
         download_and_upload_dem,
+        download_and_upload_glo30_dem,
         generate_qfield_project,
         process_imported_odm_assets,
         create_project_from_imagery_exif,

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -240,6 +240,9 @@ class Settings(BaseSettings):
     OAM_STAC_BROWSER_URL: str = "https://api.imagery.hotosm.org/browser"
     OAM_BROWSE_URL: str = "https://imagery.hotosm.org"
     OAM_STAC_COLLECTION: str = "openaerialmap"
+    # Terrain-following DEM, served from OAM ingested GLO-30 dataset
+    OAM_RASTER_API_URL: str = "https://api.imagery.hotosm.org/raster"
+    DEM_STAC_COLLECTION: str = "cop-dem-glo-30"
     # Covers OAM queueing and server-side download.
     OAM_SOURCE_URL_EXPIRY_HOURS: int = 24
     DRAGONFLY_DSN: str = "redis://dragonfly:6379/0"

--- a/src/backend/app/db/db_models.py
+++ b/src/backend/app/db/db_models.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import cast
 
 from app.models.enums import (
+    DEMSource,
     FinalOutput,
     ImageProcessingStatus,
     ImageStatus,
@@ -145,6 +146,8 @@ class DbProject(Base):
     camera_bearings = cast(list[int], Column(ARRAY(SmallInteger), nullable=True))
     gimble_angles_degrees = cast(list, Column(ARRAY(SmallInteger), nullable=True))
     is_terrain_follow = cast(bool, Column(Boolean, default=False))
+    # Existing projects have no reliable DEM source history.
+    dem_source = cast(DEMSource, Column(Enum(DEMSource), nullable=True))
     dem_url = cast(str, Column(String, nullable=True))
     hashtags = cast(list, Column(ARRAY(String)))  # Project hashtag
     output_orthophoto_url = cast(str, Column(String, nullable=True))

--- a/src/backend/app/dem/glo30.py
+++ b/src/backend/app/dem/glo30.py
@@ -1,0 +1,130 @@
+"""Download project DEM crops from Copernicus GLO-30 via OAM TiTiler."""
+
+import io
+import math
+
+import httpx
+from app.config import settings
+from app.projects import project_logic
+from arq import Retry
+from fastapi import UploadFile
+from loguru import logger as log
+
+# GLO-30 pixel edges are offset half a pixel from whole degrees.
+PIXEL_DEG = 1 / 3600
+GRID_ORIGIN = -0.5 * PIXEL_DEG
+
+DEFAULT_BUFFER_PX = 1
+
+# 4096 pixels is roughly 127 km at the equator.
+MAX_DIMENSION_PX = 4096
+
+REQUEST_TIMEOUT = 180
+
+RETRY_DEFER_SECONDS = 30
+
+
+def _snap_down(value: float) -> float:
+    """Return the grid edge at or below a coordinate."""
+    return GRID_ORIGIN + math.floor((value - GRID_ORIGIN) / PIXEL_DEG) * PIXEL_DEG
+
+
+def _snap_up(value: float) -> float:
+    """Return the grid edge at or above a coordinate."""
+    return GRID_ORIGIN + math.ceil((value - GRID_ORIGIN) / PIXEL_DEG) * PIXEL_DEG
+
+
+def snap_bbox(
+    bbox: tuple[float, float, float, float],
+    buffer_px: int = DEFAULT_BUFFER_PX,
+) -> tuple[tuple[float, float, float, float], int, int]:
+    """Snap a bbox to the GLO-30 grid and return its pixel dimensions."""
+    minx, miny, maxx, maxy = bbox
+    if minx >= maxx or miny >= maxy:
+        raise ValueError(f"Degenerate bbox: {bbox}")
+
+    pad = buffer_px * PIXEL_DEG
+    minx = _snap_down(minx - pad)
+    miny = _snap_down(miny - pad)
+    maxx = _snap_up(maxx + pad)
+    maxy = _snap_up(maxy + pad)
+
+    width = round((maxx - minx) / PIXEL_DEG)
+    height = round((maxy - miny) / PIXEL_DEG)
+
+    if width > MAX_DIMENSION_PX or height > MAX_DIMENSION_PX:
+        raise ValueError(
+            f"Project AOI needs a {width}x{height} px DEM, over the "
+            f"{MAX_DIMENSION_PX} px limit. Split the project, or upload a DEM."
+        )
+
+    return (minx, miny, maxx, maxy), width, height
+
+
+def dem_crop_url(bbox: tuple[float, float, float, float]) -> str:
+    """Build the TiTiler URL for a GeoTIFF crop of the GLO-30 mosaic."""
+    (minx, miny, maxx, maxy), width, height = snap_bbox(bbox)
+    return (
+        f"{settings.OAM_RASTER_API_URL.rstrip('/')}"
+        f"/collections/{settings.DEM_STAC_COLLECTION}"
+        f"/bbox/{minx:.10f},{miny:.10f},{maxx:.10f},{maxy:.10f}.tif"
+        f"?assets=data&width={width}&height={height}&return_mask=false"
+    )
+
+
+async def fetch_dem(bbox: tuple[float, float, float, float]) -> bytes:
+    """Fetch a GLO-30 GeoTIFF covering a bbox."""
+    url = dem_crop_url(bbox)
+    log.info(f"Requesting GLO-30 DEM crop: {url}")
+
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+
+    if not response.content:
+        raise ValueError(f"TiTiler returned an empty DEM for bbox {bbox}")
+
+    log.info(f"Received {len(response.content)} byte DEM for bbox {bbox}")
+    return response.content
+
+
+async def download_and_upload_glo30_dem(ctx, project_id: str, bbox: list, **_kwargs):
+    """ARQ worker function to crop GLO-30 for a project and store it on S3."""
+    log.info(f"Starting GLO-30 DEM job for project ({project_id}) over {bbox}")
+
+    # Retry failures that may succeed on a later attempt.
+    try:
+        dem_bytes = await fetch_dem(tuple(bbox))
+
+        dem = UploadFile(
+            file=io.BytesIO(dem_bytes),
+            filename="dem.tif",
+            headers={"content-type": "image/tiff"},  # type: ignore[arg-type]
+        )
+        dem_url = await project_logic.upload_file_to_s3(project_id, dem, "dem.tif")
+        log.info(f"Uploaded GLO-30 DEM for project ({project_id}) to: {dem_url}")
+
+        async with ctx["db_pool"].connection() as conn:
+            await project_logic.update_url(conn, project_id, dem_url)
+    except ValueError:
+        raise
+    except Exception as e:
+        attempt = ctx.get("job_try", 1)
+        log.warning(
+            f"GLO-30 DEM job failed for project ({project_id}), attempt {attempt}: {e}"
+        )
+        raise Retry(defer=attempt * RETRY_DEFER_SECONDS) from e
+
+    log.info(f"Successfully completed GLO-30 DEM job for project ({project_id})")
+
+
+async def enqueue_glo30_dem_download(bbox, project_id: str, redis):
+    """Enqueue a GLO-30 DEM crop to the arq-worker queue."""
+    job = await redis.enqueue_job(
+        "download_and_upload_glo30_dem",
+        str(project_id),
+        list(bbox),
+        _queue_name="default_queue",
+    )
+    log.info(f"Queued GLO-30 DEM job: {job.job_id} for project: {project_id}")
+    return job

--- a/src/backend/app/migrations/versions/c1f4a7e9b2d0_add_project_dem_source.py
+++ b/src/backend/app/migrations/versions/c1f4a7e9b2d0_add_project_dem_source.py
@@ -1,0 +1,31 @@
+"""add project dem_source
+
+Revision ID: c1f4a7e9b2d0
+Revises: 7ed1c618666b
+Create Date: 2026-09-04 15:20:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c1f4a7e9b2d0"
+down_revision: str | None = "7ed1c618666b"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    demsource = sa.Enum("GLO30", "JAXA", "UPLOAD", name="demsource")
+    demsource.create(op.get_bind(), checkfirst=True)
+
+    # Existing projects have no reliable DEM source history.
+    op.add_column("projects", sa.Column("dem_source", demsource, nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("projects", "dem_source")
+    sa.Enum(name="demsource").drop(op.get_bind(), checkfirst=True)

--- a/src/backend/app/models/enums.py
+++ b/src/backend/app/models/enums.py
@@ -185,6 +185,14 @@ class EventType(StrEnum):
     IMAGE_PROCESSING_START = "image_processing_start"
 
 
+class DEMSource(StrEnum):
+    """Enum to describe where a project's terrain-following DEM comes from."""
+
+    GLO30 = "GLO30"
+    JAXA = "JAXA"
+    UPLOAD = "UPLOAD"
+
+
 class ProjectCompletionStatus(StrEnum):
     """Enum to describe all possible project completion status."""
 

--- a/src/backend/app/projects/project_logic.py
+++ b/src/backend/app/projects/project_logic.py
@@ -19,6 +19,7 @@ from app.images.image_processing import (
     submit_scaleodm_task,
 )
 from app.models.enums import (
+    DEMSource,
     FinalOutput,
     ImageProcessingStatus,
     ImageStatus,
@@ -216,6 +217,40 @@ async def update_url(db: Connection, project_id: uuid.UUID, url: str):
             SET dem_url = %(url)s
             WHERE id = %(project_id)s""",
             {"url": url, "project_id": project_id},
+        )
+
+    return True
+
+
+def resolve_dem_source(
+    requested: DEMSource | None,
+    is_terrain_follow: bool,
+    dem_stored: bool,
+) -> DEMSource | None:
+    """Resolve the DEM source after any upload attempt."""
+    if not is_terrain_follow:
+        return None
+    if dem_stored:
+        return DEMSource.UPLOAD
+    if requested == DEMSource.JAXA:
+        return DEMSource.JAXA
+    return DEMSource.GLO30
+
+
+async def update_dem_source(
+    db: Connection, project_id: uuid.UUID, dem_source: DEMSource | None
+):
+    """Update a project's recorded DEM source."""
+    async with db.cursor() as cur:
+        await cur.execute(
+            """
+            UPDATE projects
+            SET dem_source = %(dem_source)s
+            WHERE id = %(project_id)s""",
+            {
+                "dem_source": dem_source.name if dem_source else None,
+                "project_id": project_id,
+            },
         )
 
     return True

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -8,9 +8,11 @@ import geojson
 from app.arq.tasks import MoveEnqueue, _enqueue_task_move, get_redis_pool
 from app.config import settings
 from app.db import database
+from app.dem.glo30 import enqueue_glo30_dem_download
 from app.images.image_classification import ImageClassifier
 from app.jaxa.upload_dem import enqueue_dem_download
 from app.models.enums import (
+    DEMSource,
     HTTPStatus,
     ImageProcessingStatus,
     OAMUploadStatus,
@@ -65,6 +67,7 @@ from fastapi.responses import StreamingResponse
 from geojson_pydantic import FeatureCollection
 from loguru import logger as log
 from psycopg import Connection
+from shapely.geometry import shape
 from stream_zip import NO_COMPRESSION_64, stream_zip
 
 router = APIRouter(
@@ -303,6 +306,12 @@ async def create_project(
     image: UploadFile = File(None),
 ):
     """Create a project in the database."""
+    # Correct this source below if the upload fails.
+    requested_dem_source = project_info.dem_source
+    project_info.dem_source = project_logic.resolve_dem_source(
+        requested_dem_source, project_info.is_terrain_follow, bool(dem)
+    )
+
     # Create project in database first
     project_id = await project_schemas.DbProject.create(db, project_info, user_data.id)
 
@@ -323,6 +332,20 @@ async def create_project(
     if dem_url:
         await project_logic.update_url(db, project_id, dem_url)
 
+    # Fall back when an upload does not reach S3.
+    dem_source = project_logic.resolve_dem_source(
+        requested_dem_source, project_info.is_terrain_follow, dem_url is not None
+    )
+    if dem_source != project_info.dem_source:
+        log.warning(
+            "Project {} wanted an uploaded DEM but it did not reach S3; "
+            "falling back to {}",
+            project_id,
+            dem_source,
+        )
+        project_info.dem_source = dem_source
+        await project_logic.update_dem_source(db, project_id, dem_source)
+
     # The frontend immediately follows this response with
     # /upload-task-boundaries. Commit here so that dependency can read the
     # project from a new DB transaction.
@@ -338,20 +361,42 @@ async def create_project(
             project_info.name,
         )
 
-    if project_info.is_terrain_follow and not dem:
-        geometry = project_info.outline["features"][0]["geometry"]
-        try:
-            redis = await get_redis_pool()
-            background_tasks.add_task(enqueue_dem_download, geometry, project_id, redis)
-        except HTTPException as e:
-            # Project creation should succeed even if DEM background queue is unavailable.
-            log.warning(
-                "Project {} created but DEM enqueue skipped (Redis unavailable): {}",
-                project_id,
-                e.detail,
-            )
+    if project_info.is_terrain_follow:
+        await _enqueue_terrain_dem(
+            dem_source, project_info, project_id, background_tasks
+        )
 
     return {"message": "Project successfully created", "project_id": project_id}
+
+
+async def _enqueue_terrain_dem(
+    dem_source: DEMSource | None,
+    project_info: project_schemas.ProjectIn,
+    project_id: uuid.UUID,
+    background_tasks: BackgroundTasks,
+) -> None:
+    """Queue a resolved DEM source when it needs downloading."""
+    if dem_source in (None, DEMSource.UPLOAD):
+        return
+
+    geometry = project_info.outline["features"][0]["geometry"]
+    try:
+        redis = await get_redis_pool()
+    except HTTPException as e:
+        log.warning(
+            "Project {} created but DEM enqueue skipped (Redis unavailable): {}",
+            project_id,
+            e.detail,
+        )
+        return
+
+    if dem_source == DEMSource.JAXA:
+        background_tasks.add_task(enqueue_dem_download, geometry, project_id, redis)
+        return
+
+    background_tasks.add_task(
+        enqueue_glo30_dem_download, shape(geometry).bounds, project_id, redis
+    )
 
 
 @router.post("/{project_id}/upload-task-boundaries", tags=["Projects"])

--- a/src/backend/app/projects/project_schemas.py
+++ b/src/backend/app/projects/project_schemas.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 import geojson
 from app.config import settings
 from app.models.enums import (
+    DEMSource,
     FinalOutput,
     HTTPStatus,
     IntEnum,
@@ -15,6 +16,7 @@ from app.models.enums import (
     ProjectVisibility,
     RegulatorApprovalStatus,
     State,
+    StrEnum,
 )
 from app.projects.s3_paths import (
     cloudnative_3d_tileset_browser_url,
@@ -98,14 +100,15 @@ def validate_geojson(
         return None
 
 
-def enum_to_str(value: IntEnum | str) -> str:
+def enum_to_str(value: IntEnum | StrEnum | str) -> str:
     """Get the string value of the enum for db insert.
-    Handles both IntEnum objects and string values.
+    Handles IntEnum and StrEnum objects, and string values.
     """
+    # StrEnum is also a str, so handle enum members first.
+    if isinstance(value, (IntEnum, StrEnum)):
+        return value.name
     if isinstance(value, str):
         return value
-    if isinstance(value, IntEnum):
-        return value.name
     return value
 
 
@@ -147,6 +150,7 @@ class ProjectIn(BaseModel):
     side_overlap: float | None = None
     gimble_angles_degrees: list[int] | None = None
     is_terrain_follow: bool = False
+    dem_source: Annotated[DEMSource, PlainSerializer(enum_to_str)] = DEMSource.GLO30
     outline: Annotated[
         FeatureCollection | Feature | Polygon, AfterValidator(validate_geojson)
     ]
@@ -301,6 +305,7 @@ class DbProject(BaseModel):
     altitude_from_ground: float | None = None
     gimble_angles_degrees: list[int] | None = None
     is_terrain_follow: bool = False
+    dem_source: DEMSource | None = None
     final_output: list[FinalOutput] | None = None
     image_url: str | None = None
     created_at: datetime

--- a/src/backend/tests/test_dem_glo30.py
+++ b/src/backend/tests/test_dem_glo30.py
@@ -1,0 +1,112 @@
+import math
+
+import pytest
+from app.config import settings
+from app.dem.glo30 import (
+    MAX_DIMENSION_PX,
+    PIXEL_DEG,
+    dem_crop_url,
+    snap_bbox,
+)
+from app.models.enums import DEMSource
+from app.projects.project_schemas import enum_to_str
+
+# These expected bounds were verified against direct GDAL reads of the source COGs.
+KATHMANDU = (85.28, 27.68, 85.32, 27.72)
+KATHMANDU_SNAPPED = (85.2798611111, 27.6798611111, 85.3201388889, 27.7201388889)
+TILE_SEAM = (85.94, 27.60, 86.06, 27.70)
+TILE_SEAM_SNAPPED = (85.9398611111, 27.5998611111, 86.0601388889, 27.7001388889)
+
+
+def on_grid(value: float) -> bool:
+    edges = (value + 0.5 * PIXEL_DEG) / PIXEL_DEG
+    return math.isclose(edges, round(edges), abs_tol=1e-6)
+
+
+@pytest.mark.parametrize(
+    ("bbox", "expected", "size"),
+    [
+        (KATHMANDU, KATHMANDU_SNAPPED, (145, 145)),
+        (TILE_SEAM, TILE_SEAM_SNAPPED, (433, 361)),
+    ],
+)
+def test_snap_bbox_reproduces_the_verified_source_grid(bbox, expected, size):
+    snapped, width, height = snap_bbox(bbox, buffer_px=0)
+
+    assert tuple(round(v, 10) for v in snapped) == expected
+    assert (width, height) == size
+
+
+def test_snap_bbox_lands_every_edge_on_the_source_grid():
+    snapped, _, _ = snap_bbox((12.3456, -7.6543, 12.5432, -7.4321))
+
+    assert all(on_grid(v) for v in snapped)
+
+
+def test_snap_bbox_only_ever_grows_the_area():
+    minx, miny, maxx, maxy = snap_bbox(KATHMANDU)[0]
+
+    assert minx <= KATHMANDU[0]
+    assert miny <= KATHMANDU[1]
+    assert maxx >= KATHMANDU[2]
+    assert maxy >= KATHMANDU[3]
+
+
+def test_snap_bbox_buffers_by_whole_pixels():
+    _, plain_w, plain_h = snap_bbox(KATHMANDU, buffer_px=0)
+    _, buffered_w, buffered_h = snap_bbox(KATHMANDU, buffer_px=1)
+
+    assert (buffered_w, buffered_h) == (plain_w + 2, plain_h + 2)
+
+
+def test_snap_bbox_survives_extreme_coordinates():
+    # Near the pole and the dateline, but not across it.
+    snapped, width, height = snap_bbox((179.9, -89.9, 179.95, -89.85))
+
+    assert all(on_grid(v) for v in snapped)
+    assert width > 0 and height > 0
+
+
+def test_an_antimeridian_crossing_aoi_is_refused_not_mirrored():
+    # A crossing polygon's bounds span the globe. Known limitation: refused
+    # rather than split, which fails loudly instead of quietly cropping the
+    # wrong side of the planet.
+    with pytest.raises(ValueError, match=str(MAX_DIMENSION_PX)):
+        snap_bbox((-179.99, 27.6, 179.99, 27.7))
+
+
+def test_snap_bbox_rejects_a_degenerate_bbox():
+    with pytest.raises(ValueError, match="Degenerate bbox"):
+        snap_bbox((85.3, 27.7, 85.3, 27.7))
+
+
+def test_snap_bbox_rejects_an_aoi_too_large_to_serve():
+    with pytest.raises(ValueError, match=str(MAX_DIMENSION_PX)):
+        snap_bbox((0.0, 0.0, 20.0, 20.0))
+
+
+def test_dem_crop_url_asks_for_a_single_band_crop_at_native_size():
+    url = dem_crop_url(TILE_SEAM)
+    snapped, width, height = snap_bbox(TILE_SEAM)
+
+    assert url.startswith(
+        f"{settings.OAM_RASTER_API_URL}/collections/"
+        f"{settings.DEM_STAC_COLLECTION}/bbox/"
+    )
+    assert f"width={width}&height={height}" in url
+    assert "return_mask=false" in url
+    assert "assets=data" in url
+    assert f"{snapped[0]:.10f},{snapped[1]:.10f}" in url
+
+
+def test_dem_source_values_match_their_names():
+    assert [source.value for source in DEMSource] == [
+        source.name for source in DEMSource
+    ]
+
+
+def test_dem_source_serialises_to_a_bare_string_for_the_insert():
+    dumped = enum_to_str(DEMSource.GLO30)
+
+    assert dumped == "GLO30"
+    assert type(dumped) is str

--- a/src/backend/tests/test_dem_source_routing.py
+++ b/src/backend/tests/test_dem_source_routing.py
@@ -1,0 +1,146 @@
+import uuid
+
+import pytest
+from app.models.enums import DEMSource
+from app.projects import project_logic, project_routes
+from app.projects.project_schemas import ProjectIn
+
+AOI = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {},
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [85.28, 27.68],
+                        [85.32, 27.68],
+                        [85.32, 27.72],
+                        [85.28, 27.72],
+                        [85.28, 27.68],
+                    ]
+                ],
+            },
+        }
+    ],
+}
+
+
+class RecordingBackgroundTasks:
+    def __init__(self):
+        self.queued = []
+
+    def add_task(self, func, *args, **kwargs):
+        self.queued.append((func, args, kwargs))
+
+    @property
+    def queued_names(self):
+        return [func.__name__ for func, _, _ in self.queued]
+
+
+def project(dem_source=None, **overrides) -> ProjectIn:
+    fields = {
+        "name": f"TEST_{uuid.uuid4()}",
+        "outline": AOI,
+        "is_terrain_follow": True,
+        "final_output": ["ORTHOPHOTO_2D"],
+        **overrides,
+    }
+    if dem_source is not None:
+        fields["dem_source"] = dem_source
+    return ProjectIn(**fields)
+
+
+@pytest.fixture(autouse=True)
+def _fake_redis(monkeypatch):
+    async def _pool():
+        return object()
+
+    monkeypatch.setattr(project_routes, "get_redis_pool", _pool)
+
+
+async def enqueue(project_info, dem_stored=False):
+    tasks = RecordingBackgroundTasks()
+    dem_source = project_logic.resolve_dem_source(
+        project_info.dem_source, project_info.is_terrain_follow, dem_stored
+    )
+    await project_routes._enqueue_terrain_dem(
+        dem_source, project_info, uuid.uuid4(), tasks
+    )
+    return tasks
+
+
+def test_default_dem_source_is_glo30():
+    assert project().dem_source == DEMSource.GLO30
+
+
+@pytest.mark.asyncio
+async def test_glo30_project_queues_a_glo30_crop():
+    tasks = await enqueue(project(DEMSource.GLO30))
+
+    assert tasks.queued_names == ["enqueue_glo30_dem_download"]
+    _, args, _ = tasks.queued[0]
+    assert args[0] == pytest.approx((85.28, 27.68, 85.32, 27.72))
+
+
+@pytest.mark.asyncio
+async def test_jaxa_stays_available_as_an_explicit_choice():
+    tasks = await enqueue(project(DEMSource.JAXA))
+
+    assert tasks.queued_names == ["enqueue_dem_download"]
+    _, args, _ = tasks.queued[0]
+    assert args[0]["type"] == "Polygon"
+
+
+@pytest.mark.asyncio
+async def test_upload_queues_nothing():
+    tasks = await enqueue(project(DEMSource.UPLOAD), dem_stored=True)
+
+    assert tasks.queued == []
+
+
+@pytest.mark.asyncio
+async def test_upload_without_a_file_falls_back_to_glo30():
+    tasks = await enqueue(project(DEMSource.UPLOAD))
+
+    assert tasks.queued_names == ["enqueue_glo30_dem_download"]
+
+
+@pytest.mark.asyncio
+async def test_an_uploaded_file_beats_the_default():
+    tasks = await enqueue(project(), dem_stored=True)
+
+    assert tasks.queued == []
+
+
+@pytest.mark.asyncio
+async def test_creation_survives_an_unavailable_queue(monkeypatch):
+    from fastapi import HTTPException
+
+    async def _unavailable():
+        raise HTTPException(status_code=503, detail="Redis unavailable")
+
+    monkeypatch.setattr(project_routes, "get_redis_pool", _unavailable)
+
+    tasks = await enqueue(project(DEMSource.GLO30))
+
+    assert tasks.queued == []
+
+
+@pytest.mark.asyncio
+async def test_a_null_dem_source_still_fetches_something():
+    project_info = project()
+    project_info.dem_source = None
+
+    tasks = await enqueue(project_info)
+
+    assert tasks.queued_names == ["enqueue_glo30_dem_download"]
+
+
+def test_an_unknown_dem_source_is_rejected_before_it_reaches_postgres():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        project("NOT_A_SOURCE")

--- a/src/frontend/messages/en.json
+++ b/src/frontend/messages/en.json
@@ -297,6 +297,7 @@
   "create_params_follow_terrain_desc": "Makes the drone maintain the same height from the ground when flying over hills, preventing crashes and improving data quality.",
   "create_params_follow_terrain_warning": "WARNING: ensure this is enabled if the terrain is hilly. Note: this does not account for tall buildings - make sure you are flying at a height above the tallest building in the flight area.",
   "create_params_dem_required": "Dem data is Required",
+  "create_params_dem_glo30": "Copernicus GLO-30 (recommended)",
   "create_params_dem_jaxa": "Download DEM file from JAXA",
   "create_params_dem_upload": "Upload DEM File",
   "create_params_dem_upload_placeholder": "Upload dem data (tif/tiff files)",

--- a/src/frontend/messages/es.json
+++ b/src/frontend/messages/es.json
@@ -297,6 +297,7 @@
   "create_params_follow_terrain_desc": "Hace que el dron mantenga la misma altura sobre el suelo al volar sobre colinas, evitando accidentes y mejorando la calidad de los datos.",
   "create_params_follow_terrain_warning": "ADVERTENCIA: asegúrate de activar esta opción si el terreno es montañoso. Nota: esto no tiene en cuenta los edificios altos; asegúrate de volar a una altura superior al edificio más alto del área de vuelo.",
   "create_params_dem_required": "Los datos del DEM son obligatorios",
+  "create_params_dem_glo30": "Copernicus GLO-30 (recomendado)",
   "create_params_dem_jaxa": "Descargar archivo DEM desde JAXA",
   "create_params_dem_upload": "Cargar archivo DEM",
   "create_params_dem_upload_placeholder": "Cargar datos del DEM (archivos tif/tiff)",

--- a/src/frontend/messages/id.json
+++ b/src/frontend/messages/id.json
@@ -297,6 +297,7 @@
   "create_params_follow_terrain_desc": "Membuat drone mempertahankan ketinggian yang sama dari permukaan tanah saat terbang di atas perbukitan, sehingga mencegah kecelakaan dan meningkatkan kualitas data.",
   "create_params_follow_terrain_warning": "PERINGATAN: pastikan opsi ini diaktifkan jika medannya berbukit. Catatan: ini tidak memperhitungkan bangunan tinggi; pastikan Anda terbang pada ketinggian di atas bangunan tertinggi di area penerbangan.",
   "create_params_dem_required": "Data DEM wajib diisi",
+  "create_params_dem_glo30": "Copernicus GLO-30 (direkomendasikan)",
   "create_params_dem_jaxa": "Unduh file DEM dari JAXA",
   "create_params_dem_upload": "Unggah Berkas DEM",
   "create_params_dem_upload_placeholder": "Unggah data DEM (file tif/tiff)",

--- a/src/frontend/src/components/CreateProject/CreateprojectLayout/index.tsx
+++ b/src/frontend/src/components/CreateProject/CreateprojectLayout/index.tsx
@@ -77,7 +77,7 @@ const defaultWizardState = {
   requireApprovalFromManagerForLocking: "not_required",
   requiresApprovalFromRegulator: "not_required",
   regulatorEmails: [],
-  demType: "auto",
+  demType: "GLO30",
   imageMergeType: "overlap",
   measurementType: "gsd",
   totalProjectArea: 0,
@@ -331,6 +331,7 @@ const CreateprojectLayout = () => {
 
       requires_approval_from_regulator: requiresApprovalFromRegulator === "required",
       regulator_emails: regulatorEmails,
+      ...(isTerrainFollow ? { dem_source: demType } : {}),
     };
     delete refactoredData?.forward_spacing;
     delete refactoredData?.side_spacing;
@@ -350,7 +351,7 @@ const CreateprojectLayout = () => {
     formData.append("project_info", JSON.stringify({ ...refactoredData }));
     formData.append("image", projectImage.projectMapImage);
 
-    if (isTerrainFollow && demType === "manual") {
+    if (isTerrainFollow && demType === "UPLOAD") {
       formData.append("dem", data?.dem?.[0]?.file);
     }
     createProject(formData);

--- a/src/frontend/src/components/CreateProject/FormContents/GenerateTasks/index.tsx
+++ b/src/frontend/src/components/CreateProject/FormContents/GenerateTasks/index.tsx
@@ -118,7 +118,7 @@ export default function GenerateTasks({ formProps }: { formProps: any }) {
               meters: task_split_dimension,
               project_geojson: convertGeojsonToFile(outline),
               is_terrain_follow: isTerrainFollow,
-              dem: isTerrainFollow && demType === "manual" ? demFile[0]?.file : null,
+              dem: isTerrainFollow && demType === "UPLOAD" ? demFile[0]?.file : null,
             };
             mutateProjectWayPoints(projectWayPointsPayload);
             return mutate(payload);

--- a/src/frontend/src/components/CreateProject/FormContents/KeyParameters/index.tsx
+++ b/src/frontend/src/components/CreateProject/FormContents/KeyParameters/index.tsx
@@ -399,7 +399,7 @@ const KeyParameters = ({ formProps }: { formProps: UseFormPropsType }) => {
                 </FormControl>
               )}
 
-              {demType === "manual" && isTerrainFollow && (
+              {demType === "UPLOAD" && isTerrainFollow && (
                 <FormControl>
                   <Controller
                     control={control}

--- a/src/frontend/src/constants/createProject.tsx
+++ b/src/frontend/src/constants/createProject.tsx
@@ -310,13 +310,19 @@ export const taskGenerationGuidelines = () => ({
   conclusion: m.create_generate_guidelines_conclusion(),
 });
 
+// Values are the backend DEMSource enum, sent as `dem_source`.
 export const demFileOptions = () => [
+  {
+    name: "Copernicus GLO-30",
+    label: m.create_params_dem_glo30(),
+    value: "GLO30",
+  },
   {
     name: "Download DEM file from JAXA",
     label: m.create_params_dem_jaxa(),
-    value: "auto",
+    value: "JAXA",
   },
-  { name: "Upload DEM File", label: m.create_params_dem_upload(), value: "manual" },
+  { name: "Upload DEM File", label: m.create_params_dem_upload(), value: "UPLOAD" },
 ];
 
 export const uploadOrDrawAreaOptions = (): Record<string, any>[] => [

--- a/src/frontend/src/store/slices/createproject.ts
+++ b/src/frontend/src/store/slices/createproject.ts
@@ -61,7 +61,7 @@ const initialState: CreateProjectState = {
   projectsFilterHasImagery: false,
   requiresApprovalFromRegulator: "not_required",
   regulatorEmails: [],
-  demType: "auto",
+  demType: "GLO30",
   selectedProjectStatus: "",
   totalProjectArea: 0,
   totalNoFlyZoneArea: 0,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Closes #560

## Describe this PR

- Until now we have used JAXA for everything.
- Copernicus GLO-30 is slightly higher resolution and also available for free since 2021.
- I ingested the GLO-30 STAC into OpenAerialMap (the data is hosted by AWS S3 open data program).
- It's possible to use OpenAerialMaps TiTiler instance to download a `.tiff` of the mosaicked DEM files for a given project BBOX.
- It's very performant - a local dev test produced a decent size DEM is 3s for me (faster than JAXA scraping).
- We can also use this for a frontend flightplan generator.

## AI Tool Usage

- [ ] No AI tools were used
- [x] AI tools were used (complete below)

**If AI-assisted:**

- Tool(s) used: Opus 4.8
- What was generated: Once the work for GLO-30 ingestion into OAM was done, the implementation in DroneTM was pretty trivial. I used Opus 4.8 to generate the enum, some backend logic, and all the frontend code.
- What you reviewed and changed: I reviewed and manually tested all of the code. It works running on localhost - projects with DEMs downloaded, inspected in rustfs.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/hotosm/drone-tm/blob/dev/CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](https://docs.hotosm.org/code-of-conduct)
- [x] PR is focused and small
- [x] Tests are included or updated
- [x] I understand all code in this PR and can answer questions about it
- [x] No secrets, credentials, or sensitive data are included
- [x] Commit messages are descriptive
- [x] Related docs and screenshots are updated

## [optional] What gif best describes this PR or how it makes you feel?
